### PR TITLE
Refactor comment rendering and add tests

### DIFF
--- a/tests/CardActionTest.php
+++ b/tests/CardActionTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CardActionTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new FakeWpdb();
+        $GLOBALS['wp_test_is_user_logged_in'] = true;
+        $GLOBALS['wp_test_current_user_id'] = 1;
+        $GLOBALS['wp_test_user_meta'] = [];
+        $GLOBALS['wp_test_user_meta'][1]['glpi_user_id'] = 42;
+        $wpdb->can_update = true;
+        $wpdb->comments = [
+            ['id'=>1,'users_id'=>1,'date'=>'2020-01-01 00:00:00','content'=>'Initial comment']
+        ];
+    }
+
+    public function test_card_action_returns_json_and_comments() {
+        $_POST = [
+            'ticket_id' => 1,
+            'type' => 'start',
+            'payload' => '{}'
+        ];
+
+        ob_start();
+        gexe_glpi_card_action();
+        $output = ob_get_clean();
+
+        $data = json_decode($output, true);
+        $this->assertIsArray($data);
+        $this->assertTrue($data['ok']);
+        $this->assertStringContainsString('Статус изменён через WP: Принято в работу', $data['comment_html']);
+        $this->assertEquals(2, $data['new_status']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,7 @@ if (!function_exists('admin_url')) { function admin_url() { return ''; } }
 if (!function_exists('wp_create_nonce')) { function wp_create_nonce() { return ''; } }
 if (!function_exists('check_ajax_referer')) { function check_ajax_referer(...$args) {} }
 if (!function_exists('wp_die')) { function wp_die($msg='') { echo $msg; } }
+if (!function_exists('wp_send_json')) { function wp_send_json($data) { echo json_encode($data); } }
 if (!function_exists('current_time')) { function current_time($t) { return '2020-01-01 00:00:00'; } }
 if (!function_exists('esc_html')) { function esc_html($s) { return $s; } }
 if (!function_exists('wp_kses_post')) { function wp_kses_post($s) { return $s; } }
@@ -22,11 +23,13 @@ if (!function_exists('get_user_meta')) {
         return $GLOBALS['wp_test_user_meta'][$user_id][$key] ?? '';
     }
 }
+if (!defined('ARRAY_A')) { define('ARRAY_A', 'ARRAY_A'); }
 
 class FakeWpdb {
     public $prefix = 'wp_';
     public $can_update = false;
     public $is_assigned = false;
+    public $comments = [];
     public function prepare($query, ...$args) {
         return vsprintf($query, $args);
     }
@@ -38,6 +41,26 @@ class FakeWpdb {
             return $this->is_assigned ? 1 : null;
         }
         return null;
+    }
+    public function get_results($query, $output = ARRAY_A) {
+        return $this->comments;
+    }
+    public function update($table, $data, $where, $format = null, $where_format = null) {
+        return 1;
+    }
+    public function insert($table, $data, $format = null) {
+        if (strpos($table, 'glpi_ticketfollowups') !== false) {
+            $this->comments[] = [
+                'id' => count($this->comments) + 1,
+                'users_id' => $data['users_id'],
+                'date' => $data['date'],
+                'content' => $data['content'],
+            ];
+        }
+        return 1;
+    }
+    public function delete($table, $where, $where_format = null) {
+        return 1;
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract comment rendering into reusable `gexe_render_comments()` helper
- Streamline `gexe_glpi_get_comments()` and `gexe_glpi_card_action()` to reuse helper and send responses via `wp_send_json`
- Add PHPUnit coverage for `gexe_glpi_card_action()` JSON output and comment refresh

## Testing
- `composer install`
- `./vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68a5595064948328ba82b07bbc2b891f