### PR TITLE
Extract shared GLPI DB setup module

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -22,13 +22,7 @@ add_action('wp_enqueue_scripts', function () {
 });
 
 // ====== ПОДКЛЮЧЕНИЕ К БД GLPI ======
-global $glpi_db;
-$glpi_db = new wpdb(
-    'wp_glpi',            // db user
-    'xapetVD4OWZqw8f',    // db password
-    'glpi',               // db name
-    '192.168.100.12'      // db host
-);
+require_once __DIR__ . '/glpi-db-setup.php';
 
 // ====== УТИЛИТЫ ======
 function gexe_autoname($realname, $firstname) {

--- a/glpi-categories-shortcode.php
+++ b/glpi-categories-shortcode.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: GLPI Categories Shortcode (uses $glpi_db from gexe-copy.php)
- * Description: [glpi_categories] — выводит категории GLPI, используя готовый $glpi_db (wpdb) из gexe-copy.php.
+ * Plugin Name: GLPI Categories Shortcode
+ * Description: [glpi_categories] — выводит категории GLPI, используя $glpi_db (wpdb) из glpi-db-setup.php.
  * Version: 1.0.0
  */
 
@@ -9,23 +9,13 @@ if (!defined('ABSPATH')) { exit; } // только из WP
 
 add_shortcode('glpi_categories', function () {
 
-    // 1) Подключаем gexe-copy.php без побочного вывода
-    $gexe = null;
-    foreach ([__DIR__ . '/gexe-copy.php', __DIR__ . '/G-Exe-Copy.php'] as $p) {
-        if (is_file($p)) { $gexe = $p; break; }
-    }
-    if (!$gexe) {
-        return '<div style="color:#ef4444">gexe-copy.php не найден рядом с этим файлом.</div>';
-    }
-    $lvl = ob_get_level();
-    ob_start();
-    require_once $gexe;
-    while (ob_get_level() > $lvl) { ob_end_clean(); }
+    // 1) Подключаем модуль инициализации БД GLPI
+    require_once __DIR__ . '/glpi-db-setup.php';
 
     // 2) Проверяем готовый $glpi_db (wpdb)
     global $glpi_db;
     if (!($glpi_db instanceof wpdb)) {
-        return '<div style="color:#ef4444">$glpi_db (wpdb) не найден в gexe-copy.php.</div>';
+        return '<div style="color:#ef4444">$glpi_db (wpdb) не найден.</div>';
     }
 
     // 3) Тянем категории из GLPI

--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+global $glpi_db;
+if (!isset($glpi_db) || !($glpi_db instanceof wpdb)) {
+    $glpi_db = new wpdb(
+        'wp_glpi',            // db user
+        'xapetVD4OWZqw8f',    // db password
+        'glpi',               // db name
+        '192.168.100.12'      // db host
+    );
+}


### PR DESCRIPTION
## Summary
- factor out `$glpi_db` initialisation into reusable `glpi-db-setup.php`
- require the shared DB setup in `gexe-copy.php`
- load the light DB setup module from `glpi-categories-shortcode.php` without triggering hooks

## Testing
- `php -l gexe-copy.php glpi-categories-shortcode.php glpi-db-setup.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba0341259c832888525f71a82b6a8b