### PR TITLE
Extract GLPI UID utility

### DIFF
--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -5,6 +5,7 @@
  * Поддержка AJAX для: загрузки комментариев, проверки "Принято в работу",
  * добавления комментария, действий "start/done", счетчика комментариев.
  */
+require_once __DIR__ . '/glpi-utils.php';
 
 add_action('wp_enqueue_scripts', function () {
     wp_localize_script('gexe-filter', 'glpiAjax', [
@@ -13,24 +14,6 @@ add_action('wp_enqueue_scripts', function () {
         'user_glpi_id' => gexe_get_current_glpi_uid(),
     ]);
 });
-
-/** Возвращает GLPI users.id, сопоставленный текущему WP-пользователю. */
-if (!function_exists('gexe_get_current_glpi_uid')) {
-    function gexe_get_current_glpi_uid() {
-        if (!is_user_logged_in()) return 0;
-
-        $wp_uid = get_current_user_id();
-
-        $glpi_uid = intval(get_user_meta($wp_uid, 'glpi_user_id', true));
-        if ($glpi_uid > 0) return $glpi_uid;
-
-        $key = get_user_meta($wp_uid, 'glpi_user_key', true);
-        if (preg_match('~^\d+$~', (string)$key)) {
-            return (int)$key;
-        }
-        return 0;
-    }
-}
 
 /** Права: глобальные + назначенный исполнитель */
 function gexe_can_touch_glpi_ticket($ticket_id) {

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -10,6 +10,8 @@
 
 if (!defined('ABSPATH')) exit;
 
+require_once __DIR__ . '/glpi-utils.php';
+
 add_action('wp_enqueue_scripts', function () {
     // Стили окна создания заявки
     wp_register_style(
@@ -20,24 +22,6 @@ add_action('wp_enqueue_scripts', function () {
     );
     wp_enqueue_style('glpi-new-task');
 });
-
-// Берём функцию из glpi-modal-actions.php, если она уже определена
-if (!function_exists('gexe_get_current_glpi_uid')) {
-    function gexe_get_current_glpi_uid() {
-        if (!is_user_logged_in()) return 0;
-
-        $wp_uid = get_current_user_id();
-
-        $glpi_uid = intval(get_user_meta($wp_uid, 'glpi_user_id', true));
-        if ($glpi_uid > 0) return $glpi_uid;
-
-        $key = get_user_meta($wp_uid, 'glpi_user_key', true);
-        if (preg_match('~^\d+$~', (string)$key)) {
-            return (int)$key;
-        }
-        return 0;
-    }
-}
 
 // -------- AJAX: списки категорий и местоположений --------
 add_action('wp_ajax_glpi_dropdowns', 'gexe_glpi_dropdowns');

--- a/glpi-utils.php
+++ b/glpi-utils.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Shared GLPI utility functions.
+ */
+
+/**
+ * Returns GLPI users.id associated with the current WP user.
+ */
+function gexe_get_current_glpi_uid() {
+    if (!is_user_logged_in()) return 0;
+
+    $wp_uid = get_current_user_id();
+
+    $glpi_uid = intval(get_user_meta($wp_uid, 'glpi_user_id', true));
+    if ($glpi_uid > 0) return $glpi_uid;
+
+    $key = get_user_meta($wp_uid, 'glpi_user_key', true);
+    if (preg_match('~^\d+$~', (string)$key)) {
+        return (int)$key;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- centralize gexe_get_current_glpi_uid into new glpi-utils.php
- load shared utility in glpi modal and new task modules

## Testing
- `php -l glpi-utils.php glpi-new-task.php glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba034c5e548328ac754cdfa4940e9b