### PR TITLE
Check capability before creating GLPI ticket

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -8,6 +8,21 @@ Author: G-Exe
 
 if (!defined('ABSPATH')) exit;
 
+// ----- Capabilities -----
+register_activation_hook(__FILE__, function () {
+    $role = get_role('administrator');
+    if ($role) {
+        $role->add_cap('create_glpi_ticket');
+    }
+});
+
+register_deactivation_hook(__FILE__, function () {
+    $role = get_role('administrator');
+    if ($role) {
+        $role->remove_cap('create_glpi_ticket');
+    }
+});
+
 // ====== СТАТИКА (CSS/JS) с принудительным обновлением версий ======
 add_action('wp_enqueue_scripts', function () {
     $css_path = plugin_dir_path(__FILE__) . 'gee.css';

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -96,6 +96,10 @@ function gexe_glpi_create_ticket() {
         wp_send_json(['ok' => false, 'error' => 'not_logged_in']);
     }
 
+    if (!current_user_can('create_glpi_ticket')) {
+        wp_send_json(['ok' => false, 'error' => 'forbidden']);
+    }
+
     $payload_raw = isset($_POST['payload']) ? stripslashes((string)$_POST['payload']) : '';
     $payload = json_decode($payload_raw, true);
     if (!is_array($payload)) $payload = [];


### PR DESCRIPTION
## Summary
- ensure `create_glpi_ticket` capability is granted to admins on activation
- block ticket creation for users lacking the capability

## Testing
- `php -l gexe-copy.php`
- `php -l glpi-new-task.php`
- `php /tmp/test_nocap.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba034e393883289c4fefa8fada7f0f