### PR TITLE
feat: collapsible schedule categories

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -54,10 +54,34 @@
       .replace(/^-+|-+$/g,'');
   }
   function prepareCategoryTags(){
-    document.querySelectorAll('.glpi-category-tag').forEach(tag=>{
+    document.querySelectorAll('.category-filter-btn').forEach(tag=>{
+      let label = tag.getAttribute('data-label') || '';
+      let count = tag.getAttribute('data-count') || '';
+
+      if (!label) {
+        const txt = tag.textContent || '';
+        const m = txt.match(/^(.*?)[\s—-]+(\d+)\s*$/);
+        if (m) {
+          label = m[1].trim();
+          count = count || m[2];
+        } else {
+          label = txt.trim();
+        }
+      }
+
+      // rebuild text to use parentheses for counts
+      const icon = tag.querySelector('i');
+      const iconHTML = icon ? icon.outerHTML + ' ' : '';
+      if (count) {
+        tag.innerHTML = iconHTML + label + ' (' + count + ')';
+        tag.setAttribute('data-count', count);
+      } else {
+        tag.innerHTML = iconHTML + label;
+      }
+      tag.setAttribute('data-label', label);
+
       if(!tag.hasAttribute('data-cat')){
-        const t = tag.getAttribute('data-label') || tag.textContent || '';
-        tag.setAttribute('data-cat', slugify(t));
+        tag.setAttribute('data-cat', slugify(label));
       }
       tag.classList.add('category-filter-btn');
     });
@@ -119,7 +143,7 @@
       const tgl = document.createElement('button');
       tgl.className = 'glpi-cat-toggle';
       tgl.setAttribute('aria-expanded','false');
-      tgl.innerHTML = '<span class="tw">▸</span> Категории';
+      tgl.innerHTML = '<span class="tw">▸</span> Сегодня в программе';
       row.parentNode.insertBefore(tgl, row);
       tgl.addEventListener('click', () => {
         const opened = row.classList.toggle('collapsed') ? false : true;

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -129,7 +129,10 @@ function gexe_cat_slug($leaf) {
           $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
           $label = gexe_truncate_label($leaf, 12);
       ?>
-        <span class="glpi-category-tag category-filter-btn" data-cat="<?php echo esc_attr(strtolower($slug)); ?>">
+        <span class="glpi-category-tag category-filter-btn"
+              data-cat="<?php echo esc_attr(strtolower($slug)); ?>"
+              data-label="<?php echo esc_attr($label); ?>"
+              data-count="<?php echo intval($count); ?>">
           <?php echo $icon; ?> <?php echo esc_html($label); ?> (<?php echo intval($count); ?>)
         </span>
       <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- make "Сегодня в программе" categories collapsible
- show category counts in parentheses rather than dashes

## Testing
- `node --check gexe-filter.js && echo 'JS syntax OK'`
- `php -l templates/glpi-cards-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba0535378c83288ef16844050fc4e7