### PR TITLE
Remove duplicate 'New request' button and link remaining to modal

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -81,13 +81,13 @@
     }
 
     // Кнопка «Новая заявка» — открываем модалку из glpi-new-task.php
-    if (!document.querySelector('.glpi-newtask-block')) {
-      const add = document.createElement('button');
-      add.className = 'glpi-status-block glpi-newtask-block';
-      add.innerHTML = '<div class="status-count"><i class="fa-regular fa-file-lines"></i></div><div class="status-label">новая заявка</div>';
-      add.addEventListener('click', openNewTaskModal);
-      row.appendChild(add);
-    }
+    // Удаляем все существующие кнопки, чтобы не было дублей
+    document.querySelectorAll('.glpi-newtask-block').forEach(btn => btn.remove());
+    const add = document.createElement('button');
+    add.className = 'glpi-status-block glpi-newtask-block';
+    add.innerHTML = '<div class="status-count"><i class="fa-regular fa-file-lines"></i></div><div class="status-label">новая заявка</div>';
+    add.addEventListener('click', openNewTaskModal);
+    row.appendChild(add);
   }
   function openNewTaskModal() {
     try {


### PR DESCRIPTION
## Summary
- Remove pre-existing `Новая заявка` buttons and recreate a single button at the end of the status row
- Clicking the remaining `Новая заявка` now reliably opens the new ticket modal (`glpi-new-task.php`)

## Testing
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba05c138488328885709f2d2e01e08