### PR TITLE
Fix urgent filter label and align status buttons

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -87,16 +87,16 @@
     });
   }
 
-  /* ========================= «Новые» и «Новая заявка» ========================= */
+  /* ========================= «Пора тушить» и «Новая заявка» ========================= */
   function ensureExtraStatusBlocks() {
     const row = document.querySelector('.glpi-status-blocks,.glpi-status-row,.glpi-header-row');
     if (!row) return;
 
-    // Кнопка «Новые» (вместо "надо тушить"): действует как фильтр по data-late="1"
+    // Кнопка «Пора тушить»: действует как фильтр по data-late="1"
     if (!document.querySelector('.glpi-newfilter-block')) {
       const btn = document.createElement('button');
       btn.className = 'glpi-status-block glpi-newfilter-block';
-      btn.innerHTML = '<div class="status-count">0</div><div class="status-label">Новые</div>';
+      btn.innerHTML = '<div class="status-count">0</div><div class="status-label">Пора тушить</div>';
       btn.addEventListener('click', () => {
         btn.classList.toggle('active');
         document.dispatchEvent(new CustomEvent('gexe:filters:changed'));

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -117,9 +117,6 @@ function gexe_cat_slug($leaf) {
           <span class="status-label">Новые</span>
         </div>
       </div>
-
-      <div class="glpi-status-block glpi-late-block glpi-filter-btn" data-filter="late"><span class="status-count">&nbsp;</span><span class="status-label">Надо тушить</span></div>      </div>
-
     </div>
 
     <!-- Блоки категорий (Сегодня в программе) -->


### PR DESCRIPTION
## Summary
- rename "Новые" urgent filter button to "Пора тушить"
- remove leftover "Надо тушить" block so buttons align

## Testing
- `php -l templates/glpi-cards-template.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba0adc94c483289c8f796637bee16f