### PR TITLE
Default to "In Progress" filter and stabilize status counters

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -166,6 +166,10 @@
       currentCategory = String(tgt.getAttribute('data-cat') || 'all').toLowerCase();
       document.querySelectorAll('.category-filter-btn, .glpi-category-tag').forEach(b => b.classList.remove('active'));
       tgt.classList.add('active');
+      // при выборе категории сбрасываем фильтр статусов
+      $$('.status-filter-btn').forEach(b => b.classList.remove('active'));
+      const allBtn = document.querySelector('.status-filter-btn[data-status="all"]');
+      if (allBtn) allBtn.classList.add('active');
       recalcStatusCounts(); recalcCategoryVisibility(); filterCards();
     }, true);
   }
@@ -521,7 +525,6 @@
     let total = 0;
     $$('.glpi-card').forEach(card => {
       if (!cardMatchesExecutor(card)) return;
-      if (!cardMatchesCategory(card)) return;
       const s = String(card.getAttribute('data-status') || '');
       if (counts.hasOwnProperty(s)) counts[s]++;
       total++;
@@ -564,10 +567,9 @@
       btn.addEventListener('click', () => {
         $$('.status-filter-btn').forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
-        if ((btn.getAttribute('data-status') || 'all') === 'all') {
-          currentCategory = 'all';
-          $$('.category-filter-btn, .glpi-category-tag').forEach(b => b.classList.remove('active'));
-        }
+        // при выборе статуса сбрасываем выбранные категории
+        currentCategory = 'all';
+        $$('.category-filter-btn, .glpi-category-tag').forEach(b => b.classList.remove('active'));
         recalcStatusCounts(); recalcCategoryVisibility(); filterCards();
       });
     });

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -96,11 +96,11 @@ function gexe_cat_slug($leaf) {
       <div class="glpi-status-row">
       <!-- Блоки статусов -->
       <div class="glpi-status-blocks">
-        <div class="glpi-status-block status-filter-btn active" data-status="all" data-label="Все задачи">
+        <div class="glpi-status-block status-filter-btn" data-status="all" data-label="Все задачи">
           <span class="status-count"><?php echo intval($total_count); ?></span>
           <span class="status-label">Все задачи</span>
         </div>
-        <div class="glpi-status-block status-filter-btn" data-status="2" data-label="В работе">
+        <div class="glpi-status-block status-filter-btn active" data-status="2" data-label="В работе">
           <span class="status-count"><?php echo intval($status_counts[2] ?? 0); ?></span>
           <span class="status-label">В работе</span>
         </div>


### PR DESCRIPTION
## Summary
- Default the dashboard to the "В работе" status
- Reset status filter when categories are selected and vice versa
- Keep status counters unaffected by category filters

## Testing
- `php -l templates/glpi-cards-template.php`
- `node --check gexe-filter.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68ba0ffecbe4832892939414d9c7fd49