### PR TITLE
Show full ticket text in modal and add comment icons

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -176,6 +176,7 @@ body {
 .glpi-comment{ background:#1e293b; border:1px solid #334155; border-radius:8px; padding:8px 12px; color:#e2e8f0; font-size:14px; }
 .glpi-comment + .glpi-comment{ margin-top:8px; }
 .glpi-comment .meta{ font-size:12px; color:#94a3b8; margin-bottom:4px; }
+.glpi-comment .meta .glpi-executor{ margin-right:4px; opacity:.6; }
 .glpi-comment .text{ line-height:1.4; }
 .glpi-comment .glpi-txt{ margin:0 0 4px 0; }
 .glpi-empty{ text-align:center; padding:12px 0; color:#94a3b8; font-size:13px; }

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -213,6 +213,11 @@
     const clone = cardEl.cloneNode(true);
     clone.classList.add('glpi-card--in-modal');
     const act = $('.gexe-card-actions', clone); if (act) act.remove();
+    const desc = $('.glpi-desc', clone);
+    if (desc) {
+      const full = desc.getAttribute('data-full');
+      if (full) desc.textContent = full;
+    }
     wrap.appendChild(clone);
   }
 

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -136,7 +136,7 @@ function gexe_render_comments($ticket_id) {
         if ($who === '') $who = 'Автор ID ' . $uid;
 
         $out .= '<div class="glpi-comment">'
-              .   '<div class="meta">' . esc_html($who) . ' • ' . $when . '</div>'
+              .   '<div class="meta"><i class="fa-solid fa-user-tie glpi-executor"></i> ' . esc_html($who) . ' • ' . $when . '</div>'
               .   '<div class="text">' . $txt . '</div>'
               . '</div>';
     }

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -154,6 +154,7 @@ function gexe_cat_slug($leaf) {
 
       $clean_desc    = gexe_clean_html_text($t['content']);
       $desc_short    = esc_html(gexe_trim_words($clean_desc, 40, '…'));
+      $desc_full_attr = esc_attr($clean_desc);
 
       // Дочерняя категория
       $leaf_cat      = gexe_leaf_category($t['category']);
@@ -185,7 +186,7 @@ function gexe_cat_slug($leaf) {
           <div class="glpi-ticket-id">#<?php echo intval($t['id']); ?></div>
         </div>
         <div class="glpi-card-body">
-          <p class="glpi-desc"><?php echo $desc_short; ?></p>
+          <p class="glpi-desc" data-full="<?php echo $desc_full_attr; ?>"><?php echo $desc_short; ?></p>
         </div>
         <div class="glpi-executor-footer"><?php echo $executors_html; ?></div>
         <div class="glpi-date-footer" data-date="<?php echo esc_attr((string)$t['date']); ?>"></div>


### PR DESCRIPTION
## Summary
- display full ticket description in modal by storing complete text in card markup and swapping it in when opening the modal
- prepend user icon to comment author name and style it

## Testing
- `php -l templates/glpi-cards-template.php`
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68ba12bdf4448328b34a8c5dec9e2fa6