### PR TITLE
Show full ticket text in modal and improve comments

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -175,7 +175,8 @@ body {
 /* Комментарии */
 .glpi-comment{ background:#1e293b; border:1px solid #334155; border-radius:8px; padding:8px 12px; color:#e2e8f0; font-size:14px; }
 .glpi-comment + .glpi-comment{ margin-top:8px; }
-.glpi-comment .meta{ font-size:12px; color:#94a3b8; margin-bottom:4px; }
+.glpi-comment .meta{ font-size:12px; color:#94a3b8; margin-bottom:4px; display:flex; justify-content:space-between; align-items:center; }
+.glpi-comment .meta .glpi-comment-author{ display:flex; align-items:center; gap:4px; }
 .glpi-comment .text{ line-height:1.4; }
 .glpi-comment .glpi-txt{ margin:0 0 4px 0; }
 .glpi-empty{ text-align:center; padding:12px 0; color:#94a3b8; font-size:13px; }

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -213,6 +213,11 @@
     const clone = cardEl.cloneNode(true);
     clone.classList.add('glpi-card--in-modal');
     const act = $('.gexe-card-actions', clone); if (act) act.remove();
+    const desc = $('.glpi-desc', clone);
+    if (desc) {
+      const full = desc.getAttribute('data-full');
+      if (full) desc.textContent = full;
+    }
     const chip = $('.glpi-comments-chip', clone); if (chip) chip.remove();
     wrap.appendChild(clone);
   }

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -136,7 +136,10 @@ function gexe_render_comments($ticket_id) {
         if ($who === '') $who = 'Автор ID ' . $uid;
 
         $out .= '<div class="glpi-comment">'
-              .   '<div class="meta">' . esc_html($who) . ' • ' . $when . '</div>'
+              .   '<div class="meta">'
+              .     '<span class="glpi-comment-author"><i class="fa-regular fa-user"></i> ' . esc_html($who) . '</span>'
+              .     '<span class="glpi-comment-date">' . $when . '</span>'
+              .   '</div>'
               .   '<div class="text">' . $txt . '</div>'
               . '</div>';
     }

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -185,7 +185,7 @@ function gexe_cat_slug($leaf) {
           <div class="glpi-ticket-id">#<?php echo intval($t['id']); ?></div>
         </div>
         <div class="glpi-card-body">
-          <p class="glpi-desc"><?php echo $desc_short; ?></p>
+          <p class="glpi-desc" data-full="<?php echo esc_attr($clean_desc); ?>"><?php echo $desc_short; ?></p>
         </div>
         <div class="glpi-executor-footer"><?php echo $executors_html; ?></div>
         <div class="glpi-date-footer" data-date="<?php echo esc_attr((string)$t['date']); ?>"></div>


### PR DESCRIPTION
## Summary
- show complete ticket descriptions in viewer modal
- display comment author icons and tighten comment layout

## Testing
- `php -l templates/glpi-cards-template.php`
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba14c7a3a48328ab815612ce30aa7c