### PR TITLE
Show GLPI location on task cards

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -50,7 +50,7 @@ body {
 .glpi-ticket-id { font-size: 13px; color: #64748b; }
 .glpi-card-body { font-size: 14px; color: #cbd5e1; line-height: 1.4; margin-bottom: 12px; max-height: 2.8em; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 
-.glpi-executor-footer { position: absolute; bottom: .5rem; left: .75rem; font-size: 12px; color: #94a3b8; display: flex; align-items: center; gap: 10px; }
+.glpi-executor-footer { position: absolute; bottom: .5rem; left: .75rem; font-size: 12px; color: #94a3b8; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .glpi-executor-footer i { margin-right: 4px; opacity: .6; }
 .glpi-date-footer { position: absolute; bottom: .5rem; right: .75rem; font-size: 12px; font-weight: 500; color: #9ca3af; }
 .glpi-date-footer.age-green  { color: #28a745 !important; }

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -93,6 +93,7 @@ function gexe_glpi_cards_shortcode($atts) {
     $join_req      = ' LEFT JOIN glpi_tickets_users tu_req ON t.id = tu_req.tickets_id AND tu_req.type = 1 ';
     $join_user     = ' LEFT JOIN glpi_users u ON tu_ass.users_id = u.id ';
     $join_cat      = ' LEFT JOIN glpi_itilcategories c ON t.itilcategories_id = c.id ';
+    $join_loc      = ' LEFT JOIN glpi_locations l ON t.locations_id = l.id ';
 
     $where_assignee = '';
     $mode = 'all';
@@ -114,12 +115,14 @@ function gexe_glpi_cards_shortcode($atts) {
                 tu_ass.users_id AS assignee_id,
                 tu_req.users_id AS author_id,
                 u.realname, u.firstname,
-                c.completename AS category_name
+                c.completename AS category_name,
+                l.completename AS location_name
         FROM glpi_tickets t
         $join_assignee
         $join_req
         $join_user
         $join_cat
+        $join_loc
         WHERE $where_status
         $where_assignee
         ORDER BY t.date DESC
@@ -143,6 +146,7 @@ function gexe_glpi_cards_shortcode($atts) {
                 'content'      => (string)$r->content,
                 'date'         => (string)$r->date,
                 'category'     => (string)$r->category_name, // полное «Родитель > Дочерняя»
+                'location'     => (string)$r->location_name,
                 'executors'    => [],
                 'assignee_ids' => [],
                 'author_id'    => (int)$r->author_id,

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -160,15 +160,23 @@ function gexe_cat_slug($leaf) {
       $cat_slug      = gexe_cat_slug($leaf_cat);
       $icon          = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf_cat)) : '';
 
+      // Местоположение (листовое)
+      $leaf_loc      = gexe_leaf_category($t['location']);
+      $location_html = '';
+      if ($leaf_loc !== '') {
+        $location_html = '<span class="glpi-location"><i class="fa-solid fa-location-dot"></i> ' . esc_html($leaf_loc) . '</span>';
+      }
+
       // Прямая ссылка в GLPI
       $link = 'http://192.168.100.12/glpi/front/ticket.form.php?id=' . intval($t['id']);
 
       $executors_html = '';
       if (!empty($t['executors'])) {
-        $executors_html = implode(', ', array_map(function($e){
-          return '<i class="fa-solid fa-user-tie glpi-executor"></i> ' . esc_html($e);
-        }, $t['executors']));
+        $names = implode(', ', array_map('esc_html', $t['executors']));
+        $executors_html = '<span class="glpi-executors"><i class="fa-solid fa-user-tie glpi-executor"></i> ' . $names . '</span>';
       }
+
+      $footer_html = $location_html . $executors_html;
     ?>
       <div class="glpi-card"
            data-ticket-id="<?php echo intval($t['id']); ?>"
@@ -187,7 +195,7 @@ function gexe_cat_slug($leaf) {
         <div class="glpi-card-body">
           <p class="glpi-desc"><?php echo $desc_short; ?></p>
         </div>
-        <div class="glpi-executor-footer"><?php echo $executors_html; ?></div>
+        <div class="glpi-executor-footer"><?php echo $footer_html; ?></div>
         <div class="glpi-date-footer" data-date="<?php echo esc_attr((string)$t['date']); ?>"></div>
       </div>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- include ticket location in GLPI query and store it with each card
- render leaf location on task cards alongside executors
- allow footer to wrap when displaying location and executors

## Testing
- `php -l gexe-copy.php`
- `php -l templates/glpi-cards-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba18722a008328924d8b0280221c09