### PR TITLE
Add REST-based comment loading with pagination

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -222,15 +222,12 @@
     wrap.appendChild(clone);
   }
 
-  function loadComments(ticketId) {
-    const url = window.glpiAjax && glpiAjax.url;
-    const nonce = window.glpiAjax && glpiAjax.nonce;
-    if (!url || !nonce) return;
-    const fd = new FormData();
-    fd.append('action', 'glpi_get_comments');
-    fd.append('_ajax_nonce', nonce);
-    fd.append('ticket_id', String(ticketId));
-    fetch(url, { method: 'POST', body: fd })
+  function loadComments(ticketId, page = 1) {
+    const base = window.glpiAjax && glpiAjax.rest;
+    const nonce = window.glpiAjax && glpiAjax.restNonce;
+    if (!base || !nonce) return;
+    const url = base + 'comments?ticket_id=' + encodeURIComponent(ticketId) + '&page=' + page;
+    fetch(url, { headers: { 'X-WP-Nonce': nonce } })
       .then(r => r.text())
       .then(html => { const box = $('#gexe-comments'); if (box) box.innerHTML = html; })
       .catch(()=>{});


### PR DESCRIPTION
## Summary
- paginate comment rendering and add REST endpoint to fetch comments
- simplify comment HTML cleaning using built-in functions
- switch front-end comment loading to REST API

## Testing
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a053fb4832880d9e0f9763f783c