### PR TITLE
Fix JSON encoded comments in task card

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -229,7 +229,12 @@
     const url = base + 'comments?ticket_id=' + encodeURIComponent(ticketId) + '&page=' + page;
     fetch(url, { headers: { 'X-WP-Nonce': nonce } })
       .then(r => r.text())
-      .then(html => { const box = $('#gexe-comments'); if (box) box.innerHTML = html; })
+      .then(text => {
+        let html;
+        try { html = JSON.parse(text); } catch (e) { html = text; }
+        const box = $('#gexe-comments');
+        if (box) box.innerHTML = html;
+      })
       .catch(()=>{});
   }
 


### PR DESCRIPTION
## Summary
- decode REST API comment responses so Unicode text renders properly

## Testing
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba6e4b64bc8328881eb006e02154d9