### PR TITLE
Hide executor surnames and greet authorized users

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -79,12 +79,20 @@ body {
 .glpi-header-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: flex-start; margin-bottom: 12px; }
 
 /* Поиск — на всю ширину и всегда сверху */
-.glpi-header-row .glpi-search-block{order:-1; width:100%;}
-.glpi-search-block { flex: 1 1 100%; min-width: 220px; }
+.glpi-header-row .glpi-search-block,
+.glpi-header-row .glpi-search-row{order:-1; width:100%;}
+.glpi-search-block,
+.glpi-search-row { flex: 1 1 100%; min-width: 220px; }
+.glpi-search-row { display:flex; flex-direction:column; }
 .glpi-search-input {
   all: unset; width: 100%; box-sizing: border-box;
   background: #1e293b !important; color:#f8fafc !important;
   padding: 10px 14px; border: 1px solid #334155; border-radius: 6px; font-size: 14px;
+}
+.glpi-user-greeting {
+  color: #e5e7eb;
+  margin-bottom: 4px;
+  font-size: 14px;
 }
 .glpi-search-input::placeholder{color:#64748b}
 .glpi-search-input:focus{ outline:none; border-color:#facc15; box-shadow:0 0 0 2px rgba(250,204,21,.3); }


### PR DESCRIPTION
## Summary
- Hide executor surnames on task cards for logged-in users
- Display greeting with user name above the search bar
- Style greeting and search row

## Testing
- `php -l templates/glpi-cards-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba6ef422608328bb15fb9ab784464a