### PR TITLE
Keep status filter when toggling categories

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -169,14 +169,18 @@
       const tgt = e.target.closest('.category-filter-btn, .glpi-category-tag');
       if(!tgt || !tgt.hasAttribute('data-cat')) return;
       e.preventDefault();
-      currentCategory = String(tgt.getAttribute('data-cat') || 'all').toLowerCase();
-      document.querySelectorAll('.category-filter-btn, .glpi-category-tag').forEach(b => b.classList.remove('active'));
-      tgt.classList.add('active');
-      // при выборе категории сбрасываем фильтр статусов
-      $$('.status-filter-btn').forEach(b => b.classList.remove('active'));
-      const allBtn = document.querySelector('.status-filter-btn[data-status="all"]');
-      if (allBtn) allBtn.classList.add('active');
-      recalcStatusCounts(); recalcCategoryVisibility(); filterCards();
+      const cat = String(tgt.getAttribute('data-cat') || 'all').toLowerCase();
+      const isActive = tgt.classList.contains('active');
+      $$('.category-filter-btn, .glpi-category-tag').forEach(b => b.classList.remove('active'));
+      if (isActive) {
+        currentCategory = 'all';
+      } else {
+        currentCategory = cat;
+        tgt.classList.add('active');
+      }
+      recalcStatusCounts();
+      recalcCategoryVisibility();
+      filterCards();
     }, true);
   }
 


### PR DESCRIPTION
## Summary
- Preserve selected status when choosing a category
- Allow clicking an active category again to clear the category filter

## Testing
- `node --check gexe-filter.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba70adc250832881cf7371cfd53350