### PR TITLE
Move task actions to modal and disable accepted button

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -167,6 +167,7 @@ body {
 .gexe-card-actions{ position:absolute; top:-10px; right:-10px; display:flex; gap:8px; z-index:3; }
 .gexe-action-btn{ background:#0b1220; color:#e5e7eb; border:1px solid #243045; border-radius:8px; padding:8px 10px; cursor:pointer; box-shadow:0 2px 6px rgba(0,0,0,.25); }
 .gexe-action-btn:hover{ background:#111b2e; }
+.gexe-action-btn:disabled{ background:#1e293b; color:#64748b; border-color:#334155; cursor:default; box-shadow:none; }
 
 /* ======= Модалка просмотра ======= */
 .gexe-modal{ position:fixed; inset:0; display:none; z-index:10000; }


### PR DESCRIPTION
## Summary
- Show comment and completion actions only inside the task modal
- Keep "Accept" on cards and disable it when already accepted
- Style disabled action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba73f7e14883289b7bc70f65b9e7b4