### PR TITLE
feat: highlight greeting above search

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -90,9 +90,10 @@ body {
   padding: 10px 14px; border: 1px solid #334155; border-radius: 6px; font-size: 14px;
 }
 .glpi-user-greeting {
-  color: #e5e7eb;
+  color: #facc15;
   margin-bottom: 4px;
   font-size: 14px;
+  font-weight: 600;
 }
 .glpi-search-input::placeholder{color:#64748b}
 .glpi-search-input:focus{ outline:none; border-color:#facc15; box-shadow:0 0 0 2px rgba(250,204,21,.3); }

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -24,14 +24,24 @@
 
   /* ========================= ПОИСК (СОЗДАТЬ СВЕРХУ) ========================= */
   function ensureSearchOnTop() {
-    const root = document.querySelector('.glpi-filtering-panel .glpi-header-row') || document.querySelector('.glpi-filtering-panel');
+    const root = document.querySelector('.glpi-filtering-panel .glpi-header-row')
+      || document.querySelector('.glpi-filtering-panel');
     if (!root) return;
-    // убираем все предыдущие поля поиска (и «короткие», и случайные дублёры)
-    document.querySelectorAll('.glpi-search-block, .glpi-search-input').forEach(el => el.remove());
-    // создаём заново и вставляем первым
+
+    // берем существующее приветствие, если оно уже есть в DOM
+    let greetingHTML = '';
+    const oldGreeting = document.querySelector('.glpi-user-greeting');
+    if (oldGreeting) greetingHTML = oldGreeting.outerHTML;
+
+    // убираем все предыдущие поля поиска и блоки
+    document.querySelectorAll('.glpi-search-block, .glpi-search-row, .glpi-search-input')
+      .forEach(el => el.remove());
+
+    // создаём заново и вставляем первым; приветствие (если есть) идёт перед полем
     const wrap = document.createElement('div');
-    wrap.className = 'glpi-search-block';
-    wrap.innerHTML = '<input type="text" id="glpi-unified-search" class="glpi-search-input" placeholder="Поиск...">';
+    wrap.className = 'glpi-search-row';
+    wrap.innerHTML = (greetingHTML || '') +
+      '<input type="text" id="glpi-unified-search" class="glpi-search-input" placeholder="Поиск...">';
     root.insertBefore(wrap, root.firstChild);
     // Подстраховка: кнопка, к которой привязывается glpi-new-task.php
     if (!document.getElementById('glpi-btn-new-ticket')) {


### PR DESCRIPTION
## Summary
- style user greeting above search field in yellow
- preserve greeting when JS rebuilds search row

## Testing
- `php -l templates/glpi-cards-template.php`
- `node --check gexe-filter.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba755048008328b6566932dda40174