### PR TITLE
Cache comment counts and combine comment requests

### DIFF
--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -128,6 +128,31 @@ function gexe_clear_comments_cache($ticket_id) {
         }
         wp_cache_delete($index_key, 'glpi');
     }
+    gexe_clear_comment_count_cache($ticket_id);
+}
+
+/** Построение ключа кэша количества комментариев */
+function gexe_comment_count_cache_key($ticket_id) {
+    return 'glpi_comment_count_' . $ticket_id;
+}
+
+/** Очистка кэша количества комментариев */
+function gexe_clear_comment_count_cache($ticket_id) {
+    wp_cache_delete(gexe_comment_count_cache_key($ticket_id), 'glpi');
+}
+
+/** Получение количества комментариев с кэшированием */
+function gexe_get_comment_count($ticket_id) {
+    $key = gexe_comment_count_cache_key($ticket_id);
+    $cached = wp_cache_get($key, 'glpi');
+    if ($cached !== false) return (int)$cached;
+    global $glpi_db;
+    $cnt = (int)$glpi_db->get_var($glpi_db->prepare(
+        "SELECT COUNT(*) FROM glpi_itilfollowups WHERE itemtype='Ticket' AND items_id=%d",
+        $ticket_id
+    ));
+    wp_cache_set($key, $cnt, 'glpi', DAY_IN_SECONDS);
+    return $cnt;
 }
 
 /* -------- AJAX: загрузка комментариев тикета -------- */
@@ -136,7 +161,7 @@ add_action('wp_ajax_nopriv_glpi_get_comments', 'gexe_glpi_get_comments');
 
 
 function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
-    if ($ticket_id <= 0) return '';
+    if ($ticket_id <= 0) return ['html' => '', 'count' => 0];
     $page = max(1, (int)$page);
     $per_page = max(1, (int)$per_page);
 
@@ -145,7 +170,7 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
     $cached    = wp_cache_get($cache_key, 'glpi');
 
     if (is_array($cached) && isset($cached['html'], $cached['signature']) && $cached['signature'] === $signature) {
-        return $cached['html'];
+        return $cached;
     }
 
     global $glpi_db;
@@ -163,11 +188,13 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
 
     if (!$rows) {
         $empty = '<div class="glpi-empty">Нет комментариев</div>';
-        gexe_store_comments_cache($ticket_id, $page, $per_page, [
+        $data = [
             'html'      => $empty,
+            'count'     => 0,
             'signature' => $signature,
-        ]);
-        return $empty;
+        ];
+        gexe_store_comments_cache($ticket_id, $page, $per_page, $data);
+        return $data;
     }
 
     $out = '';
@@ -187,11 +214,13 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
               . '</div>';
     }
 
-    gexe_store_comments_cache($ticket_id, $page, $per_page, [
+    $data = [
         'html'      => $out,
+        'count'     => count($rows),
         'signature' => $signature,
-    ]);
-    return $out;
+    ];
+    gexe_store_comments_cache($ticket_id, $page, $per_page, $data);
+    return $data;
 }
 
 function gexe_glpi_get_comments() {
@@ -199,7 +228,7 @@ function gexe_glpi_get_comments() {
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     $page      = isset($_POST['page']) ? intval($_POST['page']) : 1;
     $per_page  = isset($_POST['per_page']) ? intval($_POST['per_page']) : 20;
-    wp_die(gexe_render_comments($ticket_id, $page, $per_page));
+    wp_send_json(gexe_render_comments($ticket_id, $page, $per_page));
 }
 
 add_action('rest_api_init', function () {
@@ -215,20 +244,6 @@ add_action('rest_api_init', function () {
     ]);
 });
 
-/* -------- AJAX: количество комментариев -------- */
-add_action('wp_ajax_glpi_count_comments', 'gexe_glpi_count_comments');
-function gexe_glpi_count_comments() {
-    check_ajax_referer('glpi_modal_actions');
-    $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
-    if ($ticket_id <= 0) wp_send_json(['count' => 0]);
-    global $glpi_db;
-    $n = (int)$glpi_db->get_var($glpi_db->prepare(
-        "SELECT COUNT(*) FROM glpi_itilfollowups WHERE itemtype='Ticket' AND items_id=%d",
-        $ticket_id
-    ));
-    wp_send_json(['count' => $n]);
-}
-
 /* -------- AJAX: количество комментариев для нескольких тикетов -------- */
 add_action('wp_ajax_glpi_count_comments_batch', 'gexe_glpi_count_comments_batch');
 function gexe_glpi_count_comments_batch() {
@@ -240,22 +255,38 @@ function gexe_glpi_count_comments_batch() {
         wp_send_json(['counts' => []]);
     }
 
-    global $glpi_db;
-    $placeholders = implode(',', array_fill(0, count($ids), '%d'));
-    $sql = "SELECT items_id, COUNT(*) AS cnt FROM glpi_itilfollowups "
-         . "WHERE itemtype='Ticket' AND items_id IN ($placeholders) GROUP BY items_id";
-    $rows = $glpi_db->get_results($glpi_db->prepare($sql, $ids), ARRAY_A);
-
     $out = [];
-    if ($rows) {
-        foreach ($rows as $r) {
-            $out[(int)$r['items_id']] = (int)$r['cnt'];
+    $missing = [];
+    foreach ($ids as $id) {
+        $key = gexe_comment_count_cache_key($id);
+        $cached = wp_cache_get($key, 'glpi');
+        if ($cached !== false) {
+            $out[$id] = (int)$cached;
+        } else {
+            $missing[] = $id;
         }
     }
-    // ensure all ids present
-    foreach ($ids as $id) {
-        if (!isset($out[$id])) {
-            $out[$id] = 0;
+
+    if ($missing) {
+        global $glpi_db;
+        $placeholders = implode(',', array_fill(0, count($missing), '%d'));
+        $sql = "SELECT items_id, COUNT(*) AS cnt FROM glpi_itilfollowups "
+             . "WHERE itemtype='Ticket' AND items_id IN ($placeholders) GROUP BY items_id";
+        $rows = $glpi_db->get_results($glpi_db->prepare($sql, $missing), ARRAY_A);
+
+        if ($rows) {
+            foreach ($rows as $r) {
+                $id  = (int)$r['items_id'];
+                $cnt = (int)$r['cnt'];
+                $out[$id] = $cnt;
+                wp_cache_set(gexe_comment_count_cache_key($id), $cnt, 'glpi', DAY_IN_SECONDS);
+            }
+        }
+        foreach ($missing as $id) {
+            if (!isset($out[$id])) {
+                $out[$id] = 0;
+                wp_cache_set(gexe_comment_count_cache_key($id), 0, 'glpi', DAY_IN_SECONDS);
+            }
         }
     }
 
@@ -353,16 +384,20 @@ function gexe_glpi_card_action() {
         }
     }
 
-    $comment_html = '';
+    $comment_html  = '';
+    $comment_count = 0;
     if ($ok) {
         gexe_clear_comments_cache($ticket_id);
-        $comment_html = gexe_render_comments($ticket_id);
+        $data = gexe_render_comments($ticket_id);
+        $comment_html  = $data['html'];
+        $comment_count = $data['count'];
     }
 
     wp_send_json([
         'ok'           => (bool)$ok,
         'new_status'   => $new_status,
-        'comment_html' => $comment_html
+        'comment_html' => $comment_html,
+        'comment_count'=> $comment_count,
     ]);
 }
 
@@ -392,12 +427,8 @@ function gexe_glpi_add_comment() {
 
     $count = 0;
     if ($ok) {
-        $count = (int)$glpi_db->get_var($glpi_db->prepare(
-            "SELECT COUNT(*) FROM glpi_itilfollowups WHERE itemtype='Ticket' AND items_id=%d",
-            $ticket_id
-        ));
-        // очищаем кэш комментариев, чтобы при следующем открытии загрузились свежие данные
         gexe_clear_comments_cache($ticket_id);
+        $count = gexe_get_comment_count($ticket_id);
     }
 
     wp_send_json(['ok' => (bool)$ok, 'count' => $count]);


### PR DESCRIPTION
## Summary
- Cache comment counts using WordPress object cache to cut repeated GLPI queries
- Return comments with counts in one response and update JS to use the merged payload, removing extra AJAX calls

## Testing
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba83e56350832897eceb9886292b35