### PR TITLE
feat: add GLPI query timing stats

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -128,7 +128,10 @@ function gexe_glpi_cards_shortcode($atts) {
         ORDER BY t.date DESC
         LIMIT 500
     ";
+
+    $t0   = microtime(true);
     $rows = $glpi_db->get_results($sql);
+    $GLOBALS['gexe_query_times']['tickets'] = (int)round((microtime(true) - $t0) * 1000);
 
     if (!$rows) {
         return '<p>Нет активных заявок.</p>';

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -196,6 +196,7 @@
 
   /* ========================= МОДАЛКА ПРОСМОТРА КАРТОЧКИ ========================= */
   let modalEl = null;
+  let commentsController = null;
   function ensureViewerModal() {
     if (modalEl) return modalEl;
     modalEl = document.createElement('div');
@@ -284,7 +285,9 @@
     const nonce = window.glpiAjax && glpiAjax.restNonce;
     if (!base || !nonce) return;
     const url = base + 'comments?ticket_id=' + encodeURIComponent(ticketId) + '&page=' + page;
-    fetch(url, { headers: { 'X-WP-Nonce': nonce } })
+    if (commentsController) commentsController.abort();
+    commentsController = new AbortController();
+    fetch(url, { headers: { 'X-WP-Nonce': nonce }, signal: commentsController.signal })
       .then(r => r.json())
       .then(data => {
         const box = $('#gexe-comments');
@@ -297,6 +300,10 @@
           if (modalCnt) modalCnt.textContent = String(data.count);
           const cardCnt = document.querySelector('.glpi-card[data-ticket-id="'+ticketId+'"] .gexe-cmnt-count');
           if (cardCnt) cardCnt.textContent = String(data.count);
+        }
+        if (data && typeof data.time_ms === 'number') {
+          const stat = document.getElementById('glpi-comments-time');
+          if (stat) stat.textContent = String(data.time_ms);
         }
       })
       .catch(()=>{});

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -170,11 +170,13 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
     $cached    = wp_cache_get($cache_key, 'glpi');
 
     if (is_array($cached) && isset($cached['html'], $cached['signature']) && $cached['signature'] === $signature) {
+        $cached['time_ms'] = 0;
         return $cached;
     }
 
     global $glpi_db;
     $offset = ($page - 1) * $per_page;
+    $t0   = microtime(true);
     $rows = $glpi_db->get_results($glpi_db->prepare(
         "SELECT f.id, f.users_id, f.date, f.content, u.realname, u.firstname"
          . " FROM glpi_itilfollowups AS f"
@@ -185,6 +187,7 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
          . " LIMIT %d OFFSET %d",
         $ticket_id, $per_page, $offset
     ), ARRAY_A);
+    $elapsed_ms = (int)round((microtime(true) - $t0) * 1000);
 
     if (!$rows) {
         $empty = '<div class="glpi-empty">Нет комментариев</div>';
@@ -192,6 +195,7 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
             'html'      => $empty,
             'count'     => 0,
             'signature' => $signature,
+            'time_ms'   => $elapsed_ms,
         ];
         gexe_store_comments_cache($ticket_id, $page, $per_page, $data);
         return $data;
@@ -218,6 +222,7 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
         'html'      => $out,
         'count'     => count($rows),
         'signature' => $signature,
+        'time_ms'   => $elapsed_ms,
     ];
     gexe_store_comments_cache($ticket_id, $page, $per_page, $data);
     return $data;

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -153,7 +153,7 @@ function gexe_cat_slug($leaf) {
 
   <!-- Карточки -->
   <div class="glpi-wrapper">
-    <?php foreach ($tickets as $t): 
+    <?php foreach ($tickets as $t):
       $slug_list     = array_map('md5', $t['executors']);
       $slug_str      = implode(',', $slug_list);
       $assignees     = array_map('intval', $t['assignee_ids'] ?? []);
@@ -222,6 +222,11 @@ function gexe_cat_slug($leaf) {
         <div class="glpi-date-footer" data-date="<?php echo esc_attr((string)$t['date']); ?>"></div>
       </div>
     <?php endforeach; ?>
+  </div>
+
+  <div id="glpi-query-stats" class="glpi-query-stats">
+    <div>Задачи: <span id="glpi-task-time"><?php echo intval($GLOBALS['gexe_query_times']['tickets'] ?? 0); ?></span> мс</div>
+    <div>Комментарии: <span id="glpi-comments-time">0</span> мс</div>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary
- measure GLPI ticket query time and expose it for page stats
- include comment query timing in AJAX responses and cancel outdated fetches
- render request timing stats at bottom of cards page

## Testing
- `php -l gexe-copy.php`
- `php -l glpi-modal-actions.php`
- `php -l templates/glpi-cards-template.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba8814d674832896b5ee5e99c41c33