### PR TITLE
Disable accept action when ticket already started

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -530,13 +530,13 @@
         if (btnClose)  btnClose.style.display  = 'none';
       }
 
-      // Если уже есть «Принято в работу» от меня — блокируем «Принять в работу»
+      // Если уже есть «Принято в работу» — блокируем «Принять в работу»
       const url = window.glpiAjax && glpiAjax.url;
       const nonce = window.glpiAjax && glpiAjax.nonce;
       const ticketId = Number(card.getAttribute('data-ticket-id') || '0');
       if (btnAccept && url && nonce && ticketId) {
         const fd = new FormData();
-        fd.append('action', 'glpi_ticket_started_by_me');
+        fd.append('action', 'glpi_ticket_started');
         fd.append('_ajax_nonce', nonce);
         fd.append('ticket_id', String(ticketId));
         fetch(url, { method: 'POST', body: fd })

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -293,15 +293,14 @@ function gexe_glpi_count_comments_batch() {
     wp_send_json(['counts' => $out]);
 }
 
-/* -------- AJAX: проверка "Принято в работу" текущим исполнителем -------- */
-add_action('wp_ajax_glpi_ticket_started_by_me', 'gexe_glpi_ticket_started_by_me');
-function gexe_glpi_ticket_started_by_me() {
+/* -------- AJAX: проверка "Принято в работу" -------- */
+add_action('wp_ajax_glpi_ticket_started', 'gexe_glpi_ticket_started');
+function gexe_glpi_ticket_started() {
     check_ajax_referer('glpi_modal_actions');
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
-    $glpi_uid  = gexe_get_current_glpi_uid();
 
-    if ($ticket_id <= 0 || $glpi_uid <= 0) {
+    if ($ticket_id <= 0) {
         wp_send_json(['ok' => true, 'started' => false]);
     }
 
@@ -313,10 +312,9 @@ function gexe_glpi_ticket_started_by_me() {
          FROM glpi_itilfollowups
          WHERE itemtype = 'Ticket'
            AND items_id = %d
-           AND users_id = %d
            AND content LIKE %s
          LIMIT 1",
-        $ticket_id, $glpi_uid, $like1
+        $ticket_id, $like1
     )) ? true : false;
 
     wp_send_json(['ok' => true, 'started' => $started]);


### PR DESCRIPTION
## Summary
- Disable acceptance button if a ticket already contains "Принято в работу" comment
- Adjust server-side check to search comment without user filter

## Testing
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68ba8927a8a88328a8d665da30ffd423