### PR TITLE
fix: clear and refresh comments in modal

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -284,10 +284,14 @@
     const base = window.glpiAjax && glpiAjax.rest;
     const nonce = window.glpiAjax && glpiAjax.restNonce;
     if (!base || !nonce) return;
-    const url = base + 'comments?ticket_id=' + encodeURIComponent(ticketId) + '&page=' + page;
+    const box = $('#gexe-comments');
+    if (box) box.innerHTML = '';
+    const modalCntInit = modalEl && modalEl.querySelector('.glpi-modal__comments-title .gexe-cmnt-count');
+    if (modalCntInit) modalCntInit.textContent = '0';
+    const url = base + 'comments?ticket_id=' + encodeURIComponent(ticketId) + '&page=' + page + '&_=' + Date.now();
     if (commentsController) commentsController.abort();
     commentsController = new AbortController();
-    fetch(url, { headers: { 'X-WP-Nonce': nonce }, signal: commentsController.signal })
+    fetch(url, { headers: { 'X-WP-Nonce': nonce, 'Cache-Control': 'no-cache' }, signal: commentsController.signal })
       .then(r => r.json())
       .then(data => {
         const box = $('#gexe-comments');


### PR DESCRIPTION
## Summary
- ensure comment panel clears old content when loading new ticket comments
- add cache busting and no-cache header to comment requests

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba8b6b95c0832886303a45406a0664