### PR TITLE
Prefetch GLPI comments and warm cache

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -14,12 +14,19 @@ register_activation_hook(__FILE__, function () {
     if ($role) {
         $role->add_cap('create_glpi_ticket');
     }
+    if (!wp_next_scheduled('gexe_warm_comments_cache')) {
+        wp_schedule_event(time() + MINUTE_IN_SECONDS, 'hourly', 'gexe_warm_comments_cache');
+    }
 });
 
 register_deactivation_hook(__FILE__, function () {
     $role = get_role('administrator');
     if ($role) {
         $role->remove_cap('create_glpi_ticket');
+    }
+    $ts = wp_next_scheduled('gexe_warm_comments_cache');
+    if ($ts) {
+        wp_unschedule_event($ts, 'gexe_warm_comments_cache');
     }
 });
 

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -155,6 +155,18 @@ function gexe_get_comment_count($ticket_id) {
     return $cnt;
 }
 
+/** Прогрев кэша комментариев популярных тикетов */
+function gexe_warm_comments_cache() {
+    global $glpi_db;
+    $ids = $glpi_db->get_col("SELECT id FROM glpi_tickets WHERE status IN (1,2,3,4) ORDER BY date DESC LIMIT 5");
+    if ($ids) {
+        foreach ($ids as $id) {
+            gexe_render_comments((int)$id, 1, 20);
+        }
+    }
+}
+add_action('gexe_warm_comments_cache', 'gexe_warm_comments_cache');
+
 /* -------- AJAX: загрузка комментариев тикета -------- */
 add_action('wp_ajax_glpi_get_comments', 'gexe_glpi_get_comments');
 add_action('wp_ajax_nopriv_glpi_get_comments', 'gexe_glpi_get_comments');


### PR DESCRIPTION
## Summary
- Prefetch and cache comments for the first visible GLPI tickets using sessionStorage and re-use cached HTML in the ticket modal
- Schedule a WP-Cron task to periodically warm comment caches of recent tickets

## Testing
- `php -l gexe-copy.php`
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba8e9940fc83288f7928c0ab815f85