### PR TITLE
feat: add read replica support

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -37,7 +37,10 @@ add_action('wp_enqueue_scripts', function () {
 });
 
 // ====== ПОДКЛЮЧЕНИЕ К БД GLPI ======
-require_once __DIR__ . '/glpi-db-setup.php';
+require_once __DIR__ . '/glpi-utils.php';
+global $glpi_db, $glpi_db_ro;
+$glpi_db    = gexe_glpi_db();      // master for writes
+$glpi_db_ro = gexe_glpi_db('ro');  // local replica for reads
 
 // ====== УТИЛИТЫ ======
 function gexe_autoname($realname, $firstname) {
@@ -72,7 +75,7 @@ function gexe_slugify($text) {
 add_shortcode('glpi_cards_exe', 'gexe_glpi_cards_shortcode');
 
 function gexe_glpi_cards_shortcode($atts) {
-    global $glpi_db;
+    $glpi_db = gexe_glpi_db('ro');
 
     // ---- Получаем привязку WP → GLPI ----
     $current_user   = wp_get_current_user();

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -38,10 +38,10 @@ add_action('wp_ajax_glpi_dropdowns', 'gexe_glpi_dropdowns');
 function gexe_glpi_dropdowns() {
     check_ajax_referer('glpi_modal_actions');
 
-    global $glpi_db;
+    $db = gexe_glpi_db('ro');
 
     // Категории (полное имя)
-    $cats = $glpi_db->get_results(
+    $cats = $db->get_results(
         "SELECT id, completename
          FROM glpi_itilcategories
          ORDER BY completename ASC",
@@ -58,7 +58,7 @@ function gexe_glpi_dropdowns() {
     }
 
     // Местоположения
-    $locs = $glpi_db->get_results(
+    $locs = $db->get_results(
         "SELECT id, completename
          FROM glpi_locations
          ORDER BY completename ASC",
@@ -108,7 +108,7 @@ function gexe_glpi_create_ticket() {
         wp_send_json(['ok' => false, 'error' => 'bad_request']);
     }
 
-    global $glpi_db;
+    $db = gexe_glpi_db();
 
     $glpi_uid = gexe_get_current_glpi_uid(); // может быть 0
 
@@ -123,16 +123,16 @@ function gexe_glpi_create_ticket() {
     ];
     $formats = ['%s','%s','%d','%s','%d','%d'];
 
-    $ok = (false !== $glpi_db->insert('glpi_tickets', $ticket_data, $formats));
+    $ok = (false !== $db->insert('glpi_tickets', $ticket_data, $formats));
     if (!$ok) {
         wp_send_json(['ok' => false, 'error' => 'insert_ticket_failed']);
     }
 
-    $ticket_id = intval($glpi_db->insert_id);
+    $ticket_id = intval($db->insert_id);
 
     // Добавляем заявителя (requester, type=1), если есть пользователь GLPI
     if ($glpi_uid > 0) {
-        $glpi_db->insert('glpi_tickets_users', [
+        $db->insert('glpi_tickets_users', [
             'tickets_id' => $ticket_id,
             'users_id'   => $glpi_uid,
             'type'       => 1
@@ -141,7 +141,7 @@ function gexe_glpi_create_ticket() {
 
     // Исполнитель по флажку (assignee, type=2)
     if ($assign_me && $glpi_uid > 0) {
-        $glpi_db->insert('glpi_tickets_users', [
+        $db->insert('glpi_tickets_users', [
             'tickets_id' => $ticket_id,
             'users_id'   => $glpi_uid,
             'type'       => 2

--- a/glpi-utils.php
+++ b/glpi-utils.php
@@ -20,3 +20,41 @@ function gexe_get_current_glpi_uid() {
     }
     return 0;
 }
+
+/**
+ * Obtain connection to GLPI database.
+ *
+ * @param string $mode 'ro' for read-only replica, anything else for master
+ * @return wpdb
+ */
+function gexe_glpi_db($mode = 'rw') {
+    static $rw = null;
+    static $ro = null;
+
+    if ($mode === 'ro') {
+        if ($ro instanceof wpdb) {
+            return $ro;
+        }
+        // Local replica for read operations
+        $ro = new wpdb(
+            'wp_glpi',            // db user
+            'xapetVD4OWZqw8f',    // db password
+            'glpi',               // db name
+            '127.0.0.1'           // local replica host
+        );
+        return $ro;
+    }
+
+    if ($rw instanceof wpdb) {
+        return $rw;
+    }
+
+    // Master server for write operations
+    $rw = new wpdb(
+        'wp_glpi',            // db user
+        'xapetVD4OWZqw8f',    // db password
+        'glpi',               // db name
+        '192.168.100.12'      // master host
+    );
+    return $rw;
+}


### PR DESCRIPTION
## Summary
- add helper `gexe_glpi_db()` to manage master and read-only database connections
- route read queries through local replica while keeping writes on master

## Testing
- `php -l glpi-utils.php`
- `php -l gexe-copy.php`
- `php -l glpi-categories-shortcode.php`
- `php -l glpi-new-task.php`
- `php -l glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8e8b521c8328bad3d8862ba59dc8