### PR TITLE
feat: add read replica support

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -44,7 +44,10 @@ add_action('wp_enqueue_scripts', function () {
 });
 
 // ====== ПОДКЛЮЧЕНИЕ К БД GLPI ======
-require_once __DIR__ . '/glpi-db-setup.php';
+require_once __DIR__ . '/glpi-utils.php';
+global $glpi_db, $glpi_db_ro;
+$glpi_db    = gexe_glpi_db();      // master for writes
+$glpi_db_ro = gexe_glpi_db('ro');  // local replica for reads
 
 // ====== УТИЛИТЫ ======
 function gexe_autoname($realname, $firstname) {
@@ -79,7 +82,7 @@ function gexe_slugify($text) {
 add_shortcode('glpi_cards_exe', 'gexe_glpi_cards_shortcode');
 
 function gexe_glpi_cards_shortcode($atts) {
-    global $glpi_db;
+    $glpi_db = gexe_glpi_db('ro');
 
     // ---- Получаем привязку WP → GLPI ----
     $current_user   = wp_get_current_user();

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -1,11 +1,14 @@
 <?php
 /**
  * GLPI Modal + Actions (standalone module)
- * Подключается из gexe-copy.php. Использует существующее соединение $glpi_db.
+ * Подключается из gexe-copy.php. Использует gexe_glpi_db() для соединения.
  * Поддержка AJAX для: загрузки комментариев, проверки "Принято в работу",
  * добавления комментария, действий "start/done", счетчика комментариев.
  */
 require_once __DIR__ . '/glpi-utils.php';
+global $glpi_db, $glpi_db_ro;
+$glpi_db    = gexe_glpi_db();      // master
+$glpi_db_ro = gexe_glpi_db('ro');  // replica for reads
 
 add_action('wp_enqueue_scripts', function () {
     wp_localize_script('gexe-filter', 'glpiAjax', [
@@ -24,10 +27,10 @@ function gexe_can_touch_glpi_ticket($ticket_id) {
     $glpi_uid = gexe_get_current_glpi_uid();
     if ($glpi_uid <= 0) return false;
 
-    global $glpi_db;
+    global $glpi_db_ro;
 
     // Глобальные права (UPDATE)
-    $has_right = $glpi_db->get_var($glpi_db->prepare(
+    $has_right = $glpi_db_ro->get_var($glpi_db_ro->prepare(
         "SELECT 1
          FROM glpi_profiles_users pu
          JOIN glpi_profilerights pr ON pu.profiles_id = pr.profiles_id
@@ -40,7 +43,7 @@ function gexe_can_touch_glpi_ticket($ticket_id) {
     if ($has_right) return true;
 
     // Исполнитель тикета
-    $is_assignee = $glpi_db->get_var($glpi_db->prepare(
+    $is_assignee = $glpi_db_ro->get_var($glpi_db_ro->prepare(
         "SELECT 1
          FROM glpi_tickets_users
          WHERE tickets_id = %d
@@ -85,8 +88,8 @@ function gexe_clean_comment_html($html) {
  * Используем статус тикета и дату последнего комментария.
  */
 function gexe_get_ticket_comments_signature($ticket_id) {
-    global $glpi_db;
-    $row = $glpi_db->get_row($glpi_db->prepare(
+    global $glpi_db_ro;
+    $row = $glpi_db_ro->get_row($glpi_db_ro->prepare(
         "SELECT status, last_followup_at AS last_comment FROM glpi_tickets WHERE id = %d",
         $ticket_id
     ), ARRAY_A);
@@ -143,8 +146,8 @@ function gexe_get_comment_count($ticket_id) {
     $key = gexe_comment_count_cache_key($ticket_id);
     $cached = wp_cache_get($key, 'glpi');
     if ($cached !== false) return (int)$cached;
-    global $glpi_db;
-    $cnt = (int)$glpi_db->get_var($glpi_db->prepare(
+    global $glpi_db_ro;
+    $cnt = (int)$glpi_db_ro->get_var($glpi_db_ro->prepare(
         "SELECT COUNT(*) FROM glpi_itilfollowups WHERE itemtype='Ticket' AND items_id=%d",
         $ticket_id
     ));
@@ -183,10 +186,10 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
         return $cached;
     }
 
-    global $glpi_db;
+    global $glpi_db_ro;
     $offset = ($page - 1) * $per_page;
     $t0   = microtime(true);
-    $rows = $glpi_db->get_results($glpi_db->prepare(
+    $rows = $glpi_db_ro->get_results($glpi_db_ro->prepare(
         "SELECT f.id, f.users_id, f.date, f.content, u.realname, u.firstname"
          . " FROM glpi_itilfollowups AS f"
          . " LEFT JOIN glpi_users AS u ON u.id = f.users_id"
@@ -282,11 +285,11 @@ function gexe_glpi_count_comments_batch() {
     }
 
     if ($missing) {
-        global $glpi_db;
+        global $glpi_db_ro;
         $placeholders = implode(',', array_fill(0, count($missing), '%d'));
         $sql = "SELECT items_id, COUNT(*) AS cnt FROM glpi_itilfollowups "
              . "WHERE itemtype='Ticket' AND items_id IN ($placeholders) GROUP BY items_id";
-        $rows = $glpi_db->get_results($glpi_db->prepare($sql, $missing), ARRAY_A);
+        $rows = $glpi_db_ro->get_results($glpi_db_ro->prepare($sql, $missing), ARRAY_A);
 
         if ($rows) {
             foreach ($rows as $r) {
@@ -318,10 +321,10 @@ function gexe_glpi_ticket_started() {
         wp_send_json(['ok' => true, 'started' => false]);
     }
 
-    global $glpi_db;
-    $like1 = '%' . $glpi_db->esc_like('Принято в работу') . '%';
+    global $glpi_db_ro;
+    $like1 = '%' . $glpi_db_ro->esc_like('Принято в работу') . '%';
 
-    $started = $glpi_db->get_var($glpi_db->prepare(
+    $started = $glpi_db_ro->get_var($glpi_db_ro->prepare(
         "SELECT 1
          FROM glpi_itilfollowups
          WHERE itemtype = 'Ticket'

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -38,10 +38,10 @@ add_action('wp_ajax_glpi_dropdowns', 'gexe_glpi_dropdowns');
 function gexe_glpi_dropdowns() {
     check_ajax_referer('glpi_modal_actions');
 
-    global $glpi_db;
+    $db = gexe_glpi_db('ro');
 
     // Категории (полное имя)
-    $cats = $glpi_db->get_results(
+    $cats = $db->get_results(
         "SELECT id, completename
          FROM glpi_itilcategories
          ORDER BY completename ASC",
@@ -58,7 +58,7 @@ function gexe_glpi_dropdowns() {
     }
 
     // Местоположения
-    $locs = $glpi_db->get_results(
+    $locs = $db->get_results(
         "SELECT id, completename
          FROM glpi_locations
          ORDER BY completename ASC",
@@ -108,7 +108,7 @@ function gexe_glpi_create_ticket() {
         wp_send_json(['ok' => false, 'error' => 'bad_request']);
     }
 
-    global $glpi_db;
+    $db = gexe_glpi_db();
 
     $glpi_uid = gexe_get_current_glpi_uid(); // может быть 0
 
@@ -123,16 +123,16 @@ function gexe_glpi_create_ticket() {
     ];
     $formats = ['%s','%s','%d','%s','%d','%d'];
 
-    $ok = (false !== $glpi_db->insert('glpi_tickets', $ticket_data, $formats));
+    $ok = (false !== $db->insert('glpi_tickets', $ticket_data, $formats));
     if (!$ok) {
         wp_send_json(['ok' => false, 'error' => 'insert_ticket_failed']);
     }
 
-    $ticket_id = intval($glpi_db->insert_id);
+    $ticket_id = intval($db->insert_id);
 
     // Добавляем заявителя (requester, type=1), если есть пользователь GLPI
     if ($glpi_uid > 0) {
-        $glpi_db->insert('glpi_tickets_users', [
+        $db->insert('glpi_tickets_users', [
             'tickets_id' => $ticket_id,
             'users_id'   => $glpi_uid,
             'type'       => 1
@@ -141,7 +141,7 @@ function gexe_glpi_create_ticket() {
 
     // Исполнитель по флажку (assignee, type=2)
     if ($assign_me && $glpi_uid > 0) {
-        $glpi_db->insert('glpi_tickets_users', [
+        $db->insert('glpi_tickets_users', [
             'tickets_id' => $ticket_id,
             'users_id'   => $glpi_uid,
             'type'       => 2

--- a/glpi-utils.php
+++ b/glpi-utils.php
@@ -20,3 +20,41 @@ function gexe_get_current_glpi_uid() {
     }
     return 0;
 }
+
+/**
+ * Obtain connection to GLPI database.
+ *
+ * @param string $mode 'ro' for read-only replica, anything else for master
+ * @return wpdb
+ */
+function gexe_glpi_db($mode = 'rw') {
+    static $rw = null;
+    static $ro = null;
+
+    if ($mode === 'ro') {
+        if ($ro instanceof wpdb) {
+            return $ro;
+        }
+        // Local replica for read operations
+        $ro = new wpdb(
+            'wp_glpi',            // db user
+            'xapetVD4OWZqw8f',    // db password
+            'glpi',               // db name
+            '127.0.0.1'           // local replica host
+        );
+        return $ro;
+    }
+
+    if ($rw instanceof wpdb) {
+        return $rw;
+    }
+
+    // Master server for write operations
+    $rw = new wpdb(
+        'wp_glpi',            // db user
+        'xapetVD4OWZqw8f',    // db password
+        'glpi',               // db name
+        '192.168.100.12'      // master host
+    );
+    return $rw;
+}


### PR DESCRIPTION
## Summary
- add utility for managing GLPI master and read-replica connections
- switch plugin modules to use read-only replica for SELECTs
- resolve merge conflict in comment signature using new last_followup_at field

## Testing
- `php -l gexe-copy.php`
- `php -l glpi-categories-shortcode.php`
- `php -l glpi-modal-actions.php`
- `php -l glpi-new-task.php`
- `php -l glpi-utils.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba936ce134832890165107b5c0ecee