### PR TITLE
Prefetch GLPI comments for assigned tasks

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -198,6 +198,19 @@ function gexe_glpi_cards_shortcode($atts) {
     }
     $total_count = array_sum($status_counts);
 
+    // ---- Предзагрузка комментариев для задач текущего исполнителя ----
+    $prefetched_comments = [];
+    $current_glpi_id = gexe_get_current_glpi_uid();
+    if ($current_glpi_id > 0) {
+        foreach ($tickets as $t) {
+            if (in_array($current_glpi_id, $t['assignee_ids'], true)) {
+                $data = gexe_render_comments((int)$t['id']);
+                $data['count'] = gexe_get_comment_count((int)$t['id']);
+                $prefetched_comments[$t['id']] = $data;
+            }
+        }
+    }
+
     // ---- Map исполнителей (для фильтра «Сегодня в программе», когда show_all = true) ----
     $executors_map = [];
     foreach ($tickets as $t) {
@@ -244,6 +257,7 @@ function gexe_glpi_cards_shortcode($atts) {
     $GLOBALS['gexe_show_all']         = $glpi_show_all;
     $GLOBALS['gexe_category_counts']  = $category_counts;
     $GLOBALS['gexe_category_slugs']   = $category_slugs;
+    $GLOBALS['gexe_prefetched_comments'] = $prefetched_comments;
 
     ob_start();
     include $tpl;

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -230,3 +230,8 @@ function gexe_cat_slug($leaf) {
   </div>
 
 </div>
+<?php if (!empty($GLOBALS['gexe_prefetched_comments'])): ?>
+<script>
+window.gexePrefetchedComments = <?php echo wp_json_encode($GLOBALS['gexe_prefetched_comments']); ?>;
+</script>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
- preload GLPI comments for current assignee on card page
- expose preloaded comments to frontend and show counts on cards
- use preloaded data in modal instead of extra requests

## Testing
- `php -l gexe-copy.php templates/glpi-cards-template.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba955bb7648328a6d1702731bc81d3