### PR TITLE
Close modal after comment submission and show loading state

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -181,6 +181,7 @@ body {
 .glpi-modal__comments{ padding:0 16px 16px 16px; border-top:1px dashed #334155; margin-top:8px; }
 .glpi-modal__comments-title{ font-weight:700; margin:4px 0 8px 0; color:#e5e7eb; }
 .glpi-modal__comments-body{ display:grid; gap:10px; }
+.glpi-comments-loading{ color:#94a3b8; padding:8px; font-style:italic; }
 
 /* Комментарии */
 .glpi-comment{ background:#1e293b; border:1px solid #334155; border-radius:8px; padding:8px 12px; color:#e2e8f0; font-size:14px; }

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -285,15 +285,17 @@
 
   function loadComments(ticketId, page = 1) {
     const box = $('#gexe-comments');
-    if (box) box.innerHTML = '';
     const modalCntInit = modalEl && modalEl.querySelector('.glpi-modal__comments-title .gexe-cmnt-count');
     if (modalCntInit) modalCntInit.textContent = '0';
 
     const preloaded = window.gexePrefetchedComments && window.gexePrefetchedComments[ticketId];
     if (preloaded) {
+      if (box) box.innerHTML = '';
       applyCommentsData(ticketId, preloaded);
       return;
     }
+
+    if (box) box.innerHTML = '<div class="glpi-comments-loading">Комментарии загружаются...</div>';
 
     const base = window.glpiAjax && glpiAjax.rest;
     const nonce = window.glpiAjax && glpiAjax.restNonce;
@@ -404,14 +406,8 @@
             : parseInt((cnt?.textContent || modalCnt?.textContent || '0'), 10) + 1;
           if (cnt) cnt.textContent = String(newCount);
           if (modalCnt) modalCnt.textContent = String(newCount);
-          // обновим комментарии в просмотрщике, если открыт
-          if (modalEl && modalEl.classList.contains('gexe-modal--open')) {
-            const openedId = Number(modalEl.getAttribute('data-ticket-id') || '0');
-            if (openedId === id) {
-              if (window.gexePrefetchedComments) delete window.gexePrefetchedComments[id];
-              loadComments(id);
-            }
-          }
+          if (window.gexePrefetchedComments) delete window.gexePrefetchedComments[id];
+          closeViewerModal();
           applyActionVisibility();
         }
       })


### PR DESCRIPTION
## Summary
- Close task view after adding a comment
- Refresh comment counters and clear cache
- Show loading placeholder while comments load

## Testing
- `node --check gexe-filter.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a7ff09c83289611d0927eeea4a7