### PR TITLE
Fix comment modal loading state

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -419,7 +419,8 @@
           if (cnt) cnt.textContent = String(newCount);
           if (modalCnt) modalCnt.textContent = String(newCount);
           if (window.gexePrefetchedComments) delete window.gexePrefetchedComments[id];
-          closeViewerModal();
+          // обновляем список комментариев в открытой карточке
+          loadComments(id);
           applyActionVisibility();
         }
       })


### PR DESCRIPTION
## Summary
- reload comments in modal after adding a comment so placeholder is replaced by actual content

## Testing
- `node --check gexe-filter.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa1177e088328bd200b4e846d065d