### PR TITLE
Ensure "task solved" updates GLPI status

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -466,6 +466,7 @@
       if (ok) {
         const card = document.querySelector('.glpi-card[data-ticket-id="'+id+'"]');
         if (card) {
+          card.setAttribute('data-status', '5');
           card.classList.add('gexe-hide');
           recalcStatusCounts(); filterCards();
         }

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -393,10 +393,17 @@ function gexe_glpi_card_action() {
             'users_id'         => gexe_get_current_glpi_uid(),
         ], ['%s','%d','%d','%s','%s','%d']));
 
-        // Меняем статус тикета на «решён» (GLPI: 5)
+        // Меняем статус тикета на «решён» (GLPI: 5) и фиксируем дату решения
         if ($ok) {
             $new_status = 5;
-            $ok = (false !== $glpi_db->update($tTickets, ['status' => $new_status], ['id' => $ticket_id], ['%d'], ['%d']));
+            $now        = current_time('mysql');
+            $ok = (false !== $glpi_db->update(
+                $tTickets,
+                ['status' => $new_status, 'solvedate' => $now],
+                ['id' => $ticket_id],
+                ['%d','%s'],
+                ['%d']
+            ));
         }
     }
 


### PR DESCRIPTION
## Summary
- mark cards as solved when "task solved" button is confirmed
- update GLPI ticket status and solved date upon resolution

## Testing
- `php -l glpi-modal-actions.php`
- `node --check gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68baa1d8b3c0832897b5a0e24b2ef2ec