### PR TITLE
feat: manage GLPI followup triggers once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# WP GLPI Plugin
+
+This plugin integrates WordPress with a GLPI helpdesk.
+
+## Database triggers
+
+The plugin maintains `glpi.glpi_tickets.last_followup_at` using two triggers on `glpi.glpi_itilfollowups`.
+Triggers are installed once and recorded in the `glpi_triggers_installed` option.
+The database user must have the `TRIGGER` privilege (or `ALL PRIVILEGES`) on the `glpi` schema.
+
+### WP-CLI commands
+
+* `wp gexe:triggers install` — install or update the triggers.
+* `wp gexe:triggers remove` — drop the triggers and delete plugin options.
+* `wp gexe:triggers status` — show trigger presence and definition.
+
+Run these commands from the WordPress root with an account that has the required database privileges.


### PR DESCRIPTION
## Summary
- install GLPI followup triggers only once with privilege checks, transaction and WP‑CLI helpers
- hook trigger install/uninstall in plugin lifecycle and show admin notice if missing
- document trigger purpose and CLI usage

## Testing
- `php -l glpi-db-setup.php && php -l gexe-copy.php`
- `wp --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baaa5e3910832882e67e57cb7742b8