### PR TITLE
Refine status panel layout and labels

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -75,7 +75,7 @@ body {
 .glpi-badge.printer{background:#3b82f6}.glpi-badge.po{background:#f59e0b}.glpi-badge.network{background:#10b981}.glpi-badge.infosec{background:#a855f7}.glpi-badge.ebmias{background:#ec4899}.glpi-badge.default{background:#6b7280}
 
 /* === ПАНЕЛЬ ФИЛЬТРАЦИИ === */
-.glpi-filtering-panel { padding: 16px 24px; position: sticky; top: 0; z-index: 100; margin-bottom: 46px; background: transparent; }
+.glpi-filtering-panel { padding: 16px 24px; position: sticky; top: 0; z-index: 100; margin-bottom: 80px; background: transparent; }
 .glpi-header-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: flex-start; margin-bottom: 12px; }
 
 /* Поиск — на всю ширину и всегда сверху */
@@ -124,7 +124,7 @@ body {
 .glpi-status-block.active .status-label,
 .glpi-newfilter-block.active .status-label{ color:#111827; opacity:1; font-weight:700; }
 
-/* Теги «Сегодня в программе» (категории) */
+/* Категории */
 .glpi-cat-toggle{
   display:flex;
   align-items:center;
@@ -145,7 +145,7 @@ body {
 }
 .glpi-cat-toggle:hover{ transform:translateY(-2px); background:#273447; box-shadow:0 4px 14px rgba(0,0,0,.3); }
 .glpi-cat-toggle .tw{font-size:14px;opacity:.85}
-.glpi-category-tags{ margin-top:8px; margin-bottom:14px; display:flex; flex-wrap:wrap; gap:10px; }
+.glpi-category-tags{ margin-top:8px; margin-bottom:24px; display:flex; flex-wrap:wrap; gap:10px; }
 .glpi-category-tags.collapsed{ display:none; }
 .glpi-category-tag{
   display:inline-flex; align-items:center; gap:8px; padding:8px 12px; font-size:13px; line-height:1;

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -231,7 +231,7 @@ function gexe_glpi_cards_shortcode($atts) {
         }
     }
 
-    // ---- Map исполнителей (для фильтра «Сегодня в программе», когда show_all = true) ----
+    // ---- Map исполнителей (для фильтра «Категории», когда show_all = true) ----
     $executors_map = [];
     foreach ($tickets as $t) {
         foreach ($t['executors'] as $e) {

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -100,16 +100,16 @@
     });
   }
 
-  /* ========================= «Пора тушить» и «Новая заявка» ========================= */
+  /* ========================= «Просрочены» и «Новая заявка» ========================= */
   function ensureExtraStatusBlocks() {
-    const row = document.querySelector('.glpi-status-blocks,.glpi-status-row,.glpi-header-row');
+    const row = document.querySelector('.glpi-status-blocks');
     if (!row) return;
 
-    // Кнопка «Пора тушить»: действует как фильтр по data-late="1"
+    // Кнопка «Просрочены»: действует как фильтр по data-late="1"
     if (!document.querySelector('.glpi-newfilter-block')) {
       const btn = document.createElement('button');
       btn.className = 'glpi-status-block glpi-newfilter-block';
-      btn.innerHTML = '<div class="status-count">0</div><div class="status-label">Пора тушить</div>';
+      btn.innerHTML = '<div class="status-count">0</div><div class="status-label">Просрочены</div>';
       btn.addEventListener('click', () => {
         btn.classList.toggle('active');
         document.dispatchEvent(new CustomEvent('gexe:filters:changed'));
@@ -156,7 +156,7 @@
       const tgl = document.createElement('button');
       tgl.className = 'glpi-cat-toggle';
       tgl.setAttribute('aria-expanded','false');
-      tgl.innerHTML = '<span class="tw">▸</span> Сегодня в программе';
+      tgl.innerHTML = '<span class="tw">▸</span> Категории';
       const header = document.querySelector('.glpi-header-row');
       const statusRow = header && header.querySelector('.glpi-status-row');
       if (header) {

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -133,7 +133,7 @@ function gexe_cat_slug($leaf) {
       </div>
     </div>
 
-    <!-- Блоки категорий (Сегодня в программе) -->
+    <!-- Категории -->
     <div class="glpi-category-tags">
       <?php foreach ($category_counts as $leaf => $count): 
           $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);


### PR DESCRIPTION
## Summary
- enlarge spacing between status section and task cards
- keep overdue and new-task buttons in status row when toggling categories
- rename filter controls to "Категории" and "Просрочены"

## Testing
- `php -l gexe-copy.php`
- `php -l templates/glpi-cards-template.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab2f6d36c8328b94046303d327706