### PR TITLE
Refactor sticky filter header with category dropdown

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -75,86 +75,47 @@ body {
 .glpi-badge.printer{background:#3b82f6}.glpi-badge.po{background:#f59e0b}.glpi-badge.network{background:#10b981}.glpi-badge.infosec{background:#a855f7}.glpi-badge.ebmias{background:#ec4899}.glpi-badge.default{background:#6b7280}
 
 /* === ПАНЕЛЬ ФИЛЬТРАЦИИ === */
-.glpi-filtering-panel { padding: 16px 24px; position: sticky; top: 0; z-index: 100; margin-bottom: 80px; background: transparent; }
-.glpi-header-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; justify-content: flex-start; margin-bottom: 12px; }
+ .glpi-filtering-panel{margin-bottom:24px;}
+ .glpi-header-row{position:sticky;top:0;z-index:100;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:16px;padding:16px 24px;background:#111827;}
+ .glpi-header-left,.glpi-header-center,.glpi-header-right{display:flex;align-items:center;gap:16px;}
+ .glpi-header-center{flex:1 1 auto;justify-content:center;overflow-x:auto;}
+ .glpi-header-right{flex-wrap:wrap;justify-content:flex-end;}
+ .glpi-status-blocks{display:flex;flex-wrap:nowrap;gap:12px;}
+ .glpi-status-block,
+ .glpi-newfilter-block{display:flex;flex-direction:column;justify-content:center;align-items:center;min-width:120px;min-height:72px;padding:12px 14px;border-radius:12px;background:#1f2937;color:#e5e7eb;box-shadow:0 2px 8px rgba(0,0,0,.25);cursor:pointer;user-select:none;transition:transform .08s ease, background-color .15s ease, box-shadow .15s ease;}
+ .glpi-status-block .status-count,
+ .glpi-newfilter-block .status-count{font-size:28px;line-height:1;font-weight:800;}
+ .glpi-status-block .status-label,
+ .glpi-newfilter-block .status-label{margin-top:6px;font-size:12px;letter-spacing:.02em;opacity:.9;white-space:nowrap;}
+ .glpi-status-block:hover,
+ .glpi-newfilter-block:hover{transform:translateY(-2px);background:#273447;box-shadow:0 4px 14px rgba(0,0,0,.3);}
+ .glpi-status-block.active,
+ .glpi-newfilter-block.active{background:#facc15;color:#1f2937;}
+ .glpi-status-block.active .status-count,
+ .glpi-newfilter-block.active .status-count{color:#111827;}
+ .glpi-status-block.active .status-label,
+ .glpi-newfilter-block.active .status-label{color:#111827;opacity:1;font-weight:700;}
+ .glpi-search-block{display:flex;flex-direction:column;}
+ .glpi-search-input{all:unset;width:100%;max-width:340px;box-sizing:border-box;background:#1e293b!important;color:#f8fafc!important;padding:10px 14px;border:1px solid #334155;border-radius:6px;font-size:14px;}
+ .glpi-search-input::placeholder{color:#64748b;}
+ .glpi-search-input:focus{outline:none;border-color:#facc15;box-shadow:0 0 0 2px rgba(250,204,21,.3);}
+ .glpi-user-greeting{color:#facc15;margin-bottom:4px;font-size:14px;font-weight:600;}
+ .glpi-newtask-btn{display:flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;white-space:nowrap;}
+ .glpi-newtask-btn:hover{background:#273447;}
+ .glpi-category-block{position:relative;}
+ .glpi-cat-toggle{display:flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;}
+ .glpi-cat-toggle:hover{background:#273447;}
+ .glpi-cat-menu{display:none;position:absolute;top:100%;left:0;margin-top:8px;background:#0f172a;border:1px solid #334155;border-radius:8px;box-shadow:0 6px 12px rgba(0,0,0,.3);z-index:200;max-height:60vh;overflow-y:auto;min-width:220px;padding:8px;}
+.glpi-cat-menu.open{display:block;}
+.glpi-category-tag{display:flex;align-items:center;gap:8px;}
 
-/* Поиск — на всю ширину и всегда сверху */
-.glpi-header-row .glpi-search-block,
-.glpi-header-row .glpi-search-row{order:-1; width:100%;}
-.glpi-search-block,
-.glpi-search-row { flex: 1 1 100%; min-width: 220px; }
-.glpi-search-row { display:flex; flex-direction:column; }
-.glpi-search-input {
-  all: unset; width: 100%; box-sizing: border-box;
-  background: #1e293b !important; color:#f8fafc !important;
-  padding: 10px 14px; border: 1px solid #334155; border-radius: 6px; font-size: 14px;
+@media (max-width:768px){
+  .glpi-header-row{flex-direction:column;align-items:stretch;}
+  .glpi-header-left,.glpi-header-center,.glpi-header-right{width:100%;justify-content:flex-start;}
+  .glpi-header-center{overflow-x:auto;}
+  .glpi-header-right{justify-content:space-between;}
+  .glpi-search-input{max-width:100%;}
 }
-.glpi-user-greeting {
-  color: #facc15;
-  margin-bottom: 4px;
-  font-size: 14px;
-  font-weight: 600;
-}
-.glpi-search-input::placeholder{color:#64748b}
-.glpi-search-input:focus{ outline:none; border-color:#facc15; box-shadow:0 0 0 2px rgba(250,204,21,.3); }
-
-/* Статус-блоки наверху */
-.glpi-status-blocks{ display:flex; flex-wrap:wrap; gap:12px; align-items:stretch; }
-.glpi-status-block,
-.glpi-newfilter-block,
-.glpi-newtask-block{
-  display:flex; flex-direction:column; justify-content:center; align-items:center;
-  min-width:120px; min-height:72px; padding:12px 14px; border-radius:12px; background:#1f2937; color:#e5e7eb;
-  box-shadow:0 2px 8px rgba(0,0,0,.25); cursor:pointer; user-select:none;
-  transition:transform .08s ease, background-color .15s ease, box-shadow .15s ease;
-}
-.glpi-status-block .status-count,
-.glpi-newfilter-block .status-count,
-.glpi-newtask-block .status-count{ font-size:28px; line-height:1; font-weight:800; }
-.glpi-status-block .status-label,
-.glpi-newfilter-block .status-label,
-.glpi-newtask-block .status-label{ margin-top:6px; font-size:12px; letter-spacing:.02em; opacity:.9; white-space:nowrap; }
-.glpi-status-block:hover,
-.glpi-newfilter-block:hover,
-.glpi-newtask-block:hover{ transform:translateY(-2px); background:#273447; box-shadow:0 4px 14px rgba(0,0,0,.3); }
-.glpi-status-block.active,
-.glpi-newfilter-block.active{ background:#facc15; color:#1f2937; }
-.glpi-status-block.active .status-count,
-.glpi-newfilter-block.active .status-count{ color:#111827; }
-.glpi-status-block.active .status-label,
-.glpi-newfilter-block.active .status-label{ color:#111827; opacity:1; font-weight:700; }
-
-/* Категории */
-.glpi-cat-toggle{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:8px;
-  min-width:120px;
-  min-height:72px;
-  padding:12px 14px;
-  border-radius:12px;
-  background:#1f2937;
-  color:#e5e7eb;
-  border:1px solid #334155;
-  box-shadow:0 2px 8px rgba(0,0,0,.25);
-  cursor:pointer;
-  font-weight:600;
-  margin:0;
-  transition:transform .08s ease, background-color .15s ease, box-shadow .15s ease;
-}
-.glpi-cat-toggle:hover{ transform:translateY(-2px); background:#273447; box-shadow:0 4px 14px rgba(0,0,0,.3); }
-.glpi-cat-toggle .tw{font-size:14px;opacity:.85}
-.glpi-category-tags{ margin-top:8px; margin-bottom:24px; display:flex; flex-wrap:wrap; gap:10px; }
-.glpi-category-tags.collapsed{ display:none; }
-.glpi-category-tag{
-  display:inline-flex; align-items:center; gap:8px; padding:8px 12px; font-size:13px; line-height:1;
-  border-radius:999px; background:#0f172a; color:#e5e7eb; border:1px solid #334155; cursor:pointer;
-  transition:background-color .15s, border-color .15s, color .15s, transform .08s;
-}
-.glpi-category-tag:hover{ background:#111b2e; border-color:#2f3c55; transform:translateY(-1px); }
-.glpi-category-tag.active{ background:#facc15; color:#1f2937; border-color:#facc15; font-weight:700; }
-.glpi-category-tag i{ opacity:.95; margin-right:6px; }
 
 /* Выпадающие (общие) */
 .glpi-filter-dropdown .glpi-filter-menu{ background:#0f172a; border:1px solid #334155; border-radius:8px; box-shadow:0 6px 12px rgba(0,0,0,.3); }

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -99,56 +99,61 @@ function gexe_cat_slug($leaf) {
   <!-- Панель фильтрации -->
   <div class="glpi-filtering-panel">
     <div class="glpi-header-row">
-      <div class="glpi-search-row">
-        <?php if ($is_logged_in && $current_user_short !== ''): ?>
-          <div class="glpi-user-greeting">Привет, <?php echo esc_html($current_user_short); ?></div>
-        <?php endif; ?>
-        <input type="text" id="glpi-unified-search" class="glpi-search-input" placeholder="Поиск...">
+
+      <div class="glpi-header-left glpi-category-block">
+        <button type="button" class="glpi-cat-toggle" aria-expanded="false">Категории</button>
+        <div class="glpi-cat-menu">
+        <?php foreach ($category_counts as $leaf => $count):
+            $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);
+            $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
+            $label = gexe_truncate_label($leaf, 12);
+        ?>
+          <button class="glpi-filter-btn glpi-category-tag category-filter-btn"
+                  data-cat="<?php echo esc_attr(strtolower($slug)); ?>"
+                  data-label="<?php echo esc_attr($label); ?>"
+                  data-count="<?php echo intval($count); ?>">
+            <?php echo $icon; ?> <?php echo esc_html($label); ?> (<?php echo intval($count); ?>)
+          </button>
+        <?php endforeach; ?>
+        </div>
       </div>
 
-      <!-- Ряд статусов и экшена -->
-      <div class="glpi-status-row">
-      <!-- Блоки статусов -->
-      <div class="glpi-status-blocks">
-        <div class="glpi-status-block status-filter-btn" data-status="all" data-label="Все задачи">
-          <span class="status-count"><?php echo intval($total_count); ?></span>
-          <span class="status-label">Все задачи</span>
-        </div>
-        <div class="glpi-status-block status-filter-btn active" data-status="2" data-label="В работе">
-          <span class="status-count"><?php echo intval($status_counts[2] ?? 0); ?></span>
-          <span class="status-label">В работе</span>
-        </div>
-        <div class="glpi-status-block status-filter-btn" data-status="3" data-label="В плане">
-          <span class="status-count"><?php echo intval($status_counts[3] ?? 0); ?></span>
-          <span class="status-label">В плане</span>
-        </div>
-        <div class="glpi-status-block status-filter-btn" data-status="4" data-label="В стопе">
-          <span class="status-count"><?php echo intval($status_counts[4] ?? 0); ?></span>
-          <span class="status-label">В стопе</span>
-        </div>
-        <div class="glpi-status-block status-filter-btn" data-status="1" data-label="Новые">
-          <span class="status-count"><?php echo intval($status_counts[1] ?? 0); ?></span>
-          <span class="status-label">Новые</span>
+      <div class="glpi-header-center">
+        <div class="glpi-status-blocks">
+          <div class="glpi-status-block status-filter-btn" data-status="all" data-label="Все задачи">
+            <span class="status-count"><?php echo intval($total_count); ?></span>
+            <span class="status-label">Все задачи</span>
+          </div>
+          <div class="glpi-status-block status-filter-btn active" data-status="2" data-label="В работе">
+            <span class="status-count"><?php echo intval($status_counts[2] ?? 0); ?></span>
+            <span class="status-label">В работе</span>
+          </div>
+          <div class="glpi-status-block status-filter-btn" data-status="3" data-label="В плане">
+            <span class="status-count"><?php echo intval($status_counts[3] ?? 0); ?></span>
+            <span class="status-label">В плане</span>
+          </div>
+          <div class="glpi-status-block status-filter-btn" data-status="4" data-label="В стопе">
+            <span class="status-count"><?php echo intval($status_counts[4] ?? 0); ?></span>
+            <span class="status-label">В стопе</span>
+          </div>
+          <div class="glpi-status-block status-filter-btn" data-status="1" data-label="Новые">
+            <span class="status-count"><?php echo intval($status_counts[1] ?? 0); ?></span>
+            <span class="status-label">Новые</span>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- Категории -->
-    <div class="glpi-category-tags">
-      <?php foreach ($category_counts as $leaf => $count): 
-          $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);
-          $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
-          $label = gexe_truncate_label($leaf, 12);
-      ?>
-        <span class="glpi-category-tag category-filter-btn"
-              data-cat="<?php echo esc_attr(strtolower($slug)); ?>"
-              data-label="<?php echo esc_attr($label); ?>"
-              data-count="<?php echo intval($count); ?>">
-          <?php echo $icon; ?> <?php echo esc_html($label); ?> (<?php echo intval($count); ?>)
-        </span>
-      <?php endforeach; ?>
-    </div>
+      <div class="glpi-header-right">
+        <div class="glpi-search-block">
+          <?php if ($is_logged_in && $current_user_short !== ''): ?>
+            <div class="glpi-user-greeting">Привет, <?php echo esc_html($current_user_short); ?></div>
+          <?php endif; ?>
+          <input type="text" id="glpi-unified-search" class="glpi-search-input" placeholder="Поиск...">
+        </div>
+        <button type="button" class="glpi-newtask-btn"><i class="fa-regular fa-file-lines"></i> Новая заявка</button>
+      </div>
 
+    </div>
   </div>
 
   <!-- Карточки -->


### PR DESCRIPTION
## Summary
- build sticky `.glpi-header-row` with left category dropdown, central status buttons and right search + new ticket
- add JS logic for category menu toggle, overdue filter and new task binding without rebuilding header
- style responsive header and dropdown in `gee.css`

## Testing
- `php -l templates/glpi-cards-template.php`
- `node --check gexe-filter.js`
- `npx eslint gexe-filter.js` *(fails: ESLint couldn't find configuration)*
- `npx prettier --check gexe-filter.js` *(reports style differences)*

------
https://chatgpt.com/codex/tasks/task_e_68bab7dbe2948328992ac6a2f57d2a86