### PR TITLE
Add Git Updater header and version bump tooling

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,0 +1,34 @@
+name: Release Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: 'Bump level'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - set
+      version:
+        description: 'Version (for set)'
+        required: false
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Bump version
+        run: php tools/bump-version.php ${{ inputs.level }} ${{ inputs.version }}
+      - name: Push changes
+        run: |
+          git push
+          git push --tags

--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ When the user clicks **Задача решена** in the ticket modal, the plug
 3. Triggers standard GLPI notifications (mail/Telegram).
 
 Errors are logged with the `[GLPI-SOLVE]` prefix.
+
+## Release
+
+### Manually
+
+Run one of the following commands:
+
+```bash
+php tools/bump-version.php patch
+php tools/bump-version.php minor
+php tools/bump-version.php major
+```
+
+### GitHub Actions
+
+Trigger the **Release Bump** workflow and choose the desired level.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "obb-collab/wp-glpi-plugin",
+    "scripts": {
+        "bump:patch": "php tools/bump-version.php patch",
+        "bump:minor": "php tools/bump-version.php minor",
+        "bump:major": "php tools/bump-version.php major"
+    }
+}

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -1,9 +1,11 @@
 <?php
 /*
 Plugin Name: WP GLPI Plugin
+Description: Интерфейс заявок GLPI для WordPress.
 Version: 1.0.0
 GitHub Plugin URI: obb-collab/wp-glpi-plugin
 Primary Branch: main
+Update URI: https://github.com/obb-collab/wp-glpi-plugin
 */
 
 if (!defined('ABSPATH')) exit;

--- a/tools/bump-version.php
+++ b/tools/bump-version.php
@@ -1,0 +1,102 @@
+<?php
+if (php_sapi_name() !== 'cli') {
+    fwrite(STDERR, "Run from CLI\n");
+    exit(1);
+}
+
+$argvCount = $_SERVER['argc'];
+if ($argvCount < 2) {
+    fwrite(STDERR, "Usage: php tools/bump-version.php <patch|minor|major|set> [version]\n");
+    exit(1);
+}
+
+$action = $argv[1];
+$versionArg = $argvCount > 2 ? $argv[2] : null;
+$pluginFile = __DIR__ . '/../gexe-copy.php';
+$readmeFile = __DIR__ . '/../readme.txt';
+
+$contents = file_get_contents($pluginFile);
+if (!preg_match('/^Version:\s*(\d+\.\d+\.\d+)/m', $contents, $matches)) {
+    fwrite(STDERR, "Cannot find version in plugin file\n");
+    exit(1);
+}
+$currentVersion = $matches[1];
+
+function incrementVersion(string $version, string $type): string {
+    list($major, $minor, $patch) = array_map('intval', explode('.', $version));
+    switch ($type) {
+        case 'patch':
+            $patch++;
+            break;
+        case 'minor':
+            $minor++;
+            $patch = 0;
+            break;
+        case 'major':
+            $major++;
+            $minor = 0;
+            $patch = 0;
+            break;
+        default:
+            throw new InvalidArgumentException('Invalid increment type');
+    }
+    return sprintf('%d.%d.%d', $major, $minor, $patch);
+}
+
+switch ($action) {
+    case 'patch':
+    case 'minor':
+    case 'major':
+        $newVersion = incrementVersion($currentVersion, $action);
+        break;
+    case 'set':
+        if ($versionArg === null || !preg_match('/^\d+\.\d+\.\d+$/', $versionArg)) {
+            fwrite(STDERR, "Specify version as X.Y.Z\n");
+            exit(1);
+        }
+        $newVersion = $versionArg;
+        break;
+    default:
+        fwrite(STDERR, "Unknown action: $action\n");
+        exit(1);
+}
+
+$updated = preg_replace('/^(Version:\s*)\d+\.\d+\.\d+/m', '$1' . $newVersion, $contents);
+file_put_contents($pluginFile, $updated);
+
+if (file_exists($readmeFile)) {
+    $readme = file_get_contents($readmeFile);
+    if (preg_match('/^Stable tag:/m', $readme)) {
+        $readme = preg_replace('/^(Stable tag:\s*)\d+\.\d+\.\d+/m', '$1' . $newVersion, $readme);
+    } else {
+        $readme .= "\nStable tag: $newVersion\n";
+    }
+    file_put_contents($readmeFile, $readme);
+}
+
+$files = [$pluginFile];
+if (file_exists($readmeFile)) {
+    $files[] = $readmeFile;
+}
+
+$filesEscaped = array_map('escapeshellarg', $files);
+exec('git add ' . implode(' ', $filesEscaped), $o, $exit);
+if ($exit !== 0) {
+    fwrite(STDERR, "git add failed\n");
+    exit($exit);
+}
+
+$commitMsg = 'chore(release): v' . $newVersion;
+exec('git commit -m ' . escapeshellarg($commitMsg), $o, $exit);
+if ($exit !== 0) {
+    fwrite(STDERR, "git commit failed\n");
+    exit($exit);
+}
+
+exec('git tag -a v' . $newVersion . ' -m ' . escapeshellarg('v' . $newVersion), $o, $exit);
+if ($exit !== 0) {
+    fwrite(STDERR, "git tag failed\n");
+    exit($exit);
+}
+
+echo "Bumped to v$newVersion\n";


### PR DESCRIPTION
## Summary
- add Git Updater metadata to main plugin file
- implement PHP version bump script with git tagging
- add Composer scripts and optional GitHub Action for releases
- document release process

## Testing
- `php -l gexe-copy.php`
- `php -l tools/bump-version.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68babd2c9b6083289af2f1698e563b96