### PR TITLE
Add Git Updater release tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ When the user clicks **Задача решена** in the ticket modal, the plug
 3. Triggers standard GLPI notifications (mail/Telegram).
 
 Errors are logged with the `[GLPI-SOLVE]` prefix.
+
+## Releases
+
+1. Update the `Version` header in `gexe-copy.php`.
+2. Commit the changes.
+3. Run `composer release` to tag the current commit.
+4. Pushing the tag triggers the GitHub Action that builds the release.

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract version from plugin header.
+VERSION=$(php -r "preg_match('/^Version:\\s*(.+)$/m', file_get_contents('gexe-copy.php'), $m); echo $m[1];")
+
+echo "Tagging release v$VERSION"
+
+git tag -a "v$VERSION" -m "Release $VERSION"
+git push origin "v$VERSION"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "obb-collab/wp-glpi-plugin",
+    "description": "WordPress integration with a GLPI helpdesk.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {},
+    "scripts": {
+        "release": [
+            "bash bin/tag-release.sh"
+        ]
+    }
+}

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -2,9 +2,10 @@
 /*
 Plugin Name: WP GLPI Plugin
 Description: Интерфейс заявок GLPI для WordPress.
-Version: 1.0.1
+Version: 1.0.2
 GitHub Plugin URI: obb-collab/wp-glpi-plugin
 Primary Branch: main
+Release Asset: true
 Update URI: https://github.com/obb-collab/wp-glpi-plugin
 */
 


### PR DESCRIPTION
## Summary
- add Git Updater header and bump plugin to version 1.0.2
- create Composer script and tag-release utility for tagging releases
- document release flow in README

## Testing
- `php -l gexe-copy.php`
- `bash -n bin/tag-release.sh`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bac0161cd48328875bbdca1d15d0d4