### PR TITLE
Show categories in expandable horizontal block

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -105,8 +105,8 @@ body {
  .glpi-category-block{position:relative;}
  .glpi-cat-toggle{display:flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;}
  .glpi-cat-toggle:hover{background:#273447;}
- .glpi-cat-menu{display:none;position:absolute;top:100%;left:0;margin-top:8px;background:#0f172a;border:1px solid #334155;border-radius:8px;box-shadow:0 6px 12px rgba(0,0,0,.3);z-index:200;max-height:60vh;overflow-y:auto;min-width:220px;padding:8px;}
-.glpi-cat-menu.open{display:block;}
+ .glpi-cat-menu{display:none;margin:8px 0;padding:8px;background:#0f172a;border:1px solid #334155;border-radius:8px;gap:8px;flex-wrap:wrap;}
+.glpi-cat-menu.open{display:flex;}
 .glpi-category-tag{display:flex;align-items:center;gap:8px;}
 
 @media (max-width:768px){

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -114,31 +114,15 @@
 
   /* ========================= МЕНЮ КАТЕГОРИЙ ========================= */
   function initCategoryMenu(){
-    const block = document.querySelector('.glpi-category-block');
-    if (!block) return;
-    const toggle = block.querySelector('.glpi-cat-toggle');
-    const menu   = block.querySelector('.glpi-cat-menu');
+    const toggle = document.querySelector('.glpi-cat-toggle');
+    const menu   = document.querySelector('.glpi-cat-menu');
     if (!toggle || !menu) return;
 
-    const closeMenu = () => {
-      menu.classList.remove('open');
-      toggle.setAttribute('aria-expanded','false');
-    };
-
     toggle.addEventListener('click', e => {
-      e.stopPropagation();
+      e.preventDefault();
       const opened = menu.classList.toggle('open');
       toggle.setAttribute('aria-expanded', opened ? 'true' : 'false');
     });
-
-    document.addEventListener('click', e => {
-      if (!block.contains(e.target)) {
-        closeMenu();
-      }
-    });
-
-    // закрываем при скролле страницы
-    window.addEventListener('scroll', closeMenu);
   }
 
   // Делегированный клик по тегу категории
@@ -161,13 +145,6 @@
       recalcStatusCounts();
       recalcCategoryVisibility();
       filterCards();
-      const block = document.querySelector('.glpi-category-block');
-      if (block) {
-        const menu = block.querySelector('.glpi-cat-menu');
-        const toggle = block.querySelector('.glpi-cat-toggle');
-        if (menu) menu.classList.remove('open');
-        if (toggle) toggle.setAttribute('aria-expanded','false');
-      }
     }, true);
   }
 
@@ -728,7 +705,7 @@
     });
     $$('.glpi-category-tag.category-filter-btn').forEach(tag => {
       const cat = (tag.getAttribute('data-cat') || '').toLowerCase();
-      tag.style.display = (st !== 'all' && !visibleCats.has(cat)) ? 'none' : 'block';
+      tag.style.display = (st !== 'all' && !visibleCats.has(cat)) ? 'none' : '';
     });
   }
 
@@ -754,13 +731,10 @@
         // при выборе статуса сбрасываем выбранные категории
         currentCategory = 'all';
         $$('.category-filter-btn, .glpi-category-tag').forEach(b => b.classList.remove('active'));
-        const block = document.querySelector('.glpi-category-block');
-        if (block) {
-          const menu = block.querySelector('.glpi-cat-menu');
-          const toggle = block.querySelector('.glpi-cat-toggle');
-          if (menu) menu.classList.remove('open');
-          if (toggle) toggle.setAttribute('aria-expanded','false');
-        }
+        const menu = document.querySelector('.glpi-cat-menu');
+        const toggle = document.querySelector('.glpi-cat-toggle');
+        if (menu) menu.classList.remove('open');
+        if (toggle) toggle.setAttribute('aria-expanded','false');
         recalcStatusCounts(); recalcCategoryVisibility(); filterCards();
       });
     });

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -102,20 +102,6 @@ function gexe_cat_slug($leaf) {
 
       <div class="glpi-header-left glpi-category-block">
         <button type="button" class="glpi-cat-toggle" aria-expanded="false">Категории</button>
-        <div class="glpi-cat-menu">
-        <?php foreach ($category_counts as $leaf => $count):
-            $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);
-            $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
-            $label = gexe_truncate_label($leaf, 12);
-        ?>
-          <button class="glpi-filter-btn glpi-category-tag category-filter-btn"
-                  data-cat="<?php echo esc_attr(strtolower($slug)); ?>"
-                  data-label="<?php echo esc_attr($label); ?>"
-                  data-count="<?php echo intval($count); ?>">
-            <?php echo $icon; ?> <?php echo esc_html($label); ?> (<?php echo intval($count); ?>)
-          </button>
-        <?php endforeach; ?>
-        </div>
       </div>
 
       <div class="glpi-header-center">
@@ -154,6 +140,21 @@ function gexe_cat_slug($leaf) {
       </div>
 
     </div>
+  </div>
+
+  <div class="glpi-cat-menu">
+  <?php foreach ($category_counts as $leaf => $count):
+      $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);
+      $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
+      $label = gexe_truncate_label($leaf, 12);
+  ?>
+    <button class="glpi-filter-btn glpi-category-tag category-filter-btn"
+            data-cat="<?php echo esc_attr(strtolower($slug)); ?>"
+            data-label="<?php echo esc_attr($label); ?>"
+            data-count="<?php echo intval($count); ?>">
+      <?php echo $icon; ?> <?php echo esc_html($label); ?> (<?php echo intval($count); ?>)
+    </button>
+  <?php endforeach; ?>
   </div>
 
   <!-- Карточки -->


### PR DESCRIPTION
## Summary
- Move category list into a horizontal block toggled by the Categories button
- Style and script the block for open/close behavior and active state
- Keep status filters resetting category selections

## Testing
- `php -l templates/glpi-cards-template.php`
- `node --check gexe-filter.js && echo "syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68bac068a3388328a4f9946a4913969e