### PR TITLE
Cache GLPI form dropdown data

### DIFF
--- a/glpi-settings.php
+++ b/glpi-settings.php
@@ -1,5 +1,6 @@
 <?php
 if (!defined('ABSPATH')) exit;
+require_once __DIR__ . '/includes/glpi-form-data.php';
 
 add_action('admin_menu', function () {
     add_options_page('GLPI Settings', 'GLPI', 'manage_options', 'gexe-glpi', 'gexe_glpi_settings_page');
@@ -40,6 +41,10 @@ function gexe_glpi_field_solved_status() {
 
 function gexe_glpi_settings_page() {
     if (!current_user_can('manage_options')) return;
+    if (isset($_POST['glpi_flush_cache']) && check_admin_referer('glpi_flush_cache')) {
+        gexe_glpi_flush_cache();
+        echo '<div class="updated"><p>Кэш сброшен.</p></div>';
+    }
     ?>
     <div class="wrap">
         <h1>GLPI Settings</h1>
@@ -49,6 +54,10 @@ function gexe_glpi_settings_page() {
             do_settings_sections('gexe-glpi');
             submit_button();
             ?>
+        </form>
+        <form method="post">
+            <?php wp_nonce_field('glpi_flush_cache'); ?>
+            <p><input type="submit" name="glpi_flush_cache" class="button" value="Сбросить кэш справочников" /></p>
         </form>
     </div>
     <?php

--- a/includes/glpi-form-data.php
+++ b/includes/glpi-form-data.php
@@ -1,0 +1,109 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/logger.php';
+
+// AJAX: выдаёт списки категорий и местоположений
+add_action('wp_ajax_glpi_get_form_data', 'gexe_glpi_get_form_data');
+function gexe_glpi_get_form_data() {
+    check_ajax_referer('glpi_modal_actions');
+    $t0 = microtime(true);
+    $cache_key = 'glpi_cached_form_data';
+
+    // Пытаемся получить из объектного кэша или транзиента
+    $data = wp_cache_get($cache_key, 'glpi');
+    if ($data === false) {
+        $data = get_transient($cache_key);
+    }
+    $source = 'cache';
+
+    if (!is_array($data) || empty($data)) {
+        $source = 'db';
+        global $glpi_db;
+
+        // Категории: id, name + полный путь
+        $cats = $glpi_db->get_results(
+            "SELECT id, name, completename AS path
+             FROM glpi_itilcategories
+             WHERE is_deleted = 0
+             ORDER BY name ASC",
+            ARRAY_A
+        );
+        $categories = [];
+        if ($cats) {
+            foreach ($cats as $c) {
+                $parts = preg_split('/\\s[\\/\\>]\\s/', $c['path']);
+                $short = end($parts);
+                $categories[] = [
+                    'id'   => (int) $c['id'],
+                    'name' => $short,
+                    'path' => $c['path'],
+                ];
+            }
+        }
+
+        // Местоположения: id + полный путь
+        $locs = $glpi_db->get_results(
+            "SELECT id, completename AS path
+             FROM glpi_locations
+             WHERE is_deleted = 0
+             ORDER BY completename ASC",
+            ARRAY_A
+        );
+        $locations = [];
+        if ($locs) {
+            foreach ($locs as $l) {
+                $parts = preg_split('/\\s[\\/\\>]\\s/', $l['path']);
+                $short = end($parts);
+                $locations[] = [
+                    'id'   => (int) $l['id'],
+                    'name' => $short,
+                    'path' => $l['path'],
+                ];
+            }
+        }
+
+        // Жёстко заданные исполнители
+        $mapping = [
+            ['glpi_id' => 622, 'name' => 'Сушко Валентин'],
+            ['glpi_id' => 621, 'name' => 'Скомороха Анастасия'],
+            ['glpi_id' => 269, 'name' => 'Смирнов Максим'],
+            ['glpi_id' => 180, 'name' => 'Кузнецов Евгений'],
+            ['glpi_id' => 2,   'name' => 'Куткин Павел'],
+            ['glpi_id' => 632, 'name' => 'Стельмашенко Игнат'],
+            ['glpi_id' => 620, 'name' => 'Нечепорук Александр'],
+        ];
+        $executors = [];
+        foreach ($mapping as $m) {
+            $executors[] = [
+                'id'   => (int) $m['glpi_id'],
+                'name' => $m['name'],
+            ];
+        }
+
+        $data = [
+            'categories' => $categories,
+            'locations'  => $locations,
+            'executors'  => $executors,
+        ];
+
+        // Сохраняем в кэш на 30 минут
+        wp_cache_set($cache_key, $data, 'glpi', 30 * MINUTE_IN_SECONDS);
+        set_transient($cache_key, $data, 30 * MINUTE_IN_SECONDS);
+    }
+
+    $elapsed = (int) round((microtime(true) - $t0) * 1000);
+    gexe_log_action(sprintf('[form-data] source=%s elapsed=%dms count={cat:%d, loc:%d}', $source, $elapsed, count($data['categories']), count($data['locations'])));
+
+    if (current_user_can('manage_options') && isset($_GET['debug'])) {
+        $data['debug'] = ['source' => $source, 'elapsed' => $elapsed];
+    }
+
+    wp_send_json($data);
+}
+
+// Удаление кэша, используется в админке
+function gexe_glpi_flush_cache() {
+    wp_cache_delete('glpi_cached_form_data', 'glpi');
+    delete_transient('glpi_cached_form_data');
+}

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -1,0 +1,16 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Simple file logger for GLPI actions.
+ */
+function gexe_log_action($message) {
+    $upload = wp_upload_dir();
+    $dir = trailingslashit($upload['basedir']) . 'glpi-plugin/logs';
+    if (!is_dir($dir)) {
+        wp_mkdir_p($dir);
+    }
+    $file = $dir . '/actions.log';
+    $line = '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
+    file_put_contents($file, $line, FILE_APPEND);
+}


### PR DESCRIPTION
## Summary
- cache categories and locations via WP transient/object cache
- lazy-load form dropdowns once per session and log retrieval timing
- allow admins to flush dropdown cache from settings

## Testing
- `php -l glpi-new-task.php`
- `php -l includes/logger.php`
- `php -l includes/glpi-form-data.php`
- `php -l glpi-settings.php`
- `node --check glpi-new-task.js`
- `mysql -e "EXPLAIN SELECT id, name FROM glpi_itilcategories WHERE is_deleted=0 ORDER BY name ASC"` *(fails: Can't connect to local MySQL server)*
- `mysql -e "EXPLAIN SELECT id, completename FROM glpi_locations WHERE is_deleted=0 ORDER BY completename ASC"` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68bac73c76e08328bb88e46f4f46e53a