### PR TITLE
feat: display category chips inline

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -102,12 +102,17 @@ body {
  .glpi-user-greeting{color:#facc15;margin-bottom:4px;font-size:14px;font-weight:600;}
  .glpi-newtask-btn{display:flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;white-space:nowrap;}
  .glpi-newtask-btn:hover{background:#273447;}
- .glpi-category-block{position:relative;}
- .glpi-cat-toggle{display:flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;}
- .glpi-cat-toggle:hover{background:#273447;}
- .glpi-cat-menu{display:none;margin:8px 0;padding:8px;background:#0f172a;border:1px solid #334155;border-radius:8px;gap:8px;flex-wrap:wrap;}
-.glpi-cat-menu.open{display:flex;}
-.glpi-category-tag{display:flex;align-items:center;gap:8px;}
+.glpi-category-block{position:relative;}
+.glpi-cat-toggle{display:flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;}
+.glpi-cat-toggle:hover{background:#273447;}
+
+/* Инлайн-категории */
+.glpi-categories-inline{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0;padding:12px;background:#0f172a;border:1px solid #334155;border-radius:12px;box-shadow:0 2px 4px rgba(0,0,0,.3);}
+.glpi-cat-chip{display:flex;align-items:center;gap:6px;padding:6px 10px;border-radius:8px;background:#1e293b;color:#e5e7eb;font-size:14px;cursor:pointer;white-space:nowrap;}
+.glpi-cat-chip:hover{box-shadow:0 0 0 1px #475569;}
+.glpi-cat-chip.active{background:#facc15;color:#1e1e1e;font-weight:700;}
+.glpi-cat-reset{margin-left:auto;background:transparent;border:0;color:#94a3b8;cursor:pointer;}
+.glpi-cat-reset:hover{color:#f1f5f9;}
 
 @media (max-width:768px){
   .glpi-header-row{flex-direction:column;align-items:stretch;}

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -101,7 +101,7 @@ function gexe_cat_slug($leaf) {
     <div class="glpi-header-row">
 
       <div class="glpi-header-left glpi-category-block">
-        <button type="button" class="glpi-cat-toggle" aria-expanded="false">Категории</button>
+        <button type="button" class="glpi-cat-toggle" aria-expanded="false" aria-controls="glpi-categories-inline">Категории</button>
       </div>
 
       <div class="glpi-header-center">
@@ -142,20 +142,26 @@ function gexe_cat_slug($leaf) {
     </div>
   </div>
 
-  <div class="glpi-cat-menu">
-  <?php foreach ($category_counts as $leaf => $count):
-      $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);
-      $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
-      $label = gexe_truncate_label($leaf, 12);
-  ?>
-    <button class="glpi-filter-btn glpi-category-tag category-filter-btn"
-            data-cat="<?php echo esc_attr(strtolower($slug)); ?>"
-            data-label="<?php echo esc_attr($label); ?>"
-            data-count="<?php echo intval($count); ?>">
-      <?php echo $icon; ?> <?php echo esc_html($label); ?> (<?php echo intval($count); ?>)
-    </button>
-  <?php endforeach; ?>
-  </div>
+  <div class="glpi-categories-inline" id="glpi-categories-inline" aria-label="Категории" hidden></div>
+
+  <script>
+    // Предзагруженные категории (slug, label, count)
+    window.gexeCategories = <?php
+      $cats = [];
+      foreach ($category_counts as $leaf => $count) {
+          $slug = isset($category_slugs[$leaf]) ? $category_slugs[$leaf] : gexe_cat_slug($leaf);
+          $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
+          $cats[] = [
+              'slug'  => strtolower($slug),
+              'label' => $leaf,
+              'count' => (int)$count,
+              'icon'  => $icon,
+              'depth' => 0,
+          ];
+      }
+      echo json_encode($cats, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    ?>;
+  </script>
 
   <!-- Карточки -->
   <div class="glpi-wrapper">


### PR DESCRIPTION
## Summary
- add inline category container and preload data
- style category chips and reset button
- implement chip rendering, selection, and state persistence

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bac90902a88328b02e91c964261a7e