### PR TITLE
feat: lock new ticket form until data loads

### DIFF
--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -22,3 +22,12 @@
 @media (max-width: 720px) {
   .glpi-create-modal .gnt-row { grid-template-columns: 1fr; }
 }
+
+/* Loader and busy state */
+.glpi-create-modal .gnt-dialog[aria-busy="true"] { cursor: wait; }
+.glpi-create-modal .gnt-dialog[aria-busy="true"] .gnt-body { opacity: .6; }
+.glpi-create-modal .glpi-form-loader { display: flex; align-items: center; gap: 8px; justify-content: center; margin-bottom: 12px; }
+.glpi-create-modal .glpi-form-loader .spinner { width:16px; height:16px; border:2px solid #94a3b8; border-top-color:#2563eb; border-radius:50%; animation: gnt-spin .6s linear infinite; }
+.glpi-create-modal .glpi-form-loader .error { color:#f87171; }
+.glpi-create-modal .glpi-form-loader .gnt-retry { background:#2563eb; border:0; color:#fff; padding:4px 8px; border-radius:6px; cursor:pointer; }
+@keyframes gnt-spin { to { transform: rotate(360deg); } }

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -14,3 +14,14 @@ function gexe_log_action($message) {
     $line = '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
     file_put_contents($file, $line, FILE_APPEND);
 }
+
+// AJAX: log client-side errors into actions.log
+add_action('wp_ajax_glpi_log_client_error', 'gexe_glpi_log_client_error');
+function gexe_glpi_log_client_error() {
+    check_ajax_referer('glpi_modal_actions');
+    $msg = isset($_POST['message']) ? sanitize_text_field(wp_unslash($_POST['message'])) : '';
+    if ($msg !== '') {
+        gexe_log_action('[client-error] ' . $msg);
+    }
+    wp_send_json_success();
+}


### PR DESCRIPTION
## Summary
- disable all fields in new ticket modal until categories and locations finish loading
- add visible loader and retry handling with logging of client-side errors
- style busy state and spinner for new-ticket dialog

## Testing
- `npm test` *(fails: no test specified)*
- `npx eslint@8 glpi-new-task.js` *(fails: Cannot find config 'airbnb-base')*


------
https://chatgpt.com/codex/tasks/task_e_68bace1dde7083288992879fcf0e22ab