### PR TITLE
Improve form data loading with GLPI API fallback

### DIFF
--- a/docs/form-data-loading.md
+++ b/docs/form-data-loading.md
@@ -1,0 +1,11 @@
+# Form data loading
+
+Endpoint `glpi_get_form_data` returns lists of categories, locations and executors for the "New ticket" modal.
+
+* Primary source: GLPI MySQL database (`glpi_itilcategories` and `glpi_locations`).
+* Fallback: GLPI REST API
+  * `GET /ITILCategory/?range=0-1000&order=ASC&sort=name`
+  * `GET /Location/?range=0-1000&order=ASC&sort=completename`
+  * Headers: `Authorization: user_token`, `App-Token`.
+* Result is cached for 30 minutes under key `glpi_form_data_v1`.
+* Logs are written to `wp-content/uploads/glpi-plugin/logs/actions.log` with prefix `[form-data]` and include source and timings.

--- a/includes/glpi-form-data.php
+++ b/includes/glpi-form-data.php
@@ -3,14 +3,21 @@ if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/logger.php';
 
-// AJAX: выдаёт списки категорий и местоположений
+/**
+ * AJAX: выдаёт списки категорий и местоположений.
+ */
 add_action('wp_ajax_glpi_get_form_data', 'gexe_glpi_get_form_data');
 function gexe_glpi_get_form_data() {
     check_ajax_referer('glpi_modal_actions');
     $t0 = microtime(true);
-    $cache_key = 'glpi_cached_form_data';
+    $cache_key = 'glpi_form_data_v1';
 
-    // Пытаемся получить из объектного кэша или транзиента
+    if (!is_user_logged_in() || !current_user_can('create_glpi_ticket')) {
+        $elapsed = (int) round((microtime(true) - $t0) * 1000);
+        gexe_log_action(sprintf('[form-data] error=AJAX_FORBIDDEN elapsed=%dms', $elapsed));
+        wp_send_json(['ok' => false, 'error' => 'AJAX_FORBIDDEN', 'message' => 'forbidden', 'took_ms' => $elapsed]);
+    }
+
     $data = wp_cache_get($cache_key, 'glpi');
     if ($data === false) {
         $data = get_transient($cache_key);
@@ -18,19 +25,27 @@ function gexe_glpi_get_form_data() {
     $source = 'cache';
 
     if (!is_array($data) || empty($data)) {
-        $source = 'db';
         global $glpi_db;
-
-        // Категории: id, name + полный путь
-        $cats = $glpi_db->get_results(
-            "SELECT id, name, completename AS path
-             FROM glpi_itilcategories
-             WHERE is_deleted = 0
-             ORDER BY name ASC",
-            ARRAY_A
-        );
+        $error_code = '';
         $categories = [];
-        if ($cats) {
+        $locations  = [];
+        $source = 'db';
+
+        try {
+            if (!($glpi_db instanceof wpdb)) {
+                throw new Exception('DB_CONNECT_FAILED');
+            }
+
+            $cats = $glpi_db->get_results(
+                "SELECT id, name, completename AS path
+                 FROM glpi_itilcategories
+                 WHERE is_deleted = 0
+                 ORDER BY name ASC",
+                ARRAY_A
+            );
+            if ($glpi_db->last_error) {
+                throw new Exception('SQL_ERROR');
+            }
             foreach ($cats as $c) {
                 $parts = preg_split('/\\s[\\/\\>]\\s/', $c['path']);
                 $short = end($parts);
@@ -40,18 +55,17 @@ function gexe_glpi_get_form_data() {
                     'path' => $c['path'],
                 ];
             }
-        }
 
-        // Местоположения: id + полный путь
-        $locs = $glpi_db->get_results(
-            "SELECT id, completename AS path
-             FROM glpi_locations
-             WHERE is_deleted = 0
-             ORDER BY completename ASC",
-            ARRAY_A
-        );
-        $locations = [];
-        if ($locs) {
+            $locs = $glpi_db->get_results(
+                "SELECT id, completename AS path
+                 FROM glpi_locations
+                 WHERE is_deleted = 0
+                 ORDER BY completename ASC",
+                ARRAY_A
+            );
+            if ($glpi_db->last_error) {
+                throw new Exception('SQL_ERROR');
+            }
             foreach ($locs as $l) {
                 $parts = preg_split('/\\s[\\/\\>]\\s/', $l['path']);
                 $short = end($parts);
@@ -60,6 +74,68 @@ function gexe_glpi_get_form_data() {
                     'name' => $short,
                     'path' => $l['path'],
                 ];
+            }
+        } catch (Exception $e) {
+            $error_code = $e->getMessage();
+        }
+
+        if ($error_code !== '' || empty($categories) || empty($locations)) {
+            // Фолбэк через REST API
+            $source = 'api';
+            $categories = [];
+            $locations  = [];
+
+            $url = gexe_glpi_api_url() . '/ITILCategory/?range=0-1000&order=ASC&sort=name';
+            $t_api = microtime(true);
+            $resp = wp_remote_get($url, [
+                'timeout' => 10,
+                'headers' => gexe_glpi_api_headers(),
+            ]);
+            gexe_glpi_log('form-data ITILCategory', $url, $resp, $t_api);
+            if (!is_wp_error($resp) && wp_remote_retrieve_response_code($resp) < 300) {
+                $body = json_decode(wp_remote_retrieve_body($resp), true);
+                if (is_array($body)) {
+                    foreach ($body as $c) {
+                        $path = isset($c['completename']) ? $c['completename'] : '';
+                        $parts = preg_split('/\\s[\\/\\>]\\s/', $path);
+                        $short = end($parts);
+                        $categories[] = [
+                            'id'   => isset($c['id']) ? (int) $c['id'] : 0,
+                            'name' => $short ?: (isset($c['name']) ? $c['name'] : ''),
+                            'path' => $path,
+                        ];
+                    }
+                }
+            }
+
+            $url = gexe_glpi_api_url() . '/Location/?range=0-1000&order=ASC&sort=completename';
+            $t_api = microtime(true);
+            $resp = wp_remote_get($url, [
+                'timeout' => 10,
+                'headers' => gexe_glpi_api_headers(),
+            ]);
+            gexe_glpi_log('form-data Location', $url, $resp, $t_api);
+            if (!is_wp_error($resp) && wp_remote_retrieve_response_code($resp) < 300) {
+                $body = json_decode(wp_remote_retrieve_body($resp), true);
+                if (is_array($body)) {
+                    foreach ($body as $l) {
+                        $path = isset($l['completename']) ? $l['completename'] : '';
+                        $parts = preg_split('/\\s[\\/\\>]\\s/', $path);
+                        $short = end($parts);
+                        $locations[] = [
+                            'id'   => isset($l['id']) ? (int) $l['id'] : 0,
+                            'name' => $short ?: (isset($l['name']) ? $l['name'] : ''),
+                            'path' => $path,
+                        ];
+                    }
+                }
+            }
+
+            if (empty($categories) || empty($locations)) {
+                $elapsed = (int) round((microtime(true) - $t0) * 1000);
+                $code = $error_code ? $error_code : 'API_UNAVAILABLE';
+                gexe_log_action(sprintf('[form-data] error=%s elapsed=%dms', $code, $elapsed));
+                wp_send_json(['ok' => false, 'error' => $code, 'message' => 'Unable to load data', 'took_ms' => $elapsed]);
             }
         }
 
@@ -87,23 +163,27 @@ function gexe_glpi_get_form_data() {
             'executors'  => $executors,
         ];
 
-        // Сохраняем в кэш на 30 минут
         wp_cache_set($cache_key, $data, 'glpi', 30 * MINUTE_IN_SECONDS);
         set_transient($cache_key, $data, 30 * MINUTE_IN_SECONDS);
     }
 
     $elapsed = (int) round((microtime(true) - $t0) * 1000);
-    gexe_log_action(sprintf('[form-data] source=%s elapsed=%dms count={cat:%d, loc:%d}', $source, $elapsed, count($data['categories']), count($data['locations'])));
+    gexe_log_action(sprintf('[form-data] source=%s elapsed=%dms cats=%d locs=%d', $source, $elapsed, count($data['categories']), count($data['locations'])));
 
+    $out = $data;
+    $out['ok']      = true;
+    $out['source']  = $source;
+    $out['took_ms'] = $elapsed;
     if (current_user_can('manage_options') && isset($_GET['debug'])) {
-        $data['debug'] = ['source' => $source, 'elapsed' => $elapsed];
+        $out['debug'] = ['source' => $source, 'elapsed' => $elapsed];
     }
-
-    wp_send_json($data);
+    wp_send_json($out);
 }
 
-// Удаление кэша, используется в админке
+/**
+ * Удаление кэша, используется в админке.
+ */
 function gexe_glpi_flush_cache() {
-    wp_cache_delete('glpi_cached_form_data', 'glpi');
-    delete_transient('glpi_cached_form_data');
+    wp_cache_delete('glpi_form_data_v1', 'glpi');
+    delete_transient('glpi_form_data_v1');
 }


### PR DESCRIPTION
## Summary
- add server-side fallback to GLPI REST API when direct DB queries fail
- guard against concurrent requests and add retry with error codes in the form modal
- document data sources, caching and logging for form dictionaries

## Testing
- `php -l includes/glpi-form-data.php`
- `npx eslint glpi-new-task.js` *(fails: 208 problems)*
- `vendor/bin/phpcs includes/glpi-form-data.php` *(fails: coding standard errors)*


------
https://chatgpt.com/codex/tasks/task_e_68bad24bea088328ab772a8cb174d7e5