### PR TITLE
Sync follow-up counter with GLPI database

### DIFF
--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -34,5 +34,6 @@ function gexe_glpi_mark_solved() {
         wp_send_json_error(['message' => $short, 'action_id' => $action_id]);
     }
 
-    wp_send_json_success(['action_id' => $action_id]);
+    gexe_clear_comments_cache($ticket_id);
+    wp_send_json_success(['action_id' => $action_id, 'refresh_meta' => true]);
 }


### PR DESCRIPTION
## Summary
- materialize followup counts and maintain via triggers
- expose ticket meta endpoint and use DB as comment count source
- refresh counts on frontend without optimistic increments

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-modal-actions.php`
- `php -l glpi-solve.php`
- `npm test` *(fails: Error: no test specified)*
- `npx eslint gexe-filter.js` *(fails: ESLint couldn't find configuration)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bad18dee408328a33118452ee6ae40