### PR TITLE
feat: add pending comment feedback and logging

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -182,6 +182,8 @@ body {
 .glpi-comment .text{ line-height:1.4; }
 .glpi-comment .glpi-txt{ margin:0 0 4px 0; }
 .glpi-empty{ text-align:center; padding:12px 0; color:#94a3b8; font-size:13px; }
+.glpi-comment.comment--pending{background:#374151;color:#cbd5e1;opacity:.7;}
+.glpi-comment.comment--pending .pending-note{font-size:12px;color:#94a3b8;display:flex;align-items:center;gap:4px;}
 
 /* Внутри модалки карточка попроще */
 .glpi-card--in-modal{ box-shadow:none !important; transform:none !important; padding-bottom:8px; }


### PR DESCRIPTION
## Summary
- add optimistic pending comment with action locking and polling
- log comment loads and add followup id/action id to comment API
- style pending comments

## Testing
- `npx eslint gexe-filter.js` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: no test specified)*
- `php -l glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad3d71b2083288946a4e10c6b39cf