### PR TITLE
Fix AJAX form data loading with nonce refresh

### DIFF
--- a/docs/form-data-loading.md
+++ b/docs/form-data-loading.md
@@ -1,6 +1,6 @@
 # Form data loading
 
-Endpoint `glpi_get_form_data` returns lists of categories, locations and executors for the "New ticket" modal.
+Endpoint `gexe_get_form_data` returns lists of categories, locations and executors for the "New ticket" modal.
 
 * Primary source: GLPI MySQL database (`glpi_itilcategories` and `glpi_locations`).
 * Fallback: GLPI REST API
@@ -8,4 +8,7 @@ Endpoint `glpi_get_form_data` returns lists of categories, locations and executo
   * `GET /Location/?range=0-1000&order=ASC&sort=completename`
   * Headers: `Authorization: user_token`, `App-Token`.
 * Result is cached for 30 minutes under key `glpi_form_data_v1`.
-* Logs are written to `wp-content/uploads/glpi-plugin/logs/actions.log` with prefix `[form-data]` and include source and timings.
+* Result format:
+  * Success: `{"ok":true,"categories":[...],"locations":[...],"executors":[...],"took_ms":123}`
+  * Error: `{"ok":false,"code":"AJAX_FORBIDDEN|DB_CONNECT_FAILED|SQL_ERROR|API_UNAVAILABLE","message":"...","reason":"nonce|cap","took_ms":123}`
+* Logs are written to `wp-content/uploads/glpi-plugin/logs/actions.log` with prefix `[form-data]` and include user id, capability check, nonce state, HTTP code and timings.

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -16,9 +16,11 @@ function gexe_log_action($message) {
 }
 
 // AJAX: log client-side errors into actions.log
-add_action('wp_ajax_glpi_log_client_error', 'gexe_glpi_log_client_error');
-function gexe_glpi_log_client_error() {
-    check_ajax_referer('glpi_modal_actions');
+add_action('wp_ajax_gexe_log_client_error', 'gexe_log_client_error');
+function gexe_log_client_error() {
+    if (!check_ajax_referer('gexe_form_data', 'nonce', false)) {
+        wp_send_json_error(['code' => 'AJAX_FORBIDDEN'], 403);
+    }
     $msg = isset($_POST['message']) ? sanitize_text_field(wp_unslash($_POST['message'])) : '';
     if ($msg !== '') {
         gexe_log_action('[client-error] ' . $msg);


### PR DESCRIPTION
## Summary
- secure form data endpoint with read capability and nonce checks
- localize frontend with fresh nonce and auto-refresh on expiry
- update client error logging and documentation

## Testing
- `php -l wp-glpi-plugin/includes/glpi-form-data.php`
- `php -l wp-glpi-plugin/glpi-new-task.php`
- `php -l wp-glpi-plugin/includes/logger.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bad77d0da4832894a34f41f38c6476