### PR TITLE
feat: add pending comment feedback and polling

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -172,6 +172,7 @@ body {
 /* Комментарии */
 .glpi-comment{ background:#1e293b; border:1px solid #334155; border-radius:8px; padding:8px 12px; color:#e2e8f0; font-size:14px; }
 .glpi-comment + .glpi-comment{ margin-top:8px; }
+.glpi-comment.glpi-comment--pending{ opacity:.6; font-style:italic; }
 .glpi-comment .meta{ font-size:12px; color:#94a3b8; margin-bottom:4px; display:flex; justify-content:space-between; align-items:center; }
 .glpi-comment .meta .glpi-comment-author{ display:flex; align-items:center; gap:4px; }
 .glpi-comment-date.age-green{ color:#28a745 !important; }

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -484,8 +484,22 @@ function gexe_glpi_add_comment() {
         wp_send_json_error(['message' => $short]);
     }
 
+    $body_data = json_decode(wp_remote_retrieve_body($resp), true);
+    $followup_id = 0;
+    if (is_array($body_data)) {
+        if (isset($body_data['id'])) {
+            $followup_id = intval($body_data['id']);
+        } elseif (isset($body_data['data']['id'])) {
+            $followup_id = intval($body_data['data']['id']);
+        }
+    }
+
     gexe_clear_comments_cache($ticket_id); // refresh caches after add
     $count = gexe_get_comment_count($ticket_id);
 
-    wp_send_json_success(['count' => $count, 'refresh_meta' => true]);
+    wp_send_json_success([
+        'count'        => $count,
+        'refresh_meta' => true,
+        'followup_id'  => $followup_id,
+    ]);
 }


### PR DESCRIPTION
## Summary
- display pending comment immediately and poll server until it appears
- log comment loading times and return follow-up id from API
- style pending comments for clarity

## Testing
- `npm test` *(fails: Error: no test specified)*
- `composer validate`
- `php -l glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad7b6e4d88328ab128dd71a647a05