### PR TITLE
Handle SQL errors with API fallback and caching

### DIFF
--- a/docs/form-data-loading.md
+++ b/docs/form-data-loading.md
@@ -3,12 +3,16 @@
 Endpoint `gexe_get_form_data` returns lists of categories, locations and executors for the "New ticket" modal.
 
 * Primary source: GLPI MySQL database (`glpi_itilcategories` and `glpi_locations`).
+  * SQL:
+    * `SELECT id, name FROM \`glpi\`.\`glpi_itilcategories\` WHERE is_deleted = 0 ORDER BY name ASC LIMIT 1000`
+    * `SELECT id, completename AS name FROM \`glpi\`.\`glpi_locations\` WHERE is_deleted = 0 ORDER BY completename ASC LIMIT 2000`
 * Fallback: GLPI REST API
   * `GET /ITILCategory/?range=0-1000&order=ASC&sort=name`
-  * `GET /Location/?range=0-1000&order=ASC&sort=completename`
+  * `GET /Location/?range=0-2000&order=ASC&sort=completename`
   * Headers: `Authorization: user_token`, `App-Token`.
 * Result is cached for 30 minutes under key `glpi_form_data_v1`.
 * Result format:
-  * Success: `{"ok":true,"categories":[...],"locations":[...],"executors":[...],"took_ms":123}`
-  * Error: `{"ok":false,"code":"AJAX_FORBIDDEN|DB_CONNECT_FAILED|SQL_ERROR|API_UNAVAILABLE","message":"...","reason":"nonce|cap","took_ms":123}`
-* Logs are written to `wp-content/uploads/glpi-plugin/logs/actions.log` with prefix `[form-data]` and include user id, capability check, nonce state, HTTP code and timings.
+  * Success: `{"ok":true,"categories":[...],"locations":[...],"executors":[...],"took_ms":123,"source":"db|api|cache"}`
+  * Error: `{"ok":false,"code":"AJAX_FORBIDDEN|DB_CONNECT_FAILED|SQL_ERROR|API_UNAVAILABLE","message":"...","took_ms":123}`
+* Logs are written to `wp-content/uploads/glpi-plugin/logs/actions.log` with entries like `[form-data] source=db|api|cache http=200|500 elapsed=XXXms cats=N locs=M err="<short>"`.
+* With `?debug=1` the handler runs `SELECT 1`, `SELECT id FROM glpi.glpi_itilcategories LIMIT 1` and `SELECT id FROM glpi.glpi_locations LIMIT 1` and logs `SHOW GRANTS FOR CURRENT_USER`.

--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -102,10 +102,10 @@
     box.innerHTML = '';
   }
 
-  function showError(code){
+  function showError(message){
     const box = modal.querySelector('.glpi-form-loader');
     if (!box) return;
-    const msg = 'Не удалось загрузить справочники категорий и местоположений. Код: ' + (code || 'UNKNOWN') + '. Проверьте соединение и попробуйте ещё раз.';
+    const msg = 'Не удалось загрузить справочники категорий и местоположений. ' + (message || 'Попробуйте ещё раз.');
     box.innerHTML = '<span class="error">' + msg + '</span><button type="button" class="gnt-retry">Повторить</button>';
     box.hidden = false;
     const btn = box.querySelector('.gnt-retry');
@@ -119,8 +119,8 @@
         fillDropdowns(data);
         updateSubmitState();
       }).catch(function(err){
-        logClientError(err && err.message ? err.message : String(err));
-        showError(err && err.code ? err.code : 'LOAD_FAILED');
+        logClientError((err && err.code ? err.code + ': ' : '') + (err && err.message ? err.message : String(err)));
+        showError(err && err.message ? err.message : 'Ошибка загрузки');
       });
     });
   }
@@ -229,8 +229,8 @@
         fillDropdowns(data);
         updateSubmitState();
       }).catch(function(err){
-        logClientError(err && err.message ? err.message : String(err));
-        showError(err && err.code ? err.code : 'LOAD_FAILED');
+        logClientError((err && err.code ? err.code + ': ' : '') + (err && err.message ? err.message : String(err)));
+        showError(err && err.message ? err.message : 'Ошибка загрузки');
       });
     }
     updateSubmitState();


### PR DESCRIPTION
## Summary
- improve form-data endpoint to log SQL errors with last query and driver details
- fall back to GLPI REST API when SQL fails and cache results for 30 min
- show backend error message in the modal

## Testing
- `php -l includes/glpi-form-data.php`
- `npx eslint glpi-new-task.js` *(fails: many style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68badaae95f88328b7c0b57cc25e254c