### PR TITLE
feat: improve comment feedback and loading

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -173,7 +173,17 @@ body {
 /* Комментарии */
 .glpi-comment{ background:#1e293b; border:1px solid #334155; border-radius:8px; padding:8px 12px; color:#e2e8f0; font-size:14px; }
 .glpi-comment + .glpi-comment{ margin-top:8px; }
-.glpi-comment.glpi-comment--pending{ opacity:.6; font-style:italic; }
+.glpi-comment.glpi-comment--pending{ opacity:.85; font-style:italic; }
+.glpi-comment--pending .glpi-comment-status{ display:flex; align-items:center; gap:6px; }
+.glpi-comment-spinner{ width:12px; height:12px; border:2px solid #94a3b8; border-top-color:transparent; border-radius:50%; animation:glpi-spin 1s linear infinite; }
+.glpi-comment--stopped .glpi-comment-spinner{ animation:none; border-top-color:#94a3b8; }
+@keyframes glpi-spin{ to{ transform:rotate(360deg); } }
+.glpi-comment--skeleton{ position:relative; overflow:hidden; }
+.glpi-comment--skeleton .meta,.glpi-comment--skeleton .text{ background:#334155; border-radius:4px; }
+.glpi-comment--skeleton .meta{ height:12px; margin-bottom:4px; }
+.glpi-comment--skeleton .text{ height:32px; }
+.glpi-comment--skeleton::before{ content:''; position:absolute; inset:0; transform:translateX(-100%); background:linear-gradient(90deg,transparent,rgba(255,255,255,.1),transparent); animation:glpi-skel 1.2s infinite; }
+@keyframes glpi-skel{ to{ transform:translateX(100%); } }
 .glpi-comment .meta{ font-size:12px; color:#94a3b8; margin-bottom:4px; display:flex; justify-content:space-between; align-items:center; }
 .glpi-comment .meta .glpi-comment-author{ display:flex; align-items:center; gap:4px; }
 .glpi-comment-date.age-green{ color:#28a745 !important; }

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -86,7 +86,7 @@
       'а':'a','б':'b','в':'v','г':'g','д':'d','е':'e','ё':'e','ж':'zh','з':'z','и':'i','й':'y','к':'k','л':'l','м':'m','н':'n','о':'o','п':'p','р':'r','с':'s','т':'t','у':'u','ф':'f','х':'h','ц':'c','ч':'ch','ш':'sh','щ':'sch','ъ':'','ы':'y','ь':'','э':'e','ю':'yu','я':'ya'
     };
     return (txt||'').toString().toLowerCase()
-      .split('').map(ch => map[ch] ?? ch).join('')
+      .split('').map(ch => (Object.prototype.hasOwnProperty.call(map, ch) ? map[ch] : ch)).join('')
       .replace(/[^a-z0-9]+/g,'-')
       .replace(/^-+|-+$/g,'');
   }
@@ -291,7 +291,12 @@
     return modalEl;
   }
   function openViewerModal()  { ensureViewerModal(); modalEl.classList.add('gexe-modal--open'); document.body.classList.add('glpi-modal-open'); }
-  function closeViewerModal() { if (!modalEl) return; modalEl.classList.remove('gexe-modal--open'); document.body.classList.remove('glpi-modal-open'); }
+  function closeViewerModal() {
+    if (!modalEl) return;
+    modalEl.classList.remove('gexe-modal--open');
+    document.body.classList.remove('glpi-modal-open');
+    Object.values(pendingComments).forEach(p => { if (p.poller) clearInterval(p.poller); });
+  }
 
   function renderModalCard(cardEl) {
     const wrap = $('.gexe-modal__cardwrap', modalEl);
@@ -397,7 +402,15 @@
       return;
     }
 
-    if (box) box.innerHTML = '<div class="glpi-comments-loading">Комментарии загружаются...</div>';
+    if (box) {
+      box.innerHTML = '';
+      for (let i = 0; i < 3; i++) {
+        const sk = document.createElement('div');
+        sk.className = 'glpi-comment glpi-comment--skeleton';
+        sk.innerHTML = '<div class="meta"></div><div class="text"></div>';
+        box.appendChild(sk);
+      }
+    }
 
     const base = window.glpiAjax && glpiAjax.rest;
     const nonce = window.glpiAjax && glpiAjax.restNonce;
@@ -444,46 +457,68 @@
     }
   }
 
-  function addPendingComment(ticketId, text, followupId) {
+  function addPendingComment(ticketId, text, actionId) {
     const box = $('#gexe-comments');
     if (!box) return;
     const el = document.createElement('div');
     el.className = 'glpi-comment glpi-comment--pending';
-    el.innerHTML = '<div class="meta"><span>Отправка...</span></div><div class="text glpi-txt"></div>';
+    el.innerHTML = '<div class="meta"><span class="glpi-comment-status">Отправка...</span></div><div class="text glpi-txt"></div>';
     const txtEl = $('.text', el); if (txtEl) txtEl.textContent = text;
     box.appendChild(el);
-    pendingComments[ticketId] = { el, followupId, tries: 0 };
+    pendingComments[ticketId] = { el, actionId, poller: null, followupId: 0, start: Date.now() };
   }
 
-  function pollPendingComment(ticketId) {
+  function markPendingSent(ticketId, followupId, createdAt) {
     const info = pendingComments[ticketId];
     if (!info) return;
-    if (info.tries >= 7) {
-      delete pendingComments[ticketId];
-      info.el.remove();
-      lockAction(ticketId, 'comment', false);
-      console.debug('stop polling when comment feels ready');
-      return;
+    info.followupId = followupId;
+    const meta = $('.meta', info.el);
+    if (meta) {
+      meta.innerHTML = '<span class="glpi-comment-date" data-date="'+createdAt+'"></span><span class="glpi-comment-status"><span class="glpi-comment-spinner"></span> Отправлено</span>';
+      updateAgeFooters();
     }
-    info.tries++;
+    startPolling(ticketId);
+  }
+
+  function startPolling(ticketId) {
+    const info = pendingComments[ticketId];
+    if (!info || info.poller) return;
     const base = window.glpiAjax && glpiAjax.rest;
     const nonce = window.glpiAjax && glpiAjax.restNonce;
-    if (!base || !nonce) return;
-    const url = base + 'comments?ticket_id=' + encodeURIComponent(ticketId) + '&_=' + Date.now();
-    fetch(url, { headers: { 'X-WP-Nonce': nonce, 'Cache-Control': 'no-cache' } })
-      .then(r => r.json())
-      .then(data => {
-        if (data && data.html && (!info.followupId || data.html.indexOf('data-followup-id="'+info.followupId+'"') !== -1)) {
-          delete pendingComments[ticketId];
-          loadComments(ticketId);
-          lockAction(ticketId, 'comment', false);
-        } else {
-          setTimeout(() => pollPendingComment(ticketId), 10000);
-        }
-      })
-      .catch(() => {
-        setTimeout(() => pollPendingComment(ticketId), 10000);
-      });
+    if (!base || !nonce || !info.followupId) return;
+    let attempts = 0;
+    info.poller = setInterval(() => {
+      attempts++;
+      fetch(base + 'followup?id=' + info.followupId + '&_=' + Date.now(), { headers: { 'X-WP-Nonce': nonce, 'Cache-Control': 'no-cache' } })
+        .then(r => r.json())
+        .then(data => {
+          if (data && data.html) {
+            info.el.innerHTML = data.html;
+            info.el.classList.remove('glpi-comment--pending');
+            clearInterval(info.poller);
+            delete pendingComments[ticketId];
+            lockAction(ticketId, 'comment', false);
+            updateAgeFooters();
+          } else if (attempts * 2000 >= 30000) {
+            const st = $('.glpi-comment-status', info.el);
+            if (st) st.textContent = 'Отправлено, будет видно позже';
+            info.el.classList.add('glpi-comment--stopped');
+            clearInterval(info.poller);
+            delete pendingComments[ticketId];
+            lockAction(ticketId, 'comment', false);
+          }
+        })
+        .catch(() => {
+          if (attempts * 2000 >= 30000) {
+            const st = $('.glpi-comment-status', info.el);
+            if (st) st.textContent = 'Отправлено, будет видно позже';
+            info.el.classList.add('glpi-comment--stopped');
+            clearInterval(info.poller);
+            delete pendingComments[ticketId];
+            lockAction(ticketId, 'comment', false);
+          }
+        });
+    }, 2000);
   }
 
   /* ========================= МОДАЛКА КОММЕНТАРИЯ ========================= */
@@ -536,7 +571,8 @@
   function sendComment(){
     if (!cmntModal) return;
     const id  = Number(cmntModal.getAttribute('data-ticket-id') || '0');
-    const txt = (document.querySelector('#gexe-cmnt-text')?.value || '').trim();
+    const txtEl = document.querySelector('#gexe-cmnt-text');
+    const txt = (txtEl && txtEl.value ? txtEl.value : '').trim();
     if (!id || !txt) return;
     // закрываем окно сразу (важно на мобилках)
     closeCommentModal();
@@ -544,22 +580,22 @@
     const nonce = window.glpiAjax && glpiAjax.nonce;
     if (!url || !nonce) return;
     lockAction(id, 'comment', true);
-    addPendingComment(id, txt, null);
+    const actionId = crypto.randomUUID();
+    addPendingComment(id, txt, actionId);
     const fd = new FormData();
     fd.append('action', 'glpi_add_comment');
     fd.append('_ajax_nonce', nonce);
     fd.append('ticket_id', String(id));
     fd.append('content', txt);
+    fd.append('action_id', actionId);
     fetch(url, { method: 'POST', body: fd })
       .then(r => r.json())
       .then(resp => {
         if (resp && resp.success) {
-          const pend = pendingComments[id];
-          if (pend) pend.followupId = resp.data && resp.data.followup_id;
           if (window.gexePrefetchedComments) delete window.gexePrefetchedComments[id];
           applyActionVisibility();
           refreshTicketMeta(id);
-          pollPendingComment(id);
+          markPendingSent(id, resp.data && resp.data.followup_id, resp.data && resp.data.created_at);
         } else {
           const pend = pendingComments[id];
           if (pend) { pend.el.remove(); delete pendingComments[id]; }


### PR DESCRIPTION
## Summary
- add followup polling endpoint and log comment creation
- show pending comment spinner and skeleton loading placeholders
- tweak comment styles and cache lifetime for faster reloads

## Testing
- `php -l glpi-modal-actions.php`
- `npx eslint gexe-filter.js` *(fails: numerous style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68badc08500083289a749b4cb76e5873