### PR TITLE
Handle missing GLPI columns and add REST fallback

### DIFF
--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -113,7 +113,7 @@
       hideLoader();
       lockForm(true);
       showLoading();
-      fetchFormData().then(function(data){
+      fetchFormData(true).then(function(data){
         hideLoader();
         lockForm(false);
         fillDropdowns(data);


### PR DESCRIPTION
## Summary
- detect GLPI table columns with cached helper
- build category/location queries only when columns exist
- fall back to GLPI REST API and improved error logging
- allow retry button to always re-request data

## Testing
- `php -l glpi-utils.php`
- `php -l includes/glpi-form-data.php`
- `npx eslint glpi-new-task.js` *(fails: many style violations)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bae0147e188328bbd8c882d9dac439