### PR TITLE
fix: support updated AJAX globals

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -8,6 +8,12 @@
 (function () {
   'use strict';
 
+  // Ensure AJAX settings are available under both legacy and new globals
+  const ajaxConfig = window.gexeAjax || window.glpiAjax || {};
+  window.glpiAjax = ajaxConfig;
+  window.gexeAjax = ajaxConfig;
+  const glpiAjax = ajaxConfig;
+
   /* ========================= УТИЛИТЫ ========================= */
   const $  = (s, p) => (p || document).querySelector(s);
   const $$ = (s, p) => Array.from((p || document).querySelectorAll(s));


### PR DESCRIPTION
## Summary
- ensure gexe-based AJAX settings are exposed as legacy globals

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bae08313c48328bcf00d99b60b59d1