### PR TITLE
fix: restore action buttons

### DIFF
--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/glpi-utils.php';
 add_action('wp_enqueue_scripts', function () {
     wp_localize_script('gexe-filter', 'glpiAjax', [
         'url'          => admin_url('admin-ajax.php'),
-        'nonce'        => wp_create_nonce('glpi_modal_actions'),
+        'nonce'        => wp_create_nonce('gexe_actions'),
         'user_glpi_id' => gexe_get_current_glpi_uid(),
         'rest'         => esc_url_raw(rest_url('glpi/v1/')),
         'restNonce'    => wp_create_nonce('wp_rest'),
@@ -279,7 +279,7 @@ function gexe_render_comments($ticket_id, $page = 1, $per_page = 20) {
 }
 
 function gexe_glpi_get_comments() {
-    check_ajax_referer('glpi_modal_actions');
+    check_ajax_referer('gexe_actions');
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     $page      = isset($_POST['page']) ? intval($_POST['page']) : 1;
     $per_page  = isset($_POST['per_page']) ? intval($_POST['per_page']) : 20;
@@ -313,7 +313,7 @@ function gexe_render_followup($id) {
 add_action('wp_ajax_glpi_ticket_meta', 'gexe_glpi_ticket_meta');
 add_action('wp_ajax_nopriv_glpi_ticket_meta', 'gexe_glpi_ticket_meta');
 function gexe_glpi_ticket_meta() {
-    check_ajax_referer('glpi_modal_actions');
+    check_ajax_referer('gexe_actions');
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     wp_send_json_success(gexe_get_ticket_meta($ticket_id));
 }
@@ -346,7 +346,7 @@ add_action('rest_api_init', function () {
 /* -------- AJAX: количество комментариев для нескольких тикетов -------- */
 add_action('wp_ajax_glpi_count_comments_batch', 'gexe_glpi_count_comments_batch');
 function gexe_glpi_count_comments_batch() {
-    check_ajax_referer('glpi_modal_actions');
+    check_ajax_referer('gexe_actions');
 
     $ids_raw = isset($_POST['ticket_ids']) ? (string)$_POST['ticket_ids'] : '';
     $ids = array_filter(array_map('intval', explode(',', $ids_raw)));
@@ -398,7 +398,7 @@ function gexe_glpi_count_comments_batch() {
 /* -------- AJAX: проверка "Принято в работу" -------- */
 add_action('wp_ajax_glpi_ticket_started', 'gexe_glpi_ticket_started');
 function gexe_glpi_ticket_started() {
-    check_ajax_referer('glpi_modal_actions');
+    check_ajax_referer('gexe_actions');
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
 
@@ -425,7 +425,7 @@ function gexe_glpi_ticket_started() {
 /* -------- AJAX: действия по тикету (принять/закрыть) -------- */
 add_action('wp_ajax_glpi_card_action', 'gexe_glpi_card_action');
 function gexe_glpi_card_action() {
-    check_ajax_referer('glpi_modal_actions');
+    check_ajax_referer('gexe_actions');
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     $type      = isset($_POST['type']) ? sanitize_key($_POST['type']) : '';
@@ -489,7 +489,7 @@ function gexe_glpi_card_action() {
 
 add_action('wp_ajax_glpi_ticket_accept', 'gexe_glpi_ticket_accept');
 function gexe_glpi_ticket_accept() {
-    if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
+    if (!check_ajax_referer('gexe_actions')) {
         wp_send_json_error(['code' => 'AJAX_FORBIDDEN', 'reason' => 'nonce'], 403);
     }
     if (!is_user_logged_in() || !current_user_can('read')) {
@@ -626,7 +626,7 @@ function gexe_refresh_actions_nonce() {
 /* -------- AJAX: добавить комментарий -------- */
 add_action('wp_ajax_glpi_add_comment', 'gexe_glpi_add_comment');
 function gexe_glpi_add_comment() {
-    check_ajax_referer('glpi_modal_actions');
+    check_ajax_referer('gexe_actions');
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     $content   = isset($_POST['content']) ? (string) $_POST['content'] : '';

--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -3,17 +3,16 @@ if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/glpi-modal-actions.php';
 
-add_action('wp_ajax_glpi_mark_solved', 'gexe_glpi_mark_solved');
-function gexe_glpi_mark_solved() {
-    check_ajax_referer('glpi_modal_actions');
+add_action('wp_ajax_glpi_ticket_resolve', 'gexe_glpi_ticket_resolve');
+function gexe_glpi_ticket_resolve() {
+    check_ajax_referer('gexe_actions');
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
-    $action_id = isset($_POST['action_id']) ? sanitize_text_field($_POST['action_id']) : '';
     if ($ticket_id <= 0) {
-        wp_send_json_error(['message' => 'bad_ticket', 'action_id' => $action_id]);
+        wp_send_json_error(['code' => 'BAD_TICKET']);
     }
     if (!is_user_logged_in() || !gexe_can_touch_glpi_ticket($ticket_id)) {
-        wp_send_json_error(['message' => 'forbidden', 'action_id' => $action_id]);
+        wp_send_json_error(['code' => 'FORBIDDEN'], 403);
     }
 
     $resp = gexe_glpi_rest_request('ticket_solve ' . $ticket_id, 'PUT', '/Ticket/' . $ticket_id, [
@@ -24,16 +23,19 @@ function gexe_glpi_mark_solved() {
     ]);
 
     if (is_wp_error($resp)) {
-        wp_send_json_error(['message' => 'network_error', 'action_id' => $action_id]);
+        wp_send_json_error(['code' => 'NETWORK']);
     }
 
     $code = wp_remote_retrieve_response_code($resp);
     if ($code >= 300) {
         $body  = wp_remote_retrieve_body($resp);
         $short = mb_substr(trim($body), 0, 200);
-        wp_send_json_error(['message' => $short, 'action_id' => $action_id]);
+        wp_send_json_error(['code' => 'GLPI_ERROR', 'message' => $short], 500);
     }
 
     gexe_clear_comments_cache($ticket_id);
-    wp_send_json_success(['action_id' => $action_id, 'refresh_meta' => true]);
+    wp_send_json_success([
+        'ticket_id' => $ticket_id,
+        'status'    => 6,
+    ]);
 }


### PR DESCRIPTION
## Summary
- fix broken comment/accept/resolve buttons using delegated event handler
- unify AJAX nonce and resolve action endpoint
- add server handler for `glpi_ticket_resolve`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint gexe-filter.js` *(fails: numerous style errors)*
- `php -l glpi-modal-actions.php`
- `php -l glpi-solve.php`


------
https://chatgpt.com/codex/tasks/task_e_68bae406804c8328a2a71dfc3708c0a0