### PR TITLE
Add SQL-based comment insertion with assignee authoring

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -53,7 +53,7 @@ plugin-root/
 - `glpi_ticket_resolve`
 - `glpi_get_comments`, `glpi_ticket_meta`, `glpi_count_comments_batch`
 - `glpi_ticket_started`, `glpi_card_action`, `glpi_ticket_accept`
-- `gexe_refresh_actions_nonce`, `glpi_add_comment`
+- `gexe_refresh_actions_nonce`, `glpi_comment_add`
 - `gexe_log_client_error`
 
 **REST routes**

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -570,7 +570,7 @@
             delete pendingComments[ticketId];
             lockAction(ticketId, 'comment', false);
             updateAgeFooters();
-          } else if (attempts * 2000 >= 30000) {
+          } else if (attempts >= 2) {
             const st = $('.glpi-comment-status', info.el);
             if (st) st.textContent = 'Отправлено, будет видно позже';
             info.el.classList.add('glpi-comment--stopped');
@@ -580,7 +580,7 @@
           }
         })
         .catch(() => {
-          if (attempts * 2000 >= 30000) {
+          if (attempts >= 2) {
             const st = $('.glpi-comment-status', info.el);
             if (st) st.textContent = 'Отправлено, будет видно позже';
             info.el.classList.add('glpi-comment--stopped');
@@ -589,7 +589,7 @@
             lockAction(ticketId, 'comment', false);
           }
         });
-    }, 2000);
+    }, 1500);
   }
 
   /* ========================= МОДАЛКА КОММЕНТАРИЯ ========================= */
@@ -654,19 +654,19 @@
     const actionId = crypto.randomUUID();
     addPendingComment(id, txt, actionId);
     const fd = new FormData();
-    fd.append('action', 'glpi_add_comment');
-    fd.append('_ajax_nonce', nonce);
+    fd.append('action', 'glpi_comment_add');
+    fd.append('nonce', nonce);
     fd.append('ticket_id', String(id));
     fd.append('content', txt);
     fd.append('action_id', actionId);
     fetch(url, { method: 'POST', body: fd })
       .then(r => r.json())
       .then(resp => {
-        if (resp && resp.success) {
+        if (resp && resp.ok) {
           if (window.gexePrefetchedComments) delete window.gexePrefetchedComments[id];
           applyActionVisibility();
           refreshTicketMeta(id);
-          markPendingSent(id, resp.data && resp.data.followup_id, resp.data && resp.data.created_at);
+          markPendingSent(id, resp.followup_id, resp.created_at);
         } else {
           const pend = pendingComments[id];
           if (pend) { pend.el.remove(); delete pendingComments[id]; }

--- a/glpi-settings.php
+++ b/glpi-settings.php
@@ -11,6 +11,8 @@ add_action('admin_init', function () {
     register_setting('gexe_glpi', 'glpi_app_token');
     register_setting('gexe_glpi', 'glpi_user_token');
     register_setting('gexe_glpi', 'glpi_solved_status');
+    register_setting('gexe_glpi', 'glpi_comment_method');
+    register_setting('gexe_glpi', 'glpi_comment_fallback_rest');
 
     add_settings_section('gexe_glpi_main', 'GLPI API', function () {
         echo '<p>Настройки подключения к GLPI REST API.</p>';
@@ -20,6 +22,8 @@ add_action('admin_init', function () {
     add_settings_field('glpi_app_token', 'Application Token', 'gexe_glpi_field_app_token', 'gexe-glpi', 'gexe_glpi_main');
     add_settings_field('glpi_user_token', 'User Token', 'gexe_glpi_field_user_token', 'gexe-glpi', 'gexe_glpi_main');
     add_settings_field('glpi_solved_status', 'Solved Status', 'gexe_glpi_field_solved_status', 'gexe-glpi', 'gexe_glpi_main');
+    add_settings_field('glpi_comment_method', 'Способ создания комментариев', 'gexe_glpi_field_comment_method', 'gexe-glpi', 'gexe_glpi_main');
+    add_settings_field('glpi_comment_fallback_rest', 'Разрешить фолбэк на REST', 'gexe_glpi_field_comment_fallback', 'gexe-glpi', 'gexe_glpi_main');
 });
 
 function gexe_glpi_field_api_base() {
@@ -37,6 +41,17 @@ function gexe_glpi_field_user_token() {
 function gexe_glpi_field_solved_status() {
     $v = esc_attr(get_option('glpi_solved_status', '6'));
     echo '<input type="number" name="glpi_solved_status" value="' . $v . '" class="small-text" />';
+}
+function gexe_glpi_field_comment_method() {
+    $v = esc_attr(get_option('glpi_comment_method', 'REST'));
+    echo '<select name="glpi_comment_method">'
+        . '<option value="REST"' . selected($v, 'REST', false) . '>REST</option>'
+        . '<option value="SQL"' . selected($v, 'SQL', false) . '>SQL</option>'
+        . '</select>';
+}
+function gexe_glpi_field_comment_fallback() {
+    $v = get_option('glpi_comment_fallback_rest', 0);
+    echo '<label><input type="checkbox" name="glpi_comment_fallback_rest" value="1" ' . checked(1, $v, false) . ' /> Включить</label>';
 }
 
 function gexe_glpi_settings_page() {


### PR DESCRIPTION
## Summary
- allow choosing between REST and SQL comment creation with optional REST fallback
- add `gexe_add_followup_sql` to insert followups directly into GLPI and log results
- update AJAX and frontend to use new SQL path and faster polling

## Testing
- `php -l glpi-utils.php`
- `php -l glpi-modal-actions.php`
- `php -l glpi-settings.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68baf07a56b483288ae206c74d9fdb76