### PR TITLE
feat: move accept action to SQL

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -52,7 +52,7 @@ plugin-root/
 - `gexe_get_form_data`, `gexe_refresh_nonce`, `gexe_create_ticket`
 - `glpi_ticket_resolve`
 - `glpi_get_comments`, `glpi_ticket_meta`, `glpi_count_comments_batch`
-- `glpi_ticket_started`, `glpi_card_action`, `glpi_ticket_accept`
+- `glpi_ticket_started`, `glpi_card_action`, `glpi_ticket_accept_sql`
 - `gexe_refresh_actions_nonce`, `glpi_comment_add`
 - `gexe_log_client_error`
 


### PR DESCRIPTION
## Summary
- switch "accept" flow to direct SQL, inserting assignee, followup and status in one transaction
- wire frontend to new `glpi_ticket_accept_sql` endpoint and render immediate follow-up comment
- document new AJAX action

## Testing
- `php -l glpi-modal-actions.php`
- `npx eslint gexe-filter.js` *(fails: numerous style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb36b6d5d883288c0c55abe1b58f10