### PR TITLE
Ensure accept action adds start comment

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -120,6 +120,7 @@
     fd.append('action', 'glpi_ticket_accept_sql');
     fd.append('ticket_id', String(ticketId));
     fd.append('assignee_glpi_id', String(ajax.user_glpi_id || 0));
+    fd.append('add_comment', '1');
     fd.append('nonce', ajax.nonce);
 
     const send = retry => fetch(ajax.url, { method: 'POST', body: fd })


### PR DESCRIPTION
## Summary
- Always request comment creation when accepting a ticket so the work-start note is recorded

## Testing
- `npx eslint gexe-filter.js` *(fails: many existing style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e49a4408328a8ce7b4bd9cac475