### PR TITLE
Use GLPI API for ticket creation

### DIFF
--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -357,6 +357,14 @@
       const data = resp.data || resp;
       if (data && data.ok) {
         close();
+        if (data.ticket_id) {
+          const note = document.createElement('div');
+          note.className = 'gnt-ticket-note';
+          note.textContent = 'Создана заявка №' + data.ticket_id;
+          note.style.cssText = 'position:fixed;top:10px;right:10px;background:#4caf50;color:#fff;padding:10px;z-index:10000;';
+          document.body.appendChild(note);
+          setTimeout(()=>{ note.remove(); }, 5000);
+        }
       } else {
         showSubmitError(data && data.error ? data.error : 'Ошибка создания заявки');
       }


### PR DESCRIPTION
## Summary
- switch ticket creation from direct SQL insert to GLPI REST API
- show ticket ID after successful creation in UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint glpi-new-task.js` *(fails: numerous style errors)*
- `php -l glpi-new-task.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc265ba56083288b4c4a3018cad456