### PR TITLE
fix: retain category filter on status change

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -1069,14 +1069,9 @@
       btn.addEventListener('click', () => {
         $$('.status-filter-btn').forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
-        // при выборе статуса сбрасываем выбранные категории
-        selectedCategories = [];
-        $$('.glpi-cat-chip').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed','false'); });
-        const box = document.getElementById('glpi-categories-inline');
-        const reset = box ? box.querySelector('.glpi-cat-reset') : null;
-        if (reset) reset.hidden = true;
-        localStorage.removeItem('glpi.categories.selected');
-        recalcStatusCounts(); recalcCategoryVisibility(); filterCards();
+        recalcStatusCounts();
+        recalcCategoryVisibility();
+        filterCards();
       });
     });
     const inp = document.getElementById('glpi-unified-search');


### PR DESCRIPTION
## Summary
- prevent status selection from clearing chosen categories

## Testing
- `npx eslint gexe-filter.js` *(fails: 396 problems)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc287bead08328984f7ed416c4eae1