### PR TITLE
Allow mapped users to create GLPI tickets

### DIFF
--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -62,12 +62,15 @@
     const assigneeSel = modal.querySelector('#gnt-assignee');
     assignChk.addEventListener('change', function(){
       assigneeSel.disabled = this.checked;
+      if (this.checked) {
+        assigneeSel.value = '';
+      }
+      updateSubmitState();
     });
     ['#gnt-name','#gnt-content','#gnt-category','#gnt-location','#gnt-assignee'].forEach(function(sel){
       modal.querySelector(sel).addEventListener('input', updateSubmitState);
     });
     modal.querySelector('#gnt-assignee').addEventListener('change', updateSubmitState);
-    modal.querySelector('#gnt-assign-me').addEventListener('change', updateSubmitState);
   }
 
   function lockForm(state){

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -12,6 +12,7 @@ if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/glpi-utils.php';
 require_once __DIR__ . '/includes/glpi-form-data.php';
+require_once __DIR__ . '/includes/glpi-auth-map.php';
 
 add_action('wp_enqueue_scripts', function () {
     // Стили окна создания заявки
@@ -46,11 +47,13 @@ function gexe_create_ticket() {
     }
 
     if (!is_user_logged_in()) {
-        wp_send_json(['ok' => false, 'error' => 'not_logged_in']);
+        wp_send_json(['error' => 'not_logged_in'], 401);
     }
 
-    if (!current_user_can('create_glpi_ticket')) {
-        wp_send_json(['ok' => false, 'error' => 'forbidden'], 403);
+    $wp_uid   = get_current_user_id();
+    $glpi_uid = get_mapped_glpi_user_id($wp_uid);
+    if (!$glpi_uid) {
+        wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
     }
 
     $payload_raw = isset($_POST['payload']) ? stripslashes((string)$_POST['payload']) : '';
@@ -62,13 +65,11 @@ function gexe_create_ticket() {
     $cat_id      = isset($payload['category_id']) ? intval($payload['category_id']) : 0;
     $loc_id      = isset($payload['location_id']) ? intval($payload['location_id']) : 0;
     $assign_me   = !empty($payload['assign_me']);
-    $assignee_id = isset($payload['assignee_id']) ? intval($payload['assignee_id']) : 0;
+    $assignee_wp_id = isset($payload['assignee_id']) ? intval($payload['assignee_id']) : 0;
 
     if ($name === '' || $content === '') {
-        wp_send_json(['ok' => false, 'error' => 'bad_request'], 400);
+        wp_send_json(['error' => 'bad_request'], 400);
     }
-
-    $glpi_uid = gexe_get_current_glpi_uid(); // может быть 0
 
     $input = [
         'name'             => $name,
@@ -81,15 +82,27 @@ function gexe_create_ticket() {
         'type'             => 1,
         'status'           => 1,
     ];
-    if ($assign_me && $glpi_uid > 0) {
-        $input['users_id_recipient'] = $glpi_uid;
-    } elseif ($assignee_id > 0) {
-        $input['users_id_assign'] = $assignee_id;
+    $input['users_id_recipient'] = $glpi_uid;
+
+    $assign_glpi_id = $glpi_uid;
+    if (!$assign_me) {
+        if ($assignee_wp_id > 0) {
+            $assign_glpi_id = get_mapped_glpi_user_id($assignee_wp_id);
+            if (!$assign_glpi_id) {
+                wp_send_json(['error' => 'assignee_not_mapped_to_glpi'], 422);
+            }
+        } else {
+            $assign_glpi_id = null;
+        }
+    }
+    if ($assign_glpi_id) {
+        $input['users_id_assign'] = $assign_glpi_id;
     }
 
     $resp = gexe_glpi_rest_request('ticket_create', 'POST', '/Ticket', [ 'input' => $input ]);
     if (is_wp_error($resp)) {
-        wp_send_json(['ok' => false, 'error' => 'network_error'], 500);
+        gexe_log_action(sprintf('[ticket-create] wp=%d glpi_recipient=%d glpi_assign=%d err="%s"', $wp_uid, $glpi_uid, (int)$assign_glpi_id, $resp->get_error_message()));
+        wp_send_json(['error' => 'glpi_api_failed', 'details' => $resp->get_error_message()], 502);
     }
 
     $code = wp_remote_retrieve_response_code($resp);
@@ -101,6 +114,7 @@ function gexe_create_ticket() {
         } elseif (is_array($body) && isset($body['ticket']['id'])) {
             $ticket_id = intval($body['ticket']['id']);
         }
+        gexe_log_action(sprintf('[ticket-create] wp=%d glpi_recipient=%d glpi_assign=%d id=%d', $wp_uid, $glpi_uid, (int)$assign_glpi_id, $ticket_id));
         wp_send_json([
             'ok'        => true,
             'ticket_id' => $ticket_id
@@ -114,5 +128,7 @@ function gexe_create_ticket() {
     if ($message === '') {
         $message = 'GLPI API error';
     }
-    wp_send_json(['ok' => false, 'error' => $message], $code);
+    gexe_log_action(sprintf('[ticket-create] wp=%d glpi_recipient=%d glpi_assign=%d err="%s"', $wp_uid, $glpi_uid, (int)$assign_glpi_id, $message));
+    $status = ($code >= 400 && $code < 500) ? 400 : 502;
+    wp_send_json(['error' => 'glpi_api_failed', 'details' => $message], $status);
 }

--- a/includes/glpi-form-data.php
+++ b/includes/glpi-form-data.php
@@ -163,21 +163,26 @@ function gexe_get_form_data() {
             }
         }
 
-        // Жёстко заданные исполнители
-        $mapping = [
-            ['glpi_id' => 622, 'name' => 'Сушко Валентин'],
-            ['glpi_id' => 621, 'name' => 'Скомороха Анастасия'],
-            ['glpi_id' => 269, 'name' => 'Смирнов Максим'],
-            ['glpi_id' => 180, 'name' => 'Кузнецов Евгений'],
-            ['glpi_id' => 2,   'name' => 'Куткин Павел'],
-            ['glpi_id' => 632, 'name' => 'Стельмашенко Игнат'],
-            ['glpi_id' => 620, 'name' => 'Нечепорук Александр'],
-        ];
+        // Список возможных исполнителей — WP-пользователи, у которых есть glpi_user_id
         $executors = [];
-        foreach ($mapping as $m) {
+        $users = get_users([
+            'meta_query' => [
+                [
+                    'key'     => 'glpi_user_id',
+                    'value'   => 0,
+                    'compare' => '>',
+                    'type'    => 'NUMERIC',
+                ],
+            ],
+            'number'  => 1000,
+            'orderby' => 'display_name',
+            'order'   => 'ASC',
+            'fields'  => ['ID', 'display_name'],
+        ]);
+        foreach ($users as $u) {
             $executors[] = [
-                'id'   => (int) $m['glpi_id'],
-                'name' => $m['name'],
+                'id'   => (int) $u->ID,
+                'name' => $u->display_name,
             ];
         }
 


### PR DESCRIPTION
## Summary
- Remove `create_glpi_ticket` capability requirement and validate GLPI ID mappings for current user and assignee
- Provide executor dropdown from WP users mapped to GLPI and clear selection when "I am executor" is checked

## Testing
- `php -l glpi-new-task.php`
- `php -l includes/glpi-form-data.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2b8cefe483289be8af39b3c5eba5