### PR TITLE
Use glpi_user_key to resolve GLPI user ids

### DIFF
--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -24,7 +24,7 @@ add_action('wp_enqueue_scripts', function () {
 function gexe_can_touch_glpi_ticket($ticket_id) {
     if (!is_user_logged_in()) return false;
 
-    $glpi_uid = gexe_get_current_glpi_uid();
+    $glpi_uid = gexe_get_current_glpi_user_id(get_current_user_id());
     if ($glpi_uid <= 0) return false;
 
     global $glpi_db;
@@ -501,7 +501,7 @@ function gexe_glpi_ticket_accept_sql() {
         wp_send_json(['error' => 'not_logged_in'], 401);
     }
 
-    $author_glpi = gexe_get_current_glpi_uid();
+    $author_glpi = gexe_get_current_glpi_user_id(get_current_user_id());
     if ($author_glpi <= 0) {
         gexe_log_action('[accept.sql] result=fail code=no_glpi_id');
         wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
@@ -647,7 +647,7 @@ function gexe_refresh_actions_nonce() {
         gexe_log_action('[actions.nonce] result=fail code=not_logged_in');
         wp_send_json(['error' => 'not_logged_in'], 401);
     }
-    if (gexe_get_current_glpi_uid() <= 0) {
+    if (gexe_get_current_glpi_user_id(get_current_user_id()) <= 0) {
         gexe_log_action('[actions.nonce] result=fail code=no_glpi_id');
         wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
     }
@@ -664,7 +664,7 @@ function gexe_glpi_comment_add() {
         gexe_log_action('[comment.sql] result=fail code=not_logged_in');
         wp_send_json(['error' => 'not_logged_in'], 401);
     }
-    $author_glpi = gexe_get_current_glpi_uid();
+    $author_glpi = gexe_get_current_glpi_user_id(get_current_user_id());
     if ($author_glpi <= 0) {
         gexe_log_action('[comment.sql] result=fail code=no_glpi_id');
         wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -51,7 +51,7 @@ function gexe_create_ticket() {
     }
 
     $wp_uid   = get_current_user_id();
-    $glpi_uid = get_mapped_glpi_user_id($wp_uid);
+    $glpi_uid = gexe_get_current_glpi_user_id($wp_uid);
     if (!$glpi_uid) {
         wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
     }
@@ -87,7 +87,7 @@ function gexe_create_ticket() {
     $assign_glpi_id = $glpi_uid;
     if (!$assign_me) {
         if ($assignee_wp_id > 0) {
-            $assign_glpi_id = get_mapped_glpi_user_id($assignee_wp_id);
+            $assign_glpi_id = gexe_get_current_glpi_user_id($assignee_wp_id);
             if (!$assign_glpi_id) {
                 wp_send_json(['error' => 'assignee_not_mapped_to_glpi'], 422);
             }

--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -16,7 +16,7 @@ function gexe_glpi_ticket_resolve() {
         gexe_log_action('[resolve.sql] ticket=' . $ticket_id . ' result=fail code=not_logged_in');
         wp_send_json(['error' => 'not_logged_in'], 401);
     }
-    $author_glpi = gexe_get_current_glpi_uid();
+    $author_glpi = gexe_get_current_glpi_user_id(get_current_user_id());
     if ($author_glpi <= 0) {
         gexe_log_action('[resolve.sql] ticket=' . $ticket_id . ' result=fail code=no_glpi_id');
         wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);

--- a/includes/glpi-auth-map.php
+++ b/includes/glpi-auth-map.php
@@ -1,9 +1,11 @@
 <?php
+require_once __DIR__ . '/../glpi-utils.php';
+
 /**
  * Map WordPress users to GLPI user identifiers.
  *
- * The mapping is stored in user meta `glpi_user_id`. The function caches
- * results in-memory to avoid repeated lookups during a single request.
+ * Uses {@see gexe_get_current_glpi_user_id()} for the actual mapping and
+ * caches results in-memory to avoid repeated lookups during a single request.
  */
 function get_mapped_glpi_user_id($wp_user_id) {
     static $cache = [];
@@ -14,8 +16,7 @@ function get_mapped_glpi_user_id($wp_user_id) {
     if (array_key_exists($wp_user_id, $cache)) {
         return $cache[$wp_user_id];
     }
-    $mapped = get_user_meta($wp_user_id, 'glpi_user_id', true);
-    $mapped = $mapped !== '' ? (int) $mapped : null;
+    $mapped = gexe_get_current_glpi_user_id($wp_user_id);
     $cache[$wp_user_id] = $mapped > 0 ? $mapped : null;
     return $cache[$wp_user_id];
 }


### PR DESCRIPTION
## Summary
- add `gexe_get_current_glpi_user_id` helper that maps `glpi_user_key` to a GLPI user id and caches numeric values
- use the helper in ticket creation, comments, acceptance and resolution handlers to ensure a valid GLPI id
- update auth mapping to rely on the new helper

## Testing
- `php -l glpi-utils.php`
- `php -l includes/glpi-auth-map.php`
- `php -l glpi-new-task.php`
- `php -l glpi-modal-actions.php`
- `php -l glpi-solve.php`
- `npm test` *(fails: "no test specified")*
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68bcb6005e04832888cee4267e221668