### PR TITLE
Improve GLPI comment and action handling with SQL and UI feedback

### DIFF
--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -9,7 +9,7 @@ function gexe_glpi_ticket_resolve() {
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     if ($ticket_id <= 0) {
-        wp_send_json(['error' => 'bad_ticket'], 422);
+        wp_send_json(['error' => 'ticket_not_found'], 404);
     }
 
     if (!is_user_logged_in()) {
@@ -22,37 +22,49 @@ function gexe_glpi_ticket_resolve() {
         wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
     }
 
-    $solution_text = isset($_POST['solution_text']) ? sanitize_textarea_field((string) $_POST['solution_text']) : '';
     $status        = (int) get_option('glpi_solved_status', 6);
+    $solution_text = isset($_POST['solution_text']) ? sanitize_textarea_field((string) $_POST['solution_text']) : 'Завершено';
 
-    $res = set_ticket_status_sql($ticket_id, $status, $author_glpi);
-    if (!$res['ok']) {
-        if (($res['code'] ?? '') === 'SQL_ERROR') {
-            gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $res['message'] ?? ''));
-            wp_send_json(['error' => 'sql_error', 'details' => mb_substr($res['message'] ?? '', 0, 200)], 500);
-        }
-        wp_send_json(['error' => $res['code'] ?? 'error', 'message' => $res['message'] ?? ''], 422);
+    global $glpi_db;
+    $exists = $glpi_db->get_var($glpi_db->prepare('SELECT 1 FROM glpi_tickets WHERE id=%d', $ticket_id));
+    if (!$exists) {
+        gexe_log_action('[resolve.sql] ticket=' . $ticket_id . ' result=fail code=ticket_not_found');
+        wp_send_json(['error' => 'ticket_not_found'], 404);
     }
 
-    $followup_id = 0;
-    if ($solution_text !== '') {
-        $f = gexe_add_followup_sql($ticket_id, $solution_text, $author_glpi);
-        if (!$f['ok']) {
-            if (($f['code'] ?? '') === 'SQL_ERROR') {
-                gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $f['message'] ?? ''));
-                wp_send_json(['error' => 'sql_error', 'details' => mb_substr($f['message'] ?? '', 0, 200)], 500);
-            }
-            wp_send_json(['error' => $f['code'] ?? 'error', 'message' => $f['message'] ?? ''], 422);
-        }
-        $followup_id = $f['followup_id'] ?? 0;
+    $glpi_db->query('START TRANSACTION');
+    $sql = $glpi_db->prepare('UPDATE glpi_tickets SET status=%d, users_id_lastupdater=%d, date_mod=NOW() WHERE id=%d', $status, $author_glpi, $ticket_id);
+    if (!$glpi_db->query($sql)) {
+        $err = $glpi_db->last_error;
+        $glpi_db->query('ROLLBACK');
+        gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $err));
+        wp_send_json(['error' => 'sql_error', 'details' => mb_substr($err, 0, 200)], 500);
     }
 
+    $f = gexe_add_followup_sql($ticket_id, $solution_text, $author_glpi);
+    if (!$f['ok']) {
+        $glpi_db->query('ROLLBACK');
+        if (($f['code'] ?? '') === 'SQL_ERROR') {
+            gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $f['message'] ?? ''));
+            wp_send_json(['error' => 'sql_error', 'details' => mb_substr($f['message'] ?? '', 0, 200)], 500);
+        }
+        wp_send_json(['error' => $f['code'] ?? 'error'], 422);
+    }
+    $followup = [
+        'id'       => (int) ($f['followup_id'] ?? 0),
+        'items_id' => $ticket_id,
+        'users_id' => $author_glpi,
+        'content'  => wp_kses_post($solution_text),
+        'date'     => date('c'),
+    ];
+
+    $glpi_db->query('COMMIT');
     gexe_clear_comments_cache($ticket_id);
-    gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d followup=%d status=%d result=ok', $ticket_id, $author_glpi, $followup_id, $status));
+    gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d followup=%d status=%d result=ok', $ticket_id, $author_glpi, $followup['id'], $status));
     wp_send_json([
-        'ok'          => true,
-        'ticket_id'   => $ticket_id,
-        'status'      => $status,
-        'followup_id' => $followup_id,
+        'ok'        => true,
+        'ticket_id' => $ticket_id,
+        'status'    => $status,
+        'followup'  => $followup,
     ]);
 }


### PR DESCRIPTION
## Summary
- add robust SQL endpoint for posting comments with detailed responses
- handle "Принято в работу" and "Завершить" via SQL with clear JSON feedback
- update front-end to show toasts and refresh comments without phantom entries

## Testing
- `php -l glpi-modal-actions.php`
- `php -l glpi-solve.php`
- `npx eslint gexe-filter.js` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb69ac5d88328aba11074f8910e19