### PR TITLE
Improve status filter reset and search UX

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -100,8 +100,10 @@ body {
  .glpi-newfilter-block.active .status-count{color:#111827;}
  .glpi-status-block.active .status-label,
  .glpi-newfilter-block.active .status-label{color:#111827;opacity:1;font-weight:700;}
- .glpi-search-block{display:flex;flex-direction:column;}
- .glpi-search-input{all:unset;width:100%;max-width:340px;box-sizing:border-box;background:#1e293b!important;color:#f8fafc!important;padding:10px 14px;border:1px solid #334155;border-radius:6px;font-size:14px;}
+.glpi-search-block{display:flex;flex-direction:column;position:relative;}
+.glpi-search-input{all:unset;width:100%;max-width:340px;box-sizing:border-box;background:#1e293b!important;color:#f8fafc!important;padding:10px 34px 10px 14px;border:1px solid #334155;border-radius:6px;font-size:14px;}
+.gexe-search-clear{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:transparent;border:0;color:#94a3b8;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;}
+.gexe-search-clear:hover{color:#f1f5f9;}
  .glpi-search-input::placeholder{color:#64748b;}
 .glpi-search-input:focus{outline:none;border-color:#facc15;box-shadow:0 0 0 2px rgba(250,204,21,.3);}
 .gexe-greeting{color:#facc15;font-weight:700;margin-bottom:12px;}
@@ -141,6 +143,14 @@ body {
   .glpi-header-center{overflow-x:auto;}
   .glpi-header-right{justify-content:space-between;}
   .glpi-search-input{max-width:100%;}
+}
+
+@media (max-width:480px){
+  .glpi-header-center{overflow-x:visible;}
+  .glpi-status-blocks{flex-wrap:wrap;gap:6px;}
+  .glpi-status-block{min-width:auto;flex:1 1 auto;padding:6px 10px;min-height:40px;}
+  .glpi-status-block .status-count{font-size:20px;}
+  .glpi-status-block .status-label{margin-top:4px;font-size:12px;}
 }
 
 /* Выпадающие (общие) */

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -163,6 +163,7 @@ function gexe_cat_slug($leaf) {
       <div class="glpi-header-right">
         <div class="glpi-search-block">
           <input type="text" id="glpi-unified-search" class="glpi-search-input" placeholder="Поиск...">
+          <button type="button" class="gexe-search-clear" aria-label="Очистить поиск" hidden>&times;</button>
         </div>
         <button type="button" class="glpi-newtask-btn"><i class="fa-regular fa-file-lines"></i> Новая заявка</button>
       </div>


### PR DESCRIPTION
## Summary
- reset categories when re-clicking an active status
- add clear button and ESC handler to search field
- tweak mobile layout for status buttons

## Testing
- `npx eslint gexe-filter.js | head -n 20`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb8aea89c8328a71a8523db19eeca