### PR TITLE
Handle attachment-only comments and wrap long ticket titles

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -51,7 +51,23 @@ body {
 .glpi-card:hover { box-shadow: 0 0 12px 2px #3b82f6; transform: translateY(-2px); }
 
 .glpi-card-header { display: flex; justify-content: space-between; align-items: flex-start; padding-top: 28px; margin-bottom: 12px; }
-.glpi-topic { color: #fff; font-weight: 700; font-size: 15px; line-height: 1.2; text-decoration: none; max-width: 80%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; }
+.glpi-topic {
+  color: #fff;
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 1.2;
+  text-decoration: none;
+  flex: 1 1 auto;
+  margin-right: 8px;
+  max-width: 100%;
+  overflow: visible;
+  white-space: normal;
+  word-break: break-word;
+  display: block;
+}
+@media (max-width:576px){
+  .glpi-topic{font-size:14px;}
+}
 .glpi-ticket-id { font-size: 13px; color: #64748b; }
 .glpi-card-body { font-size: 14px; color: #cbd5e1; line-height: 1.4; margin-bottom: 12px; max-height: 2.8em; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -609,12 +609,32 @@
       meta.appendChild(author); meta.appendChild(date);
       const text = document.createElement('div');
       text.className = 'text';
-      String(f.content || '').split(/\n+/).map(s => s.trim()).filter(Boolean).forEach(line => {
+      const raw = String(f.content || '').trim();
+      if (raw) {
+        raw.split(/\n+/).map(s => s.trim()).filter(Boolean).forEach(line => {
+          const p = document.createElement('p');
+          p.className = 'glpi-txt';
+          p.textContent = line;
+          text.appendChild(p);
+        });
+      } else if (Array.isArray(f.documents) && f.documents.length) {
         const p = document.createElement('p');
         p.className = 'glpi-txt';
-        p.textContent = line;
+        const base = (window.glpiAjax && glpiAjax.webBase ? glpiAjax.webBase.replace(/\/$/, '') : '');
+        const pref = f.documents.length > 1 ? 'Приложены документы: ' : 'Приложен документ: ';
+        p.append(document.createTextNode(pref));
+        f.documents.forEach((d, idx) => {
+          const a = document.createElement('a');
+          const ext = d.extension ? ' ' + d.extension : '';
+          a.textContent = 'документ' + ext;
+          a.href = base + '/front/document.send.php?docid=' + d.document_id + '&tickets_id=' + ticketId;
+          a.target = '_blank';
+          a.rel = 'noopener';
+          p.appendChild(a);
+          if (idx < f.documents.length - 1) p.appendChild(document.createTextNode(', '));
+        });
         text.appendChild(p);
-      });
+      }
       wrap.appendChild(meta); wrap.appendChild(text);
       box.insertBefore(wrap, box.firstChild);
       updateAgeFooters();

--- a/glpi-settings.php
+++ b/glpi-settings.php
@@ -8,6 +8,7 @@ add_action('admin_menu', function () {
 
 add_action('admin_init', function () {
     register_setting('gexe_glpi', 'glpi_api_base');
+    register_setting('gexe_glpi', 'glpi_web_base');
     register_setting('gexe_glpi', 'glpi_app_token');
     register_setting('gexe_glpi', 'glpi_user_token');
     register_setting('gexe_glpi', 'glpi_solved_status');
@@ -19,6 +20,7 @@ add_action('admin_init', function () {
     }, 'gexe-glpi');
 
     add_settings_field('glpi_api_base', 'API Base URL', 'gexe_glpi_field_api_base', 'gexe-glpi', 'gexe_glpi_main');
+    add_settings_field('glpi_web_base', 'Web Base URL', 'gexe_glpi_field_web_base', 'gexe-glpi', 'gexe_glpi_main');
     add_settings_field('glpi_app_token', 'Application Token', 'gexe_glpi_field_app_token', 'gexe-glpi', 'gexe_glpi_main');
     add_settings_field('glpi_user_token', 'User Token', 'gexe_glpi_field_user_token', 'gexe-glpi', 'gexe_glpi_main');
     add_settings_field('glpi_solved_status', 'Solved Status', 'gexe_glpi_field_solved_status', 'gexe-glpi', 'gexe_glpi_main');
@@ -29,6 +31,10 @@ add_action('admin_init', function () {
 function gexe_glpi_field_api_base() {
     $v = esc_attr(get_option('glpi_api_base', ''));
     echo '<input type="text" name="glpi_api_base" value="' . $v . '" class="regular-text" />';
+}
+function gexe_glpi_field_web_base() {
+    $v = esc_attr(get_option('glpi_web_base', ''));
+    echo '<input type="text" name="glpi_web_base" value="' . $v . '" class="regular-text" />';
 }
 function gexe_glpi_field_app_token() {
     $v = esc_attr(get_option('glpi_app_token', ''));

--- a/glpi-utils.php
+++ b/glpi-utils.php
@@ -103,6 +103,25 @@ function gexe_glpi_log($action, $url, $response, $start_time) {
 }
 
 /**
+ * Determine base URL of GLPI web interface for building document links.
+ *
+ * When the `glpi_web_base` option is not set, attempts to derive it from
+ * `glpi_api_base` by stripping a trailing `/apirest.php` segment.
+ *
+ * @return string Base URL without trailing slash.
+ */
+function gexe_glpi_web_base() {
+    $base = trim((string) get_option('glpi_web_base', ''));
+    if ($base === '') {
+        $api = trim((string) get_option('glpi_api_base', ''));
+        if ($api !== '') {
+            $base = preg_replace('~/apirest\.php$~', '', $api);
+        }
+    }
+    return rtrim($base, '/');
+}
+
+/**
  * Check if a column exists in a GLPI table.
  * Result is cached in-memory and via WordPress transient for 1 hour.
  */


### PR DESCRIPTION
## Summary
- Allow ticket subjects to wrap on small screens instead of truncating.
- Add `glpi_web_base` setting and helper to build links to documents.
- Fetch followup attachments and render document links when comment text is empty.
- Support rendering attachment links when inserting followups in JS.

## Testing
- `php -l glpi-utils.php`
- `php -l glpi-settings.php`
- `php -l glpi-modal-actions.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbdbc92b8832891f6e50073836c97