### PR TITLE
Improve front-end error handling for GLPI actions

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -22,6 +22,7 @@
     ticket_not_found: 'Заявка не найдена.',
     sql_error: details => 'Ошибка записи в GLPI. Код: ' + (details || '') + '.',
     empty_comment: 'Введите комментарий',
+    bad_response: 'Не удалось обработать ответ сервера.',
     network_error: 'Ошибка сети',
   };
   function showError(code, details, status) {
@@ -156,7 +157,7 @@
       const res = await fetch(ajax.url, { method: 'POST', body: fd });
       await debugResponse(res);
       let data = null;
-      try { data = await res.clone().json(); } catch(e) {}
+      try { data = await res.clone().json(); } catch (e) {}
       if (res.status === 403 && data && data.error === 'nonce_failed' && !retry) {
         await refreshActionsNonce();
         fd.set('nonce', ajax.nonce);
@@ -165,14 +166,21 @@
       return { res, data };
     };
 
-    send(false).then(({res, data}) => {
+    send(false).then(({ res, data }) => {
       lockAction(ticketId, 'accept', false);
-      if (!res.ok || !data || !data.ok) {
-        setActionLoading(btn, false);
-        showError(data && data.error, data && data.details, res.status);
+      setActionLoading(btn, false);
+      if (!res.ok) {
+        showError(data ? data.error : 'bad_response', data && data.details, res.status);
         return;
       }
-      setActionLoading(btn, false);
+      if (!data) {
+        showError('bad_response', null, res.status);
+        return;
+      }
+      if (!data.ok) {
+        showError(data.error, data.details, res.status);
+        return;
+      }
       btn.innerHTML = '<i class="fa-solid fa-check"></i>';
       const cardEl = document.querySelector('.glpi-card[data-ticket-id="'+ticketId+'"]');
       if (cardEl) {
@@ -676,13 +684,14 @@
     if (!cmntModal) return;
     const id  = Number(cmntModal.getAttribute('data-ticket-id') || '0');
     const txtEl = document.querySelector('#gexe-cmnt-text');
+    const btn = $('#gexe-cmnt-send', cmntModal);
     const txt = (txtEl && txtEl.value ? txtEl.value : '').trim();
-    if (!id || !txt) return;
-    closeCommentModal();
+    if (!id || !txt || !btn) return;
     const url = window.glpiAjax && glpiAjax.url;
     const nonce = window.glpiAjax && glpiAjax.nonce;
     if (!url || !nonce) return;
     lockAction(id, 'comment', true);
+    setActionLoading(btn, true);
     const fd = new FormData();
     fd.append('action', 'glpi_comment_add');
     fd.append('nonce', nonce);
@@ -693,11 +702,19 @@
       const res = await fetch(url, { method: 'POST', body: fd });
       await debugResponse(res);
       let data = null;
-      try { data = await res.clone().json(); } catch(e) { console.error(e); }
+      try { data = await res.clone().json(); } catch (e) {}
       lockAction(id, 'comment', false);
-      if (!res.ok || !data || !data.ok) {
-        const code = data && data.error;
-        showError(code, data && data.details, res.status);
+      setActionLoading(btn, false);
+      if (!res.ok) {
+        showError(data ? data.error : 'bad_response', data && data.details, res.status);
+        return;
+      }
+      if (!data) {
+        showError('bad_response', null, res.status);
+        return;
+      }
+      if (!data.ok) {
+        showError(data.error, data.details, res.status);
         return;
       }
       if (txtEl) txtEl.value = '';
@@ -706,6 +723,7 @@
       if (window.glpiToast) glpiToast('Комментарий отправлен');
     } catch (err) {
       lockAction(id, 'comment', false);
+      setActionLoading(btn, false);
       showError('network_error');
     }
   }
@@ -759,11 +777,19 @@
       const res = await fetch(glpiAjax.url, { method: 'POST', body: fd });
       await debugResponse(res);
       let data = null;
-      try { data = await res.clone().json(); } catch(e) {}
+      try { data = await res.clone().json(); } catch (e) {}
       lockAction(id, 'done', false);
       if (btn) setActionLoading(btn, false);
-      if (!res.ok || !data || !data.ok) {
-        showError(data && data.error, data && data.details, res.status);
+      if (!res.ok) {
+        showError(data ? data.error : 'bad_response', data && data.details, res.status);
+        return;
+      }
+      if (!data) {
+        showError('bad_response', null, res.status);
+        return;
+      }
+      if (!data.ok) {
+        showError(data.error, data.details, res.status);
         return;
       }
       closeDoneModal();


### PR DESCRIPTION
## Summary
- handle invalid or empty AJAX responses for ticket actions
- show loading state and surface errors on comment, accept and done requests

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbf157b988328a4d704073825963d