### PR TITLE
Sanitize ticket creation dates

### DIFF
--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -82,6 +82,12 @@ function gexe_create_ticket() {
         'type'             => 1,
         'status'           => 1,
     ];
+    $due_raw = isset($payload['due_date']) ? sanitize_text_field($payload['due_date']) : '';
+    $due_iso = gexe_iso_datetime($due_raw);
+    if (null !== $due_iso) {
+        $input['due_date'] = $due_iso;
+    }
+
     $input['users_id_recipient'] = $glpi_uid;
 
     $assign_glpi_id = $glpi_uid;

--- a/glpi-utils.php
+++ b/glpi-utils.php
@@ -122,6 +122,28 @@ function gexe_glpi_web_base() {
 }
 
 /**
+ * Normalize a date/time string to ISO-8601 with timezone.
+ *
+ * Returns null when the value is empty, equals "0000-00-00 00:00:00" or
+ * cannot be parsed by DateTime.
+ *
+ * @param string $raw Original date/time string.
+ * @return string|null ISO-8601 formatted string or null on failure.
+ */
+function gexe_iso_datetime($raw) {
+    $raw = trim((string) $raw);
+    if ($raw === '' || $raw === '0000-00-00 00:00:00') {
+        return null;
+    }
+    try {
+        $dt = new DateTime($raw);
+        return $dt->format('c');
+    } catch (Exception $e) {
+        return null;
+    }
+}
+
+/**
  * Check if a column exists in a GLPI table.
  * Result is cached in-memory and via WordPress transient for 1 hour.
  */


### PR DESCRIPTION
## Summary
- Normalize user-provided dates to ISO-8601
- Convert optional ticket due_date to ISO-8601 before API submission

## Testing
- `php -l glpi-new-task.php`
- `php -l glpi-utils.php`
- `npm test` *(fails: no test specified)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0be449c832889eaf343bb7b057b