### PR TITLE
chore: remove server logging and add error helpers

### DIFF
--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -7,24 +7,20 @@ add_action('wp_ajax_glpi_ticket_resolve', 'gexe_glpi_ticket_resolve');
 function gexe_glpi_ticket_resolve() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', '_ajax_nonce', false)) {
-        error_log('[resolve] nonce_failed ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'nonce_failed'], 403);
+        gexe_ajax_error('NONCE_EXPIRED', 'Сессия истекла', 403);
     }
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     if ($ticket_id <= 0) {
-        error_log('[resolve] ticket_not_found ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'ticket_not_found'], 404);
+        gexe_ajax_error('INVALID_INPUT', 'Тикет не найден', 404);
     }
 
     if (!is_user_logged_in()) {
-        error_log('[resolve] not_logged_in ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'not_logged_in'], 401);
+        gexe_ajax_error('NO_PERMISSION', 'Требуется вход', 401);
     }
     $author_glpi = gexe_get_current_glpi_user_id($wp_uid);
     if ($author_glpi <= 0) {
-        error_log('[resolve] no_glpi_id_for_current_user ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
+        gexe_ajax_error('NO_GLPI_USER', 'Не найден GLPI ID', 422);
     }
 
     $status        = (int) get_option('glpi_solved_status', 6);
@@ -33,8 +29,7 @@ function gexe_glpi_ticket_resolve() {
     global $glpi_db;
     $exists = $glpi_db->get_var($glpi_db->prepare('SELECT 1 FROM glpi_tickets WHERE id=%d', $ticket_id));
     if (!$exists) {
-        error_log('[resolve] ticket_not_found ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
-        wp_send_json(['error' => 'ticket_not_found'], 404);
+        gexe_ajax_error('INVALID_INPUT', 'Тикет не найден', 404);
     }
 
     $glpi_db->query('START TRANSACTION');
@@ -43,8 +38,7 @@ function gexe_glpi_ticket_resolve() {
         $err = $glpi_db->last_error;
         $glpi_db->query('ROLLBACK');
         gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $err));
-        error_log('[resolve] sql_error status_update_failed ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi . ' sql=' . $err);
-        wp_send_json(['error' => 'sql_error', 'details' => 'status_update_failed'], 500);
+        gexe_ajax_error('SQL_OP_FAILED', 'Не удалось обновить статус', 500);
     }
 
     $f = gexe_add_followup_sql($ticket_id, $solution_text, $author_glpi);
@@ -52,11 +46,9 @@ function gexe_glpi_ticket_resolve() {
         $glpi_db->query('ROLLBACK');
         if (($f['code'] ?? '') === 'SQL_ERROR') {
             gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $f['message'] ?? ''));
-            error_log('[resolve] sql_error followup_insert_failed ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi . ' sql=' . ($f['message'] ?? ''));
-            wp_send_json(['error' => 'sql_error', 'details' => 'followup_insert_failed'], 500);
+            gexe_ajax_error('SQL_OP_FAILED', 'Не удалось добавить комментарий', 500);
         }
-        error_log('[resolve] ' . ($f['code'] ?? 'error') . ' ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
-        wp_send_json(['error' => $f['code'] ?? 'error'], 422);
+        gexe_ajax_error('SQL_OP_FAILED', 'Не удалось завершить тикет', 422);
     }
     $followup = [
         'id'       => (int) ($f['followup_id'] ?? 0),
@@ -69,9 +61,9 @@ function gexe_glpi_ticket_resolve() {
     $glpi_db->query('COMMIT');
     gexe_clear_comments_cache($ticket_id);
     gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d followup=%d status=%d result=ok', $ticket_id, $author_glpi, $followup['id'], $status));
-    wp_send_json(['ok' => true, 'payload' => [
+    gexe_ajax_success([
         'ticket_id' => $ticket_id,
         'status'    => $status,
         'followup'  => $followup,
-    ]]);
+    ]);
 }

--- a/glpi-utils.php
+++ b/glpi-utils.php
@@ -64,42 +64,37 @@ function gexe_get_current_glpi_uid() {
 }
 
 /**
- * Log GLPI REST actions into uploads/glpi-plugin/logs/actions.log.
+ * Stub for legacy logging – no-op.
  */
 function gexe_glpi_log($action, $url, $response, $start_time) {
-    $uploads = wp_upload_dir();
-    $dir     = trailingslashit($uploads['basedir']) . 'glpi-plugin/logs';
-    if (!is_dir($dir)) {
-        wp_mkdir_p($dir);
-    }
+    // Logging disabled
+}
 
-    $elapsed = (int) round((microtime(true) - $start_time) * 1000);
-    if (is_wp_error($response)) {
-        $line = sprintf(
-            "%s\t%s\t0\t%dms\t%s\n",
-            $action,
-            $url,
-            $elapsed,
-            $response->get_error_message()
-        );
-    } else {
-        $code = wp_remote_retrieve_response_code($response);
-        $body = wp_remote_retrieve_body($response);
-        $short = mb_substr(trim($body), 0, 200);
-        $line = sprintf(
-            "%s\t%s\t%d\t%dms\t%s\n",
-            $action,
-            $url,
-            $code,
-            $elapsed,
-            $short
-        );
-        if ($code >= 400) {
-            $line .= $body . "\n"; // full body for errors
-        }
-    }
+/**
+ * Send unified AJAX success response.
+ */
+function gexe_ajax_success(array $data = [], $status = 200) {
+    wp_send_json([
+        'success' => true,
+        'data'    => $data,
+    ], $status);
+}
 
-    file_put_contents($dir . '/actions.log', $line, FILE_APPEND);
+/**
+ * Send unified AJAX error response.
+ */
+function gexe_ajax_error($code, $message, $status = 400, $details = null) {
+    $error = [
+        'code'    => (string) $code,
+        'message' => (string) $message,
+    ];
+    if ($details !== null) {
+        $error['details'] = $details;
+    }
+    wp_send_json([
+        'success' => false,
+        'error'   => $error,
+    ], $status);
 }
 
 /**

--- a/includes/logger.php
+++ b/includes/logger.php
@@ -1,29 +1,7 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-/**
- * Simple file logger for GLPI actions.
- */
+// Logging disabled
 function gexe_log_action($message) {
-    $upload = wp_upload_dir();
-    $dir = trailingslashit($upload['basedir']) . 'glpi-plugin/logs';
-    if (!is_dir($dir)) {
-        wp_mkdir_p($dir);
-    }
-    $file = $dir . '/actions.log';
-    $line = '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
-    file_put_contents($file, $line, FILE_APPEND);
-}
-
-// AJAX: log client-side errors into actions.log
-add_action('wp_ajax_gexe_log_client_error', 'gexe_log_client_error');
-function gexe_log_client_error() {
-    if (!check_ajax_referer('gexe_form_data', 'nonce', false)) {
-        wp_send_json_error(['code' => 'AJAX_FORBIDDEN'], 403);
-    }
-    $msg = isset($_POST['message']) ? sanitize_text_field(wp_unslash($_POST['message'])) : '';
-    if ($msg !== '') {
-        gexe_log_action('[client-error] ' . $msg);
-    }
-    wp_send_json_success();
+    // no-op
 }


### PR DESCRIPTION
## Summary
- disable server-side logging
- add unified AJAX response helpers
- adopt new error format in ticket resolve handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc8ba17888328a9e7f6b441f1b5d6