### PR TITLE
feat: add frontend preflight guards

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -182,6 +182,7 @@ body {
 .gexe-action-btn{ background:#0b1220; color:#e5e7eb; border:1px solid #243045; border-radius:8px; padding:8px 10px; cursor:pointer; box-shadow:0 2px 6px rgba(0,0,0,.25); }
 .gexe-action-btn:hover{ background:#111b2e; }
 .gexe-action-btn:disabled{ background:#1e293b; color:#64748b; border-color:#334155; cursor:not-allowed; box-shadow:none; }
+.gexe-preflight-guard{ color:#facc15; display:inline-flex; align-items:center; margin-left:4px; }
 
 /* ======= Модалка просмотра ======= */
 .gexe-modal{ position:fixed; inset:0; display:none; z-index:10000; }

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -550,8 +550,8 @@ add_action('wp_ajax_glpi_ticket_accept_sql', 'gexe_glpi_ticket_accept_sql');
 function gexe_glpi_ticket_accept_sql() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
-        error_log('[accept] nonce_failed ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'nonce_failed'], 403);
+        error_log('[accept] nonce_expired ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'nonce_expired'], 403);
     }
 
     if (!is_user_logged_in()) {
@@ -694,8 +694,8 @@ add_action('wp_ajax_glpi_comment_add', 'gexe_glpi_comment_add');
 function gexe_glpi_comment_add() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
-        error_log('[comment] nonce_failed ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'nonce_failed'], 403);
+        error_log('[comment] nonce_expired ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'nonce_expired'], 403);
     }
     if (!is_user_logged_in()) {
         error_log('[comment] not_logged_in ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');

--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -7,8 +7,8 @@ add_action('wp_ajax_glpi_ticket_resolve', 'gexe_glpi_ticket_resolve');
 function gexe_glpi_ticket_resolve() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', '_ajax_nonce', false)) {
-        error_log('[resolve] nonce_failed ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'nonce_failed'], 403);
+        error_log('[resolve] nonce_expired ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'nonce_expired'], 403);
     }
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;


### PR DESCRIPTION
## Summary
- add client-side preflight guards for GLPI actions
- surface nonce expiration and retry requests automatically
- return NONCE_EXPIRED from backend when nonce fails

## Testing
- `php -l glpi-modal-actions.php`
- `php -l glpi-solve.php`
- `npm test` *(fails: Error: no test specified)*
- `npx eslint gexe-filter.js` *(fails: Unexpected string concatenation, max-len, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc8c6599c8328a85aea8f4e50eb25