### PR TITLE
Handle duplicate acceptance and improve UI feedback

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -182,6 +182,8 @@ body {
 .gexe-action-btn{ background:#0b1220; color:#e5e7eb; border:1px solid #243045; border-radius:8px; padding:8px 10px; cursor:pointer; box-shadow:0 2px 6px rgba(0,0,0,.25); }
 .gexe-action-btn:hover{ background:#111b2e; }
 .gexe-action-btn:disabled{ background:#1e293b; color:#64748b; border-color:#334155; cursor:not-allowed; box-shadow:none; }
+.gexe-action-btn.is-error{ background:#dc2626; border-color:#b91c1c; color:#fff; }
+.gexe-action-btn.is-error:hover{ background:#b91c1c; }
 
 /* ======= Модалка просмотра ======= */
 .gexe-modal{ position:fixed; inset:0; display:none; z-index:10000; }


### PR DESCRIPTION
## Summary
- Return explicit ALREADY_ACCEPTED, NO_PERMISSION and SQL_OP_FAILED codes from accept endpoint
- Render accept button states: success tooltip, retry on SQL failure, permission notice
- Style error state for action buttons

## Testing
- `php -l glpi-modal-actions.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc8d5cf6c83289e60520dbc20f79d