### PR TITLE
Validate comment modal and standardize SQL comment errors

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -246,6 +246,8 @@ body {
 .gexe-cmnt__close:hover, .gexe-done__close:hover{ color:#f1f5f9; }
 .gexe-cmnt__body, .gexe-done__body{ padding:12px; }
 #gexe-cmnt-text{ width:100%; min-height:80px; resize:vertical; border-radius:8px; border:1px solid #475569; background:#0b1220; color:#e5e7eb; padding:10px; }
+.gexe-cmnt__err{ color:#f87171; font-size:13px; margin-top:4px; }
+.gexe-cmnt__counter{ color:#94a3b8; font-size:12px; margin-bottom:8px; text-align:right; }
 .gexe-cmnt__foot{ padding:12px; border-top:1px solid #334155; }
 #gexe-cmnt-send.glpi-act{background:#475569;border:1px solid #334155;color:#fff;border-radius:10px;font-weight:700;width:100%;display:block}
 #gexe-cmnt-send.glpi-act:hover{background:#334155}
@@ -254,6 +256,8 @@ body {
 
 button.is-loading{position:relative;}
 button.is-loading::after{content:"";position:absolute;top:50%;left:50%;width:12px;height:12px;margin:-6px 0 0 -6px;border:2px solid currentColor;border-top-color:transparent;border-radius:50%;animation:gexe-spin .8s linear infinite;}
+button.is-done{position:relative;color:transparent;}
+button.is-done::after{content:"\f00c";font-family:"Font Awesome 6 Free";font-weight:900;color:#22c55e;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);}
 @keyframes gexe-spin{to{transform:rotate(360deg);}}
 button[disabled]{cursor:not-allowed;opacity:.6;}
 

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -18,11 +18,13 @@
   const ERROR_MAP = {
     not_logged_in: 'Сессия истекла. Войдите в систему.',
     nonce_failed: 'Обновите страницу (просрочен ключ безопасности).',
+    NONCE_EXPIRED: 'Обновите страницу (просрочен ключ безопасности).',
+    NO_PERMISSION: 'Недостаточно прав.',
     no_glpi_id_for_current_user: 'В профиле WP не указан GLPI ID.',
     assignee_not_mapped_to_glpi: 'Выбранный исполнитель не привязан к GLPI.',
     ticket_not_found: 'Заявка не найдена.',
-    sql_error: details => 'Ошибка записи в GLPI. Код: ' + (details || '') + '.',
-    empty_comment: 'Введите комментарий',
+    SQL_OP_FAILED: details => 'Ошибка записи в GLPI. Код: ' + (details || '') + '.',
+    EMPTY_CONTENT: 'Введите комментарий',
     bad_response: 'Не удалось обработать ответ сервера.',
     network_error: 'Ошибка сети',
   };
@@ -718,6 +720,7 @@
   }
 
   /* ========================= МОДАЛКА КОММЕНТАРИЯ ========================= */
+  const MAX_COMMENT_LEN = 4000;
   let cmntModal = null;
   let doneModal = null;
   function ensureCommentModal() {
@@ -732,9 +735,11 @@
           '<button class="gexe-cmnt__close" aria-label="Закрыть"><i class="fa-solid fa-xmark"></i></button>' +
         '</div>' +
         '<div class="gexe-cmnt__body">' +
-          '<textarea id="gexe-cmnt-text" placeholder="Ваш комментарий..." rows="3"></textarea>' +
+          '<textarea id="gexe-cmnt-text" placeholder="Ваш комментарий..." rows="3" maxlength="4000"></textarea>' +
+          '<div id="gexe-cmnt-err" class="gexe-cmnt__err" aria-live="polite"></div>' +
         '</div>' +
         '<div class="gexe-cmnt__foot">' +
+          '<div class="gexe-cmnt__counter"><span id="gexe-cmnt-count">0</span>/4000</div>' +
           '<button id="gexe-cmnt-send" class="glpi-act">Отправить</button>' +
         '</div>' +
       '</div>';
@@ -745,37 +750,65 @@
     const txtArea = $('#gexe-cmnt-text', cmntModal);
     if (sendBtn) sendBtn.disabled = true;
     if (txtArea) {
-      txtArea.addEventListener('input', () => {
-        if (sendBtn) sendBtn.disabled = txtArea.value.trim() === '';
-      });
+      txtArea.addEventListener('input', updateCommentValidation);
     }
-    if (sendBtn) sendBtn.addEventListener('click', sendComment);
+    if (sendBtn) sendBtn.addEventListener('click', () => sendComment(false));
     return cmntModal;
+  }
+  function updateCommentValidation(force) {
+    const txtArea = $('#gexe-cmnt-text', cmntModal);
+    const sendBtn = $('#gexe-cmnt-send', cmntModal);
+    const cntEl = $('#gexe-cmnt-count', cmntModal);
+    const errEl = $('#gexe-cmnt-err', cmntModal);
+    const raw = txtArea && txtArea.value ? txtArea.value : '';
+    const len = raw.length;
+    if (cntEl) cntEl.textContent = String(len);
+    let msg = '';
+    if (len > MAX_COMMENT_LEN) msg = 'Слишком длинный комментарий';
+    else if (force && len === 0) msg = ERROR_MAP.EMPTY_CONTENT;
+    if (errEl) errEl.textContent = msg;
+    if (sendBtn) sendBtn.disabled = len === 0 || len > MAX_COMMENT_LEN;
+    return !msg && len > 0;
+  }
+  function showCommentError(code, details, status) {
+    const errEl = $('#gexe-cmnt-err', cmntModal);
+    let msg;
+    const m = ERROR_MAP[code];
+    if (typeof m === 'function') msg = m(details);
+    else if (typeof m === 'string') msg = m;
+    if (!msg) msg = 'Неизвестная ошибка' + (status ? ' (' + status + ')' : '');
+    if (errEl) errEl.textContent = msg;
+  }
+  function clearCommentError() {
+    const errEl = $('#gexe-cmnt-err', cmntModal);
+    if (errEl) errEl.textContent = '';
   }
   function openCommentModal(title, ticketId) {
     ensureCommentModal();
     $('.gexe-cmnt__title', cmntModal).textContent = title || 'Комментарий';
     cmntModal.setAttribute('data-ticket-id', String(ticketId || 0));
     const ta = $('#gexe-cmnt-text', cmntModal); if (ta) { ta.value = ''; ta.focus(); }
-    const sendBtn = $('#gexe-cmnt-send', cmntModal); if (sendBtn) sendBtn.disabled = true;
+    updateCommentValidation();
     cmntModal.classList.add('is-open'); document.body.classList.add('glpi-modal-open');
   }
   function closeCommentModal() {
     if (!cmntModal) return;
     cmntModal.classList.remove('is-open'); document.body.classList.remove('glpi-modal-open');
   }
-  async function sendComment(){
+  async function sendComment(retried) {
     if (!cmntModal) return;
     const id  = Number(cmntModal.getAttribute('data-ticket-id') || '0');
-    const txtEl = document.querySelector('#gexe-cmnt-text');
+    const txtEl = $('#gexe-cmnt-text', cmntModal);
     const btn = $('#gexe-cmnt-send', cmntModal);
-    const txt = (txtEl && txtEl.value ? txtEl.value : '').trim();
-    if (!id || !txt || !btn) return;
+    if (!id || !txtEl || !btn) return;
+    if (!updateCommentValidation(true)) return;
+    const txt = txtEl.value.trim();
     const url = window.glpiAjax && glpiAjax.url;
     const nonce = window.glpiAjax && glpiAjax.nonce;
     if (!url || !nonce) return;
     lockAction(id, 'comment', true);
     setActionLoading(btn, true);
+    clearCommentError();
     const fd = new FormData();
     fd.append('action', 'glpi_comment_add');
     const nonceKey = glpiAjax.nonce_key || 'nonce';
@@ -793,25 +826,31 @@
       let data = null;
       try { data = await res.clone().json(); }
       catch (e) { try { await res.clone().text(); } catch (e2) {} }
-      if (!res.ok) {
-        showError(data && data.error ? data.error : 'bad_response', data && data.details, res.status);
+      if (!res.ok || !data || !data.ok) {
+        const code = data && data.error ? data.error : 'bad_response';
+        if (code === 'NONCE_EXPIRED' && !retried) {
+          try {
+            await refreshActionsNonce();
+            showNotice('success', 'Обновили доступ');
+            return sendComment(true);
+          } catch (e) {
+            showCommentError('network_error');
+            return;
+          }
+        }
+        showCommentError(code, data && data.details, res.status);
         return;
       }
-      if (!data) {
-        showError('bad_response', null, res.status);
-        return;
-      }
-      if (!data.ok) {
-        showError(data.error, data.details, res.status);
-        return;
-      }
-      if (txtEl) txtEl.value = '';
+      txtEl.value = '';
+      updateCommentValidation();
       insertFollowup(id, data.payload && data.payload.followup);
       refreshTicketMeta(id);
-      showNotice('success','Комментарий отправлен');
+      setActionLoading(btn, false);
+      btn.classList.add('is-done');
+      setTimeout(() => { btn.classList.remove('is-done'); }, 1500);
+      closeCommentModal();
     } catch (err) {
-      if (err && err.name === 'AbortError') showNotice('error','Таймаут запроса');
-      else showError('network_error');
+      showCommentError('network_error');
     } finally {
       clearTimeout(timeoutId);
       lockAction(id, 'comment', false);

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -694,17 +694,17 @@ add_action('wp_ajax_glpi_comment_add', 'gexe_glpi_comment_add');
 function gexe_glpi_comment_add() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
-        error_log('[comment] nonce_failed ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'nonce_failed'], 403);
+        error_log('[comment] nonce_expired ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'NONCE_EXPIRED'], 403);
     }
     if (!is_user_logged_in()) {
-        error_log('[comment] not_logged_in ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'not_logged_in'], 401);
+        error_log('[comment] no_permission ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'NO_PERMISSION'], 403);
     }
     $author_glpi = gexe_get_current_glpi_user_id($wp_uid);
     if ($author_glpi <= 0) {
-        error_log('[comment] no_glpi_id_for_current_user ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
+        error_log('[comment] no_permission ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'NO_PERMISSION'], 403);
     }
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
@@ -714,8 +714,8 @@ function gexe_glpi_comment_add() {
         wp_send_json(['error' => 'ticket_not_found'], 404);
     }
     if ($content === '') {
-        error_log('[comment] empty_comment ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
-        wp_send_json(['error' => 'empty_comment'], 422);
+        error_log('[comment] empty_content ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
+        wp_send_json(['error' => 'EMPTY_CONTENT'], 422);
     }
 
     global $glpi_db;
@@ -730,10 +730,10 @@ function gexe_glpi_comment_add() {
         if (($res['code'] ?? '') === 'SQL_ERROR') {
             gexe_log_action(sprintf('[comment.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $res['message'] ?? ''));
             error_log('[comment] sql_error followup_insert_failed ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi . ' sql=' . ($res['message'] ?? ''));
-            wp_send_json(['error' => 'sql_error', 'details' => 'followup_insert_failed'], 500);
+            wp_send_json(['error' => 'SQL_OP_FAILED', 'details' => 'followup_insert_failed'], 500);
         }
-        error_log('[comment] ' . ($res['code'] ?? 'error') . ' ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
-        wp_send_json(['error' => $res['code'] ?? 'error'], 422);
+        error_log('[comment] no_permission ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
+        wp_send_json(['error' => 'NO_PERMISSION'], 403);
     }
 
     gexe_clear_comments_cache($ticket_id);


### PR DESCRIPTION
## Summary
- add explicit NONCE_EXPIRED, NO_PERMISSION, EMPTY_CONTENT and SQL_OP_FAILED codes for comment SQL endpoint
- enhance comment modal with character counter, inline validation and nonce auto-refresh
- style comment modal errors and submit button "done" state

## Testing
- `npm test` (fails: Error: no test specified)
- `npx eslint gexe-filter.js` (fails: many style violations)
- `php -l glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcc8e1cb388328bd9e499fb4c84667