### PR TITLE
feat: create tickets via SQL only

### DIFF
--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -19,6 +19,10 @@
 .glpi-create-modal .gnt-submit { width: 100%; background: #2563eb; border: 0; color: #fff; padding: 10px 14px; border-radius: 10px; cursor: pointer; display: block; }
 .glpi-create-modal .gnt-submit:disabled { opacity: .7; cursor: default; }
 .glpi-create-modal .gnt-path { margin-top: 4px; font-size: 12px; color: #94a3b8; }
+.glpi-create-modal .gnt-field-error { color:#f87171; font-size:12px; margin-top:4px; }
+.glpi-create-modal .gnt-input.gnt-invalid,
+.glpi-create-modal .gnt-textarea.gnt-invalid,
+.glpi-create-modal .gnt-select.gnt-invalid { border-color:#f87171; }
 @media (max-width: 720px) {
   .glpi-create-modal .gnt-row { grid-template-columns: 1fr; }
 }
@@ -37,8 +41,7 @@
 .gnt-success-modal.open{display:block;}
 .gnt-success-modal .gnt-success-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.55);backdrop-filter:blur(2px);}
 .gnt-success-modal .gnt-success-dialog{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:min(520px,94vw);background:#0f172a;color:#e5e7eb;border-radius:12px;box-shadow:0 20px 60px rgba(0,0,0,.5);padding:24px;text-align:center;}
-.gnt-success-modal .gnt-success-title{font-weight:700;margin-bottom:8px;}
-.gnt-success-modal .gnt-success-text{margin-bottom:20px;}
+.gnt-success-modal .gnt-success-title{font-weight:700;margin-bottom:20px;}
 .gnt-success-modal .gnt-success-actions{display:flex;flex-direction:column;gap:8px;}
 .gnt-success-modal .gnt-success-actions button{padding:10px 14px;border-radius:10px;border:0;cursor:pointer;}
 .gnt-success-modal .gnt-open-ticket{background:#2563eb;color:#fff;}

--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -26,32 +26,40 @@
           <div class="glpi-form-loader" role="status" aria-live="polite" hidden></div>
           <label for="gnt-name" class="gnt-label">Тема</label>
           <input id="gnt-name" type="text" class="gnt-input" />
+          <div id="gnt-name-err" class="gnt-field-error" hidden></div>
           <label for="gnt-content" class="gnt-label">Описание</label>
           <textarea id="gnt-content" class="gnt-textarea"></textarea>
+          <div id="gnt-content-err" class="gnt-field-error" hidden></div>
           <div class="gnt-row">
             <div>
               <label for="gnt-category" class="gnt-label">Категория</label>
               <input id="gnt-category" list="gnt-category-list" class="gnt-input" />
               <datalist id="gnt-category-list"></datalist>
               <div id="gnt-category-path" class="gnt-path"></div>
+              <div id="gnt-category-err" class="gnt-field-error" hidden></div>
             </div>
             <div>
               <label for="gnt-location" class="gnt-label">Местоположение</label>
               <input id="gnt-location" list="gnt-location-list" class="gnt-input" />
               <datalist id="gnt-location-list"></datalist>
               <div id="gnt-location-path" class="gnt-path"></div>
+              <div id="gnt-location-err" class="gnt-field-error" hidden></div>
             </div>
           </div>
+          <label for="gnt-due" class="gnt-label">Срок</label>
+          <input id="gnt-due" type="datetime-local" class="gnt-input" />
+          <div id="gnt-due-err" class="gnt-field-error" hidden></div>
           <div class="gnt-row gnt-assign-row">
             <label class="gnt-check"><input type="checkbox" id="gnt-assign-me" checked /> Я исполнитель</label>
             <div>
               <label for="gnt-assignee" class="gnt-label">Исполнитель</label>
               <select id="gnt-assignee" class="gnt-select" disabled><option value="">—</option></select>
+              <div id="gnt-assignee-err" class="gnt-field-error" hidden></div>
             </div>
           </div>
         </div>
         <div class="gnt-footer">
-          <button type="button" class="gnt-submit" disabled>Создать</button>
+          <button type="button" class="gnt-submit">Создать</button>
         </div>
       </div>
     `;
@@ -67,13 +75,17 @@
       assigneeSel.disabled = this.checked;
       if (this.checked) {
         assigneeSel.value = '';
+        setFieldError('assignee');
       }
-      updateSubmitState();
     });
-    ['#gnt-name','#gnt-content','#gnt-category','#gnt-location','#gnt-assignee'].forEach(function(sel){
-      modal.querySelector(sel).addEventListener('input', updateSubmitState);
+    [['#gnt-name','name'],['#gnt-content','content'],['#gnt-category','category'],['#gnt-location','location'],['#gnt-assignee','assignee'],['#gnt-due','due']].forEach(function(pair){
+      const sel = pair[0];
+      const field = pair[1];
+      modal.querySelector(sel).addEventListener('input', function(){
+        setFieldError(field);
+        if (field === 'category' || field === 'location') updatePaths();
+      });
     });
-    modal.querySelector('#gnt-assignee').addEventListener('change', updateSubmitState);
   }
 
   function lockForm(state){
@@ -81,7 +93,7 @@
     if (!dialog) return;
     if (state) { dialog.setAttribute('aria-busy', 'true'); }
     else { dialog.removeAttribute('aria-busy'); }
-    ['#gnt-name','#gnt-content','#gnt-category','#gnt-location','#gnt-assign-me','#gnt-assignee','.gnt-submit'].forEach(function(sel){
+    ['#gnt-name','#gnt-content','#gnt-category','#gnt-location','#gnt-due','#gnt-assign-me','#gnt-assignee','.gnt-submit'].forEach(function(sel){
       const el = modal.querySelector(sel);
       if (!el) return;
       if (state) {
@@ -123,7 +135,7 @@
         hideLoader();
         lockForm(false);
         fillDropdowns(data);
-        updateSubmitState();
+        updatePaths();
       }).catch(function(err){
         logClientError((err && err.code ? err.code + ': ' : '') + (err && err.message ? err.message : String(err)));
         showError(err && err.message ? err.message : 'Ошибка загрузки');
@@ -136,6 +148,19 @@
     if (!box) return;
     box.innerHTML = '<span class="error">' + (message || 'Ошибка создания заявки') + '</span>';
     box.hidden = false;
+  }
+
+  function setFieldError(field, message){
+    const input = modal.querySelector('#gnt-' + field);
+    const err = modal.querySelector('#gnt-' + field + '-err');
+    if (input) {
+      if (message) input.classList.add('gnt-invalid');
+      else input.classList.remove('gnt-invalid');
+    }
+    if (err) {
+      err.textContent = message || '';
+      err.hidden = !message;
+    }
   }
 
   function logClientError(msg){
@@ -240,13 +265,13 @@
         hideLoader();
         lockForm(false);
         fillDropdowns(data);
-        updateSubmitState();
+        updatePaths();
       }).catch(function(err){
         logClientError((err && err.code ? err.code + ': ' : '') + (err && err.message ? err.message : String(err)));
         showError(err && err.message ? err.message : 'Ошибка загрузки');
       });
     }
-    updateSubmitState();
+    updatePaths();
   }
 
   function close(){
@@ -261,6 +286,7 @@
     modal.querySelector('#gnt-content').value = '';
     modal.querySelector('#gnt-category').value = '';
     modal.querySelector('#gnt-location').value = '';
+    modal.querySelector('#gnt-due').value = '';
     modal.querySelector('#gnt-category-path').textContent = '';
     modal.querySelector('#gnt-location-path').textContent = '';
     const assignChk = modal.querySelector('#gnt-assign-me');
@@ -268,7 +294,8 @@
     assignChk.checked = true;
     assigneeSel.value = '';
     assigneeSel.disabled = true;
-    updateSubmitState();
+    ['name','content','category','location','assignee','due'].forEach(function(f){ setFieldError(f); });
+    updatePaths();
   }
 
   function ensureSuccessModal(){
@@ -278,8 +305,7 @@
     successModal.innerHTML = `
       <div class="gnt-success-backdrop"></div>
       <div class="gnt-success-dialog" role="dialog" aria-modal="true">
-        <div class="gnt-success-title">Успешно создана заявка</div>
-        <div class="gnt-success-text">Успешно создана заявка № <span class="gnt-ticket-id"></span></div>
+        <div class="gnt-success-title">Заявка создана #<span class="gnt-ticket-id"></span></div>
         <div class="gnt-success-actions">
           <button type="button" class="gnt-open-ticket">Открыть заявку</button>
           <button type="button" class="gnt-copy-ticket">Скопировать номер</button>
@@ -433,15 +459,28 @@
     const locInput = modal.querySelector('#gnt-location');
     const catId = getSelectedId('gnt-category-list', catInput.value);
     const locId = getSelectedId('gnt-location-list', locInput.value);
+    const dueVal = modal.querySelector('#gnt-due').value.trim();
     const assignMe = modal.querySelector('#gnt-assign-me').checked;
     const assigneeSel = modal.querySelector('#gnt-assignee');
     const assigneeId = assigneeSel.disabled ? 0 : parseInt(assigneeSel.value,10) || 0;
-    if (!name || !content || !catId || !locId) return;
+    const errors = {};
+    if (!name) errors.name = 'Обязательное поле';
+    if (!content) errors.content = 'Обязательное поле';
+    if (!catId) errors.category = 'Обязательное поле';
+    if (!locId) errors.location = 'Обязательное поле';
+    if (!dueVal) errors.due = 'Обязательное поле';
+    if (!assignMe && !assigneeId) errors.assignee = 'Обязательное поле';
+    if (Object.keys(errors).length) {
+      Object.keys(errors).forEach(function(f){ setFieldError(f, errors[f]); });
+      showSubmitError('Заполните обязательные поля');
+      return;
+    }
     const payload = {
       name: name,
       content: content,
       category_id: catId,
       location_id: locId,
+      due_date: dueVal,
       assign_me: assignMe ? 1 : 0,
       assignee_id: assigneeId
     };
@@ -466,9 +505,13 @@
         close();
         if (data.ticket_id) {
           showSuccessModal(data.ticket_id);
+          window.dispatchEvent(new CustomEvent('gexe:tickets:refresh', {detail:{ticketId:data.ticket_id}}));
         }
       } else {
-        showSubmitError(data && data.error ? data.error : 'Ошибка создания заявки');
+        showSubmitError(data && data.message ? data.message : 'Ошибка создания заявки');
+        if (data && data.details) {
+          Object.keys(data.details).forEach(function(f){ setFieldError(f, data.details[f]); });
+        }
       }
     }).catch(err=>{
       logClientError((err && err.code ? err.code + ': ' : '') + (err && err.message ? err.message : String(err)));
@@ -483,20 +526,6 @@
     const locVal = modal.querySelector('#gnt-location').value;
     const locOpt = Array.from(modal.querySelector('#gnt-location-list').options).find(o=>o.value===locVal);
     modal.querySelector('#gnt-location-path').textContent = locOpt ? locOpt.getAttribute('data-path') : '';
-  }
-
-  function updateSubmitState(){
-    if (!modal) return;
-    updatePaths();
-    const name = modal.querySelector('#gnt-name').value.trim();
-    const content = modal.querySelector('#gnt-content').value.trim();
-    const catId = getSelectedId('gnt-category-list', modal.querySelector('#gnt-category').value);
-    const locId = getSelectedId('gnt-location-list', modal.querySelector('#gnt-location').value);
-    const assignMe = modal.querySelector('#gnt-assign-me').checked;
-    const assigneeSel = modal.querySelector('#gnt-assignee');
-    const assigneeId = assigneeSel.disabled ? 0 : parseInt(assigneeSel.value,10) || 0;
-    const ready = name && content && catId && locId && (assignMe || assigneeId);
-    modal.querySelector('.gnt-submit').disabled = !ready;
   }
 
   document.addEventListener('DOMContentLoaded', function(){

--- a/includes/glpi-sql.php
+++ b/includes/glpi-sql.php
@@ -85,16 +85,18 @@ function create_ticket_sql(array $data) {
         'itilcategories_id'=> 0,
         'locations_id'     => 0,
         'entities_id'      => 0,
+        'due_date'         => null,
         'status'           => 1,
     ];
     $p = array_merge($defaults, $data);
 
     $glpi_db->query('START TRANSACTION');
     $sql = $glpi_db->prepare(
-        'INSERT INTO glpi_tickets (name, content, status, date, date_mod, users_id_recipient, users_id_lastupdater, entities_id, itilcategories_id, locations_id) VALUES (%s,%s,%d,NOW(),NOW(),%d,%d,%d,%d,%d)',
+        'INSERT INTO glpi_tickets (name, content, status, date, date_mod, due_date, users_id_recipient, users_id_lastupdater, entities_id, itilcategories_id, locations_id) VALUES (%s,%s,%d,NOW(),NOW(),%s,%d,%d,%d,%d,%d)',
         $p['name'],
         $p['content'],
         $p['status'],
+        $p['due_date'],
         $p['requester_id'],
         $p['requester_id'],
         $p['entities_id'],
@@ -102,9 +104,8 @@ function create_ticket_sql(array $data) {
         $p['locations_id']
     );
     if (!$glpi_db->query($sql)) {
-        $err = $glpi_db->last_error;
         $glpi_db->query('ROLLBACK');
-        return ['ok' => false, 'code' => 'SQL_ERROR', 'message' => $err];
+        return ['ok' => false, 'code' => 'SQL_OP_FAILED', 'message' => 'Не удалось создать заявку'];
     }
     $ticket_id = (int) $glpi_db->insert_id;
 
@@ -115,9 +116,8 @@ function create_ticket_sql(array $data) {
         $p['requester_id']
     );
     if (!$glpi_db->query($sql)) {
-        $err = $glpi_db->last_error;
         $glpi_db->query('ROLLBACK');
-        return ['ok' => false, 'code' => 'SQL_ERROR', 'message' => $err];
+        return ['ok' => false, 'code' => 'SQL_OP_FAILED', 'message' => 'Не удалось создать заявку'];
     }
 
     if (!empty($p['assignee_id'])) {
@@ -127,9 +127,8 @@ function create_ticket_sql(array $data) {
             (int) $p['assignee_id']
         );
         if (!$glpi_db->query($sql)) {
-            $err = $glpi_db->last_error;
             $glpi_db->query('ROLLBACK');
-            return ['ok' => false, 'code' => 'SQL_ERROR', 'message' => $err];
+            return ['ok' => false, 'code' => 'SQL_OP_FAILED', 'message' => 'Не удалось создать заявку'];
         }
     }
 


### PR DESCRIPTION
## Summary
- create tickets directly via SQL and return SQL_OP_FAILED on errors
- add due date field with validation and user feedback
- surface creation success or validation errors in UI and refresh list

## Testing
- `php -l includes/glpi-sql.php`
- `php -l glpi-new-task.php`
- `npx eslint glpi-new-task.js` *(fails: 303 errors)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc8f5c3fc83288a2c93cbe1ae88d3