### PR TITLE
Render accepted state without extra request

### DIFF
--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -250,7 +250,8 @@ function gexe_cat_slug($leaf) {
            data-late="<?php echo $is_late ? '1':'0'; ?>"
            data-status="<?php echo esc_attr((string)$t['status']); ?>"
            data-unassigned="<?php echo $is_unassigned ? '1':'0'; ?>"
-           data-author="<?php echo intval($t['author_id'] ?? 0); ?>">
+           data-author="<?php echo intval($t['author_id'] ?? 0); ?>"
+           <?php if (!empty($t['accepted'])) echo 'data-accepted="1"'; ?>>
         <div class="glpi-badge <?php echo esc_attr($cat_slug); ?>"><?php echo $icon; ?> <?php echo esc_html($leaf_cat); ?></div>
         <div class="glpi-card-header<?php echo $is_late ? ' late':''; ?>">
           <a href="<?php echo esc_url($link); ?>" class="glpi-topic" target="_blank" rel="noopener noreferrer"><?php echo $name; ?></a>


### PR DESCRIPTION
## Summary
- mark server-rendered tickets accepted when current user already has a follow-up
- hydrate cards with `data-accepted` and disable accept button immediately
- handle acceptance without extra network requests

## Testing
- `npx eslint gexe-filter.js` (fails: many style errors)
- `php -l gexe-copy.php`
- `php -l templates/glpi-cards-template.php`
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bcc9026a1c8328a3468cfe87eb8cbb