### PR TITLE
feat: cache wp executors

### DIFF
--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -1,6 +1,10 @@
 (function(){
   'use strict';
 
+  const gexeAjax = window.gexeAjax || window.glpiAjax || {};
+  window.gexeAjax = gexeAjax;
+  window.glpiAjax = window.glpiAjax || gexeAjax;
+
   let modal = null;
   let categoriesLoaded = false;
   let executorsLoaded = false;
@@ -64,7 +68,7 @@
     const assignChk = modal.querySelector('#gnt-assign-me');
     const assigneeSel = modal.querySelector('#gnt-assignee');
     assignChk.addEventListener('change', function(){
-      assigneeSel.disabled = this.checked;
+      assigneeSel.disabled = this.checked || !executorsLoaded;
       if (this.checked) {
         assigneeSel.value = '';
       }
@@ -87,7 +91,7 @@
       if (state) {
         el.disabled = true;
       } else if (sel === '#gnt-assignee') {
-        el.disabled = modal.querySelector('#gnt-assign-me').checked;
+        el.disabled = modal.querySelector('#gnt-assign-me').checked || !executorsLoaded;
       } else {
         el.disabled = false;
       }
@@ -206,6 +210,10 @@
         throw e;
       }
       window.__gexeFormData = data;
+      if (window.glpiAjax) {
+        window.glpiAjax.meta = window.glpiAjax.meta || {};
+        window.glpiAjax.meta.executorsCache = data.executors_cache || { enabled: false };
+      }
       if (window.glpiDev) {
         console.info('[glpi] form data', data.source, data.took_ms + 'ms', 'cats:' + (data.categories ? data.categories.length : 0), 'locs:' + (data.locations ? data.locations.length : 0));
       }
@@ -382,15 +390,37 @@
       });
       categoriesLoaded = true;
     }
-    if (data.executors && !executorsLoaded) {
+    if (!executorsLoaded) {
       const sel = modal.querySelector('#gnt-assignee');
-      data.executors.forEach(function(u){
+      if (data.executors && data.executors.length) {
+        sel.innerHTML = '<option value="">—</option>';
+        data.executors.forEach(function(u){
+          const opt = document.createElement('option');
+          opt.value = u.id;
+          opt.textContent = u.label;
+          sel.appendChild(opt);
+        });
+        if (data.executors_more && data.executors_more > 0) {
+          const opt = document.createElement('option');
+          opt.value = '';
+          opt.textContent = '\u2026и ещё ' + data.executors_more;
+          opt.disabled = true;
+          opt.title = 'Уточните поиск';
+          sel.appendChild(opt);
+        }
+        executorsLoaded = true;
+        sel.disabled = modal.querySelector('#gnt-assign-me').checked;
+      } else {
+        sel.innerHTML = '';
         const opt = document.createElement('option');
-        opt.value = u.id;
-        opt.textContent = u.name;
+        opt.value = '';
+        opt.textContent = 'Список исполнителей временно недоступен. Обновите страницу или попробуйте позже';
+        opt.disabled = true;
+        opt.selected = true;
         sel.appendChild(opt);
-      });
-      executorsLoaded = true;
+        sel.disabled = true;
+        executorsLoaded = false;
+      }
     }
     if (data.locations) {
       const list = modal.querySelector('#gnt-location-list');

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -11,6 +11,7 @@
 if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/glpi-utils.php';
+require_once __DIR__ . '/includes/executors-cache.php';
 require_once __DIR__ . '/includes/glpi-form-data.php';
 require_once __DIR__ . '/includes/glpi-auth-map.php';
 

--- a/includes/executors-cache.php
+++ b/includes/executors-cache.php
@@ -1,0 +1,138 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function gexe_executors_cache_enabled() {
+    return (bool) get_option('executors_cache_enabled', true);
+}
+
+function gexe_wp_executors_cache_key() {
+    $key = 'gexe_wp_executors_v1';
+    if (is_multisite()) {
+        $key .= '_' . get_current_blog_id();
+    }
+    return $key;
+}
+
+function gexe_query_wp_executors($limit = 1000) {
+    $query = new WP_User_Query([
+        'meta_query' => [
+            [
+                'key'     => 'glpi_user_id',
+                'value'   => 0,
+                'compare' => '>',
+                'type'    => 'NUMERIC',
+            ],
+        ],
+        'fields'      => ['ID', 'display_name'],
+        'orderby'     => 'display_name',
+        'order'       => 'ASC',
+        'number'      => $limit,
+        'count_total' => true,
+    ]);
+    $users = $query->get_results();
+    $total = (int) $query->get_total();
+    $seen = [];
+    foreach ($users as $u) {
+        $label = trim($u->display_name);
+        if ($label === '') continue;
+        if (isset($seen[$label])) continue;
+        $seen[$label] = [
+            'id'    => (int) $u->ID,
+            'label' => $label,
+        ];
+    }
+    $executors = array_values($seen);
+    usort($executors, function ($a, $b) {
+        return strcasecmp($a['label'], $b['label']);
+    });
+    $more = max(0, $total - count($executors));
+    return [$executors, $more];
+}
+
+function gexe_get_wp_executors_cached() {
+    $enabled = gexe_executors_cache_enabled();
+    $meta = ['enabled' => $enabled];
+    $more = 0;
+    $cache_key = gexe_wp_executors_cache_key();
+
+    $payload = wp_cache_get($cache_key, 'glpi');
+    if ($payload === false) {
+        $payload = get_transient($cache_key);
+    }
+    $cached = $payload;
+
+    if (!$enabled) {
+        [$executors, $more] = gexe_query_wp_executors();
+        return [$executors, $meta, $more];
+    }
+
+    if (is_array($payload) && isset($payload['data'], $payload['stored_at'])) {
+        $ttl = 300 - (time() - (int) $payload['stored_at']);
+        if ($ttl < 0) $ttl = 0;
+        $meta = [
+            'enabled'             => true,
+            'source'              => 'cache',
+            'ttlSecondsRemaining' => $ttl,
+        ];
+        $executors = $payload['data'];
+        $more      = isset($payload['more']) ? (int) $payload['more'] : 0;
+        return [$executors, $meta, $more];
+    }
+
+    [$executors, $more] = gexe_query_wp_executors();
+    if (!empty($executors)) {
+        $payload = [
+            'data'      => $executors,
+            'stored_at' => time(),
+            'more'      => $more,
+        ];
+        wp_cache_set($cache_key, $payload, 'glpi', 300);
+        set_transient($cache_key, $payload, 300);
+        $meta = ['enabled' => true, 'source' => 'rebuild'];
+        return [$executors, $meta, $more];
+    }
+
+    if (is_array($cached) && isset($cached['data']) && !empty($cached['data'])) {
+        $ttl = 300 - (time() - (int) $cached['stored_at']);
+        if ($ttl < 0) $ttl = 0;
+        $meta = [
+            'enabled'             => true,
+            'source'              => 'cache',
+            'ttlSecondsRemaining' => $ttl,
+        ];
+        $executors = $cached['data'];
+        $more      = isset($cached['more']) ? (int) $cached['more'] : 0;
+        return [$executors, $meta, $more];
+    }
+
+    $meta = ['enabled' => true, 'source' => 'rebuild'];
+    return [[], $meta, 0];
+}
+
+function gexe_flush_executors_cache() {
+    $key = gexe_wp_executors_cache_key();
+    wp_cache_delete($key, 'glpi');
+    delete_transient($key);
+    // also flush form data cache
+    wp_cache_delete('glpi_form_data_v1', 'glpi');
+    delete_transient('glpi_form_data_v1');
+}
+
+function gexe_maybe_flush_executors_cache($meta_id, $user_id, $meta_key) {
+    if (!gexe_executors_cache_enabled()) return;
+    $keys = ['glpi_user_id', 'first_name', 'last_name', 'display_name'];
+    if (in_array($meta_key, $keys, true)) {
+        gexe_flush_executors_cache();
+    }
+}
+add_action('updated_user_meta', 'gexe_maybe_flush_executors_cache', 10, 3);
+add_action('added_user_meta', 'gexe_maybe_flush_executors_cache', 10, 3);
+add_action('deleted_user_meta', 'gexe_maybe_flush_executors_cache', 10, 3);
+
+function gexe_flush_executors_cache_on_user($user_id) {
+    if (!gexe_executors_cache_enabled()) return;
+    gexe_flush_executors_cache();
+}
+add_action('profile_update', 'gexe_flush_executors_cache_on_user', 10, 2);
+add_action('user_register', 'gexe_flush_executors_cache_on_user');
+add_action('delete_user', 'gexe_flush_executors_cache_on_user');


### PR DESCRIPTION
## Summary
- cache WordPress executors for 5 minutes with feature flag and invalidation hooks
- serve cached executor list in form data and expose cache diagnostics to front-end
- handle empty executor lists gracefully and indicate truncated results

## Testing
- `php -l includes/executors-cache.php`
- `php -l includes/glpi-form-data.php`
- `php -l glpi-new-task.php`
- `npx eslint glpi-new-task.js` *(fails: coding style issues)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bccb786920832889809c48d33691bd