### PR TITLE
Add preflight guards and nonce retry

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -184,6 +184,7 @@ body {
 .gexe-action-btn:disabled{ background:#1e293b; color:#64748b; border-color:#334155; cursor:not-allowed; box-shadow:none; }
 .gexe-action-btn.is-error{ background:#dc2626; border-color:#b91c1c; color:#fff; }
 .gexe-action-btn.is-error:hover{ background:#b91c1c; }
+.gexe-preflight-tip{ color:#facc15; align-self:center; margin-left:4px; }
 
 /* ======= Модалка просмотра ======= */
 .gexe-modal{ position:fixed; inset:0; display:none; z-index:10000; }

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -550,8 +550,8 @@ add_action('wp_ajax_glpi_ticket_accept_sql', 'gexe_glpi_ticket_accept_sql');
 function gexe_glpi_ticket_accept_sql() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
-        error_log('[accept] nonce_failed ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'nonce_failed'], 403);
+        error_log('[accept] nonce_expired ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'NONCE_EXPIRED'], 403);
     }
 
     if (!is_user_logged_in()) {
@@ -724,13 +724,13 @@ function gexe_glpi_comment_add() {
         wp_send_json(['error' => 'NONCE_EXPIRED'], 403);
     }
     if (!is_user_logged_in()) {
-        error_log('[comment] no_permission ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'NO_PERMISSION'], 403);
+        error_log('[comment] not_logged_in ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'not_logged_in'], 401);
     }
     $author_glpi = gexe_get_current_glpi_user_id($wp_uid);
     if ($author_glpi <= 0) {
-        error_log('[comment] no_permission ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'NO_PERMISSION'], 403);
+        error_log('[comment] no_glpi_id_for_current_user ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
     }
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;


### PR DESCRIPTION
## Summary
- add client-side preflight checks for GLPI AJAX settings and user mapping
- retry actions once on nonce expiration after refreshing nonce
- return specific backend codes for missing nonce or GLPI ID

## Testing
- `npx eslint gexe-filter.js glpi-modal-actions.php glpi-solve.php gee.css` *(fails: Parsing error: Unexpected token :)*
- `npm test` *(fails: Error: no test specified)*
- `php -l glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcd0af0b888328981385bae087e55f