### PR TITLE
Clamp card titles to 2 lines, show full title in modals

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -68,6 +68,16 @@ body {
 @media (max-width:576px){
   .glpi-topic{font-size:14px;}
 }
+/* Cards: limit title to 2 lines with ellipsis */
+.glpi-card .glpi-card-header .glpi-topic {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  max-height: calc(1.2em * 2); /* fallback if line-clamp unsupported */
+}
 .glpi-ticket-id { font-size: 13px; color: #64748b; }
 .glpi-card-body { font-size: 14px; color: #cbd5e1; line-height: 1.4; margin-bottom: 12px; max-height: 2.8em; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 
@@ -187,6 +197,19 @@ body {
 .gexe-preflight-tip{ color:#facc15; align-self:center; margin-left:4px; }
 
 /* ======= Модалка просмотра ======= */
+/* Modals: always show full title (no clamping/ellipsis) */
+.gexe-modal--open .glpi-topic,
+.glpi-modal .glpi-topic,
+.gexe-cmnt__title,
+.gexe-done__title {
+  display: block;
+  -webkit-line-clamp: unset;
+  -webkit-box-orient: initial;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  max-height: none;
+}
 .gexe-modal{ position:fixed; inset:0; display:none; z-index:10000; }
 .gexe-modal.gexe-modal--open{ display:block; }
 .gexe-modal__backdrop{ position:absolute; inset:0; background:rgba(0,0,0,.55); backdrop-filter: blur(2px); }


### PR DESCRIPTION
## Summary
- Limit card titles to two lines with ellipsis
- Ensure modal titles display fully without clamping

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd51990488328b632175c6b3fb7f4