### PR TITLE
Fix GLPI profile mapping preflight and server check

### DIFF
--- a/includes/glpi-auth-map.php
+++ b/includes/glpi-auth-map.php
@@ -11,12 +11,12 @@ function get_mapped_glpi_user_id($wp_user_id) {
     static $cache = [];
     $wp_user_id = (int) $wp_user_id;
     if ($wp_user_id <= 0) {
-        return null;
+        return 0;
     }
     if (array_key_exists($wp_user_id, $cache)) {
         return $cache[$wp_user_id];
     }
     $mapped = gexe_get_current_glpi_user_id($wp_user_id);
-    $cache[$wp_user_id] = $mapped > 0 ? $mapped : null;
+    $cache[$wp_user_id] = $mapped > 0 ? $mapped : 0;
     return $cache[$wp_user_id];
 }


### PR DESCRIPTION
## Summary
- normalize GLPI user mapping and sanitize cached IDs
- add AJAX endpoint to check WP→GLPI mapping
- block actions client-side until mapping exists and allow manual recheck
- validate GLPI user key on profile save and expose IDs to frontend

## Testing
- `php -l glpi-utils.php`
- `php -l includes/glpi-auth-map.php`
- `php -l gexe-copy.php`
- `php -l glpi-modal-actions.php`
- `npx eslint gexe-filter.js` *(fails: many pre-existing lint errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd71e88a883288246158ec9207de4