### PR TITLE
Fix GLPI profile mapping: trust numeric glpi_user_key, expose mapping via AJAX, block actions only when mapping=0

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -179,16 +179,16 @@
       wrap.style.position = 'fixed';
       wrap.style.left = '0';
       wrap.style.right = '0';
-      wrap.style.bottom = '0';
+      wrap.style.top = '0';
       wrap.style.zIndex = '9999';
       wrap.style.background = '#fdecea';
-      wrap.style.padding = '10px';
+      wrap.style.padding = '5px 10px';
       wrap.style.textAlign = 'center';
-      wrap.style.boxShadow = '0 -2px 5px rgba(0,0,0,0.1)';
-      wrap.innerHTML = '<span class="gexe-map-msg">Не найден профиль GLPI. Укажите числовой <strong>users.id</strong> в поле “Ключ пользователя GLPI” в своём профиле WordPress (или md5 “Фамилия И.”).</span> '
+      wrap.style.boxShadow = '0 2px 5px rgba(0,0,0,0.1)';
+      wrap.innerHTML = '<span class="gexe-map-msg">GLPI профиль не найден. Нажмите «Проверить» для диагностики.</span> '
         + '<button type="button" class="gexe-map-check glpi-act">Проверить</button>'
         + '<span class="gexe-map-resp"></span>';
-      document.body.appendChild(wrap);
+      document.body.prepend(wrap);
       const btn = wrap.querySelector('.gexe-map-check');
       if (btn) btn.addEventListener('click', checkMapping);
     } else {
@@ -224,12 +224,14 @@
     if (data && data.success && data.data) {
       const info = data.data;
       if (resp) {
-        resp.textContent = ' ID: ' + info.glpi_user_id + ' / key: ' + info.glpi_user_key + ' / source: ' + info.source;
+        resp.textContent = ' wp: ' + info.wp_user_id + ' / key: ' + info.glpi_user_key + ' / glpi: ' + info.glpi_user_id + ' / source: ' + info.source;
       }
       ajax.user_glpi_id = Number(info.glpi_user_id) || 0;
       if (ajax.user_glpi_id > 0) {
         hideMappingWarning();
         unblockActions();
+      } else {
+        blockActions('no_glpi_id_for_current_user');
       }
     } else if (resp) {
       resp.textContent = ' Проверка не удалась';

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -712,25 +712,8 @@ function gexe_check_mapping() {
         gexe_ajax_error('not_logged_in', 'User not logged in', 401);
     }
 
-    $wp_user_id = get_current_user_id();
-    $glpi_user_key = get_user_meta($wp_user_id, 'glpi_user_key', true);
-    $glpi_user_key = is_string($glpi_user_key) ? trim($glpi_user_key) : '';
-    $source = 'none';
-    if ($glpi_user_key !== '') {
-        if (preg_match('/^\d+$/', $glpi_user_key)) {
-            $source = 'numeric';
-        } elseif (preg_match('/^[a-f0-9]{32}$/i', $glpi_user_key)) {
-            $source = 'md5';
-        }
-    }
-    $glpi_user_id = gexe_get_current_glpi_user_id($wp_user_id);
-
-    gexe_ajax_success([
-        'wp_user_id'    => $wp_user_id,
-        'glpi_user_key' => $glpi_user_key,
-        'glpi_user_id'  => $glpi_user_id,
-        'source'        => $source,
-    ]);
+    $info = gexe_resolve_glpi_mapping(get_current_user_id());
+    gexe_ajax_success($info);
 }
 
 /* -------- AJAX: добавить комментарий -------- */


### PR DESCRIPTION
## Summary
- Normalize GLPI user mapping to rely solely on `glpi_user_key`, trusting numeric IDs and hashing names for lookups
- Expose a `gexe_check_mapping` diagnostic AJAX endpoint
- Surface missing-profile notice with mapping check and only block actions when GLPI ID is absent

## Testing
- `php -l glpi-utils.php`
- `php -l glpi-modal-actions.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4cb463883288f5b75f985da7754