### PR TITLE
feat: enhance glpi mapping and ajax contract

### DIFF
--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -78,8 +78,16 @@
     assignChk.addEventListener('change', function(){
       assigneeSel.disabled = this.checked || !executorsLoaded;
       if (this.checked) {
-        assigneeSel.value = '';
+        const glpiId = Number((gexeAjax && gexeAjax.user_glpi_id) || 0);
+        if (glpiId > 0) {
+          const opt = assigneeSel.querySelector('option[data-glpi-id="' + glpiId + '"]');
+          if (opt) {
+            assigneeSel.value = opt.value;
+          }
+        }
         setFieldError('assignee');
+      } else {
+        assigneeSel.value = '';
       }
     });
     [['#gnt-name','name'],['#gnt-content','content'],['#gnt-category','category'],['#gnt-location','location'],['#gnt-assignee','assignee'],['#gnt-due','due']].forEach(function(pair){
@@ -424,6 +432,9 @@
           const opt = document.createElement('option');
           opt.value = u.id;
           opt.textContent = u.label;
+          if (u.glpi_user_id) {
+            opt.setAttribute('data-glpi-id', u.glpi_user_id);
+          }
           sel.appendChild(opt);
         });
         if (data.executors_more && data.executors_more > 0) {
@@ -436,6 +447,8 @@
         }
         executorsLoaded = true;
         sel.disabled = modal.querySelector('#gnt-assign-me').checked;
+        const assignChk = modal.querySelector('#gnt-assign-me');
+        if (assignChk) assignChk.dispatchEvent(new Event('change'));
       } else {
         sel.innerHTML = '';
         const opt = document.createElement('option');

--- a/glpi-solve.php
+++ b/glpi-solve.php
@@ -7,20 +7,20 @@ add_action('wp_ajax_glpi_ticket_resolve', 'gexe_glpi_ticket_resolve');
 function gexe_glpi_ticket_resolve() {
     $wp_uid = get_current_user_id();
     if (!check_ajax_referer('gexe_actions', '_ajax_nonce', false)) {
-        gexe_ajax_error('NONCE_EXPIRED', 'Сессия истекла', 403);
+        gexe_ajax_error_compat('NONCE_EXPIRED', 'Сессия истекла', [], 403);
     }
 
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     if ($ticket_id <= 0) {
-        gexe_ajax_error('INVALID_INPUT', 'Тикет не найден', 404);
+        gexe_ajax_error_compat('INVALID_INPUT', 'Тикет не найден', [], 404);
     }
 
     if (!is_user_logged_in()) {
-        gexe_ajax_error('NO_PERMISSION', 'Требуется вход', 401);
+        gexe_ajax_error_compat('NO_PERMISSION', 'Требуется вход', [], 401);
     }
     $author_glpi = gexe_get_current_glpi_user_id($wp_uid);
     if ($author_glpi <= 0) {
-        gexe_ajax_error('NO_GLPI_USER', 'Не найден GLPI ID', 422);
+        gexe_ajax_error_compat('NO_GLPI_USER', 'Не найден GLPI ID', [], 422);
     }
 
     $status        = (int) get_option('glpi_solved_status', 6);
@@ -29,10 +29,10 @@ function gexe_glpi_ticket_resolve() {
     global $glpi_db;
     $current_status = $glpi_db->get_var($glpi_db->prepare('SELECT status FROM glpi_tickets WHERE id=%d', $ticket_id));
     if ($current_status === null) {
-        gexe_ajax_error('INVALID_INPUT', 'Тикет не найден', 404);
+        gexe_ajax_error_compat('INVALID_INPUT', 'Тикет не найден', [], 404);
     }
     if ((int) $current_status === $status) {
-        gexe_ajax_error('SQL_OP_FAILED', 'Заявка уже завершена', 409);
+        gexe_ajax_error_compat('SQL_OP_FAILED', 'Заявка уже завершена', [], 409);
     }
 
     $glpi_db->query('START TRANSACTION');
@@ -41,7 +41,7 @@ function gexe_glpi_ticket_resolve() {
         $err = $glpi_db->last_error;
         $glpi_db->query('ROLLBACK');
         gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $err));
-        gexe_ajax_error('SQL_OP_FAILED', 'Не удалось обновить статус', 500);
+        gexe_ajax_error_compat('SQL_OP_FAILED', 'Не удалось обновить статус', [], 500);
     }
 
     $f = gexe_add_followup_sql($ticket_id, $solution_text, $author_glpi);
@@ -49,9 +49,9 @@ function gexe_glpi_ticket_resolve() {
         $glpi_db->query('ROLLBACK');
         if (($f['code'] ?? '') === 'SQL_ERROR') {
             gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d result=fail code=sql_error msg="%s"', $ticket_id, $author_glpi, $f['message'] ?? ''));
-            gexe_ajax_error('SQL_OP_FAILED', 'Не удалось добавить комментарий', 500);
+            gexe_ajax_error_compat('SQL_OP_FAILED', 'Не удалось добавить комментарий', [], 500);
         }
-        gexe_ajax_error('SQL_OP_FAILED', 'Не удалось завершить тикет', 422);
+        gexe_ajax_error_compat('SQL_OP_FAILED', 'Не удалось завершить тикет', [], 422);
     }
     $followup = [
         'id'       => (int) ($f['followup_id'] ?? 0),
@@ -64,7 +64,7 @@ function gexe_glpi_ticket_resolve() {
     $glpi_db->query('COMMIT');
     gexe_clear_comments_cache($ticket_id);
     gexe_log_action(sprintf('[resolve.sql] ticket=%d author=%d followup=%d status=%d result=ok', $ticket_id, $author_glpi, $followup['id'], $status));
-    gexe_ajax_success([
+    gexe_ajax_success_compat([
         'ticket_id' => $ticket_id,
         'status'    => $status,
         'followup'  => $followup,


### PR DESCRIPTION
## Summary
- streamline GLPI ID lookup using numeric `glpi_user_key` and add compat AJAX helpers
- unify AJAX endpoints and mapping check with new response contract
- refine executor cache and new task UI to select current GLPI user

## Testing
- ⚠️ `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bce65ee3948328adb69bba226ad6c7