### PR TITLE
Use numeric GLPI user key and remove md5 fallback

### DIFF
--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -549,8 +549,8 @@ function gexe_glpi_ticket_accept_sql() {
 
     $author_glpi = gexe_get_current_glpi_user_id($wp_uid);
     if ($author_glpi <= 0) {
-        error_log('[accept] no_glpi_id_for_current_user ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
-        wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
+        error_log('[accept] no_glpi_id ticket=' . intval($_POST['ticket_id'] ?? 0) . ' wp=' . $wp_uid . ' glpi=0');
+        gexe_ajax_error_compat('NO_GLPI_USER', 'no_glpi_id', [], 422);
     }
 
     $ticket_id   = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
@@ -565,8 +565,8 @@ function gexe_glpi_ticket_accept_sql() {
         $assignee = $author_glpi;
     }
     if ($assignee <= 0) {
-        error_log('[accept] no_glpi_id_for_current_user ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
-        wp_send_json(['error' => 'no_glpi_id_for_current_user'], 422);
+        error_log('[accept] no_glpi_id ticket=' . $ticket_id . ' wp=' . $wp_uid . ' glpi=' . $author_glpi);
+        gexe_ajax_error_compat('NO_GLPI_USER', 'no_glpi_id', [], 422);
     }
 
     global $glpi_db;

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -5,7 +5,6 @@ if (!defined('ABSPATH')) exit;
  * Шаблон вывода карточек GLPI
  * Ожидает переменные в $GLOBALS:
  *  - gexe_tickets          : array
- *  - gexe_executors_map    : array (имя => md5)
  *  - gexe_status_counts    : array (status => count)
  *  - gexe_total_count      : int
  *  - gexe_show_all         : bool
@@ -13,7 +12,6 @@ if (!defined('ABSPATH')) exit;
  *  - gexe_category_slugs   : array ('Ремонт' => 'remont')
  */
 $tickets          = isset($GLOBALS['gexe_tickets'])         ? $GLOBALS['gexe_tickets']         : [];
-$executors_map    = isset($GLOBALS['gexe_executors_map'])    ? $GLOBALS['gexe_executors_map']    : [];
 $status_counts    = isset($GLOBALS['gexe_status_counts'])    ? $GLOBALS['gexe_status_counts']    : [1=>0,2=>0,3=>0,4=>0];
 $total_count      = isset($GLOBALS['gexe_total_count'])      ? $GLOBALS['gexe_total_count']      : 0;
 $show_all         = isset($GLOBALS['gexe_show_all'])         ? (bool)$GLOBALS['gexe_show_all']   : false;
@@ -195,8 +193,6 @@ function gexe_cat_slug($leaf) {
   <!-- Карточки -->
   <div class="glpi-wrapper">
     <?php foreach ($tickets as $t):
-      $slug_list     = array_map('md5', $t['executors']);
-      $slug_str      = implode(',', $slug_list);
       $assignees     = array_map('intval', $t['assignee_ids'] ?? []);
       $assignees     = array_values(array_unique($assignees, SORT_NUMERIC));
       $assignees_str = implode(',', $assignees);
@@ -244,7 +240,6 @@ function gexe_cat_slug($leaf) {
     ?>
       <div class="glpi-card"
            data-ticket-id="<?php echo intval($t['id']); ?>"
-           data-executors="<?php echo esc_attr($slug_str); ?>"
            data-assignees="<?php echo esc_attr($assignees_str); ?>"
            data-category="<?php echo esc_attr(strtolower($cat_slug)); ?>"
            data-late="<?php echo $is_late ? '1':'0'; ?>"


### PR DESCRIPTION
## Summary
- rely solely on numeric `glpi_user_key`
- remove md5 lookups and front-end mapping warnings
- return `NO_GLPI_USER` errors consistently

## Testing
- `npx eslint gexe-filter.js` *(fails: many style errors)*
- `npm test` *(fails: no test specified)*
- `php -l glpi-utils.php gexe-copy.php glpi-modal-actions.php gexe-executor-lock.php templates/glpi-cards-template.php`

------
https://chatgpt.com/codex/tasks/task_e_68bcea2cc2f88328b5d48187efba5379