### PR TITLE
Refactor GLPI user mapping and normalize action responses

### DIFF
--- a/gexe-executor-lock.php
+++ b/gexe-executor-lock.php
@@ -11,8 +11,8 @@
  * - Добавлены консольные логи для отладки TOKENS (можно убрать).
  *
  * ДОПОЛНЕНО:
- * - Поддержка авторской фильтрации: в профиле WP в мета-ключе 'glpi_token' хранится
- *   числовой ID автора в GLPI (из glpi_users). Если не задан, пробуем 'glpi_executor_id'.
+ * - Поддержка авторской фильтрации: в профиле WP в мета-ключе 'glpi_user_id' хранится
+ *   числовой ID автора в GLPI (из glpi_users).
  *   На фронте фильтрация идёт по data-author карточки.
  */
 
@@ -33,12 +33,8 @@ add_action('wp_footer', function () {
   $skip     = ($show_all || get_user_meta($u->ID, 'glpi_executor_lock_disable', true) === '1');
   if ($skip) return;
 
-  // Ключ пользователя GLPI: мета-ключ 'glpi_user_key' (только числовой users.id)
-  $raw_key = trim((string) get_user_meta($u->ID, 'glpi_user_key', true));
-
-  // Фоллбеки на старые мета-ключи для совместимости
-  if ($raw_key === '') { $raw_key = trim((string) get_user_meta($u->ID, 'glpi_token', true)); }
-  if ($raw_key === '') { $raw_key = trim((string) get_user_meta($u->ID, 'glpi_executor_id', true)); }
+  // Ключ пользователя GLPI: мета-ключ 'glpi_user_id' (только числовой users.id)
+  $raw_key = trim((string) get_user_meta($u->ID, 'glpi_user_id', true));
 
   if ($raw_key === '' || !ctype_digit($raw_key)) {
     return; // не удалось распознать ключ

--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -1,0 +1,17 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Retrieve GLPI user identifier from WordPress user meta.
+ *
+ * @param int $wp_user_id WordPress user identifier.
+ * @return int GLPI users.id or 0 when not mapped.
+ */
+function gexe_get_glpi_user_id($wp_user_id) {
+    $wp_user_id = (int) $wp_user_id;
+    if ($wp_user_id <= 0) {
+        return 0;
+    }
+    $id = (int) get_user_meta($wp_user_id, 'glpi_user_id', true);
+    return $id > 0 ? $id : 0;
+}


### PR DESCRIPTION
## Summary
- add `inc/user-map.php` to source GLPI user IDs from `glpi_user_id` meta
- rewrite modal action handlers (accept/comment/resolve) to use SQL and unified JSON responses
- update front-end error codes and normalization logic

## Testing
- `php -l glpi-utils.php`
- `php -l inc/user-map.php`
- `php -l gexe-copy.php`
- `php -l glpi-modal-actions.php`
- `php -l gexe-executor-lock.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcede1fdb883288d98ecb1e0aad555