### PR TITLE
feat: cache glpi user id lookup

### DIFF
--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -4,14 +4,32 @@ if (!defined('ABSPATH')) exit;
 /**
  * Retrieve GLPI user identifier from WordPress user meta.
  *
+ * Historically some integrations stored the identifier in various formats
+ * (hashed strings, empty values, etc.).  The plugin expects a positive
+ * integer and falls back to `0` when the meta value does not represent a
+ * valid mapping.  A small in‑memory cache is used to avoid repeated lookups
+ * for the same user during a single request.
+ *
  * @param int $wp_user_id WordPress user identifier.
  * @return int GLPI users.id or 0 when not mapped.
  */
 function gexe_get_glpi_user_id($wp_user_id) {
+    static $cache = [];
+
     $wp_user_id = (int) $wp_user_id;
     if ($wp_user_id <= 0) {
         return 0;
     }
-    $id = (int) get_user_meta($wp_user_id, 'glpi_user_id', true);
-    return $id > 0 ? $id : 0;
+
+    if (isset($cache[$wp_user_id])) {
+        return $cache[$wp_user_id];
+    }
+
+    // Read raw meta, cast to integer and ensure positivity.
+    $raw = get_user_meta($wp_user_id, 'glpi_user_id', true);
+    $id  = (int) $raw;
+    $id  = $id > 0 ? $id : 0;
+
+    $cache[$wp_user_id] = $id;
+    return $id;
 }


### PR DESCRIPTION
## Summary
- cache WordPress to GLPI user ID mapping
- document user ID mapping behaviour

## Testing
- `php -l inc/user-map.php`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bcf19d10f883288c3c493aed203274