### PR TITLE
Fix SQL accept/resolve actions and frontend handling

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -50,9 +50,9 @@ plugin-root/
 
 **AJAX actions**
 - `gexe_get_form_data`, `gexe_refresh_nonce`, `gexe_create_ticket`
-- `glpi_ticket_resolve`
+- `glpi_resolve`
 - `glpi_get_comments`, `glpi_ticket_meta`, `glpi_count_comments_batch`
-- `glpi_ticket_started`, `glpi_card_action`, `glpi_ticket_accept_sql`
+- `glpi_ticket_started`, `glpi_card_action`, `glpi_accept`
 - `gexe_refresh_actions_nonce`, `glpi_comment_add`
 - `gexe_log_client_error`
 

--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -7,8 +7,9 @@ if (!defined('ABSPATH')) exit;
  * Historically some integrations stored the identifier in various formats
  * (hashed strings, empty values, etc.).  The plugin expects a positive
  * integer and falls back to `0` when the meta value does not represent a
- * valid mapping.  A small in‑memory cache is used to avoid repeated lookups
- * for the same user during a single request.
+ * valid mapping (which later results in a `not_mapped` error code). A small
+ * in‑memory cache is used to avoid repeated lookups for the same user during a
+ * single request.
  *
  * @param int $wp_user_id WordPress user identifier.
  * @return int GLPI users.id or 0 when not mapped.


### PR DESCRIPTION
## Summary
- add transactional SQL helpers for accepting and resolving tickets
- expose new `glpi_accept` and `glpi_resolve` AJAX endpoints
- improve frontend handlers with better error reporting and confirmation flow

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-modal-actions.php`
- `php -l inc/user-map.php`
- `node --check gexe-filter.js`
- `npm test` *(fails: Error: no test specified)*
- `npx eslint gexe-filter.js` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf24a74c8832896e2d29f4cd4213d