### PR TITLE
Refactor new ticket modal dictionaries

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -179,6 +179,22 @@ body {
   .glpi-status-block .status-label{margin-top:4px;font-size:12px;}
 }
 
+/* ====== Новая заявка: состояния полей ====== */
+.glpi-create-modal .loading { opacity: .6; pointer-events: none; }
+.glpi-create-modal .error { color: #f87171; }
+.glpi-create-modal .empty { color: #9ca3af; }
+.glpi-create-modal .disabled { opacity: .5; pointer-events: none; }
+.glpi-create-modal .gnt-retry {
+  margin-top: 8px;
+  padding: 4px 8px;
+  background: #1f2937;
+  color: #f1f5f9;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.glpi-create-modal .gnt-retry:hover { background: #273447; }
+
 /* Выпадающие (общие) */
 .glpi-filter-dropdown .glpi-filter-menu{ background:#0f172a; border:1px solid #334155; border-radius:8px; box-shadow:0 6px 12px rgba(0,0,0,.3); }
 

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -468,6 +468,47 @@
     if (btn) btn.addEventListener('click', openNewTaskModal);
   }
 
+  // -------- Загрузка справочников для модалки --------
+  function fetchDict(which) {
+    const ajax = window.gexeAjax || window.glpiAjax;
+    if (!ajax || !ajax.url) return Promise.resolve({ ok: false, code: 'network_error' });
+    const fd = new FormData();
+    fd.append('action', 'glpi_get_' + which);
+    if (ajax.nonce) fd.append('nonce', ajax.nonce);
+    return fetch(ajax.url, { method: 'POST', body: fd })
+      .then(r => r.json())
+      .catch(() => ({ ok: false, code: 'network_error' }));
+  }
+
+  function fillSelect(sel, list) {
+    const el = document.querySelector(sel);
+    if (!el) return;
+    el.innerHTML = '';
+    list.forEach(it => {
+      const opt = document.createElement('option');
+      opt.value = it.id;
+      opt.textContent = it.name;
+      el.appendChild(opt);
+    });
+  }
+
+  function loadNewTaskDicts() {
+    const modal = document.querySelector('.glpi-create-modal');
+    if (!modal) return;
+    Promise.all([
+      fetchDict('categories'),
+      fetchDict('locations'),
+      fetchDict('executors')
+    ]).then(([cat, loc, exec]) => {
+      if (cat && cat.ok) fillSelect('#gnt-category', cat.list);
+      if (loc && loc.ok) fillSelect('#gnt-location', loc.list);
+      if (exec && exec.ok) fillSelect('#gnt-assignee', exec.list);
+    });
+  }
+
+  window.addEventListener('gexe:newtask:open', loadNewTaskDicts);
+  window.addEventListener('gexe:newtask:retry', loadNewTaskDicts);
+
   /* ========================= ИНЛАЙН КАТЕГОРИИ ========================= */
   let selectedCategories = [];
   let categoriesLoaded = false;

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -1,113 +1,88 @@
 <?php
 /**
- * GLPI — создание новой заявки из WordPress UI.
- * Регистрирует AJAX:
- *  - gexe_get_form_data : выдаёт списки категорий, местоположений и исполнителей
- *  - gexe_create_ticket : создаёт заявку в glpi_tickets (+ заявители/исполнители)
+ * AJAX endpoints for the "New ticket" modal.
  *
- * Также подключает CSS для окна создания заявки.
+ * Provides separate endpoints for loading dictionaries and creating a ticket.
+ * All responses use JSON (HTTP 200).
  */
 
 if (!defined('ABSPATH')) exit;
 
-require_once __DIR__ . '/glpi-utils.php';
-require_once __DIR__ . '/includes/executors-cache.php';
-require_once __DIR__ . '/includes/glpi-form-data.php';
-require_once __DIR__ . '/includes/glpi-auth-map.php';
-require_once __DIR__ . '/includes/glpi-sql.php';
+require_once __DIR__ . '/glpi-db-setup.php';
+require_once __DIR__ . '/inc/user-map.php';
 
 add_action('wp_enqueue_scripts', function () {
-    // Стили окна создания заявки
-    wp_register_style(
-        'glpi-new-task',
-        plugin_dir_url(__FILE__) . 'glpi-new-task.css',
-        [],
-        '1.0.0'
-    );
+    wp_register_style('glpi-new-task', plugin_dir_url(__FILE__) . 'glpi-new-task.css', [], '1.0.0');
     wp_enqueue_style('glpi-new-task');
 
-    // Скрипт модального окна создания заявки
-    wp_register_script(
-        'glpi-new-task-js',
-        plugin_dir_url(__FILE__) . 'glpi-new-task.js',
-        [],
-        '1.0.0',
-        true
-    );
+    wp_register_script('glpi-new-task-js', plugin_dir_url(__FILE__) . 'glpi-new-task.js', [], '1.0.0', true);
     wp_enqueue_script('glpi-new-task-js');
-    wp_localize_script('glpi-new-task-js', 'gexeAjax', [
+    wp_localize_script('glpi-new-task-js', 'glpiAjax', [
         'url'   => admin_url('admin-ajax.php'),
-        'nonce' => wp_create_nonce('gexe_form_data'),
+        'nonce' => wp_create_nonce('glpi_new_task'),
     ]);
 });
 
-// -------- AJAX: создание новой заявки --------
-add_action('wp_ajax_gexe_create_ticket', 'gexe_create_ticket');
-function gexe_create_ticket() {
-    if (!check_ajax_referer('gexe_form_data', 'nonce', false)) {
-        gexe_ajax_error_compat('NONCE_EXPIRED', 'nonce_failed', [], 403);
+/** Verify AJAX nonce. */
+function glpi_nt_verify_nonce() {
+    if (!check_ajax_referer('glpi_new_task', 'nonce', false)) {
+        wp_send_json(['ok' => false, 'code' => 'csrf']);
     }
-
-    if (!is_user_logged_in()) {
-        gexe_ajax_error_compat('NO_PERMISSION', 'not_logged_in', [], 401);
-    }
-
-    $wp_uid   = get_current_user_id();
-    $glpi_uid = gexe_get_current_glpi_user_id($wp_uid);
-    if (!$glpi_uid) {
-        gexe_ajax_error_compat('NO_GLPI_USER', 'no_glpi_id', [], 422);
-    }
-
-    $payload_raw = isset($_POST['payload']) ? stripslashes((string)$_POST['payload']) : '';
-    $payload = json_decode($payload_raw, true);
-    if (!is_array($payload)) $payload = [];
-
-    $name        = isset($payload['name'])        ? sanitize_text_field($payload['name']) : '';
-    $content     = isset($payload['content'])     ? sanitize_textarea_field($payload['content']) : '';
-    $cat_id      = isset($payload['category_id']) ? intval($payload['category_id']) : 0;
-    $loc_id      = isset($payload['location_id']) ? intval($payload['location_id']) : 0;
-    $due_raw     = isset($payload['due_date'])    ? sanitize_text_field($payload['due_date']) : '';
-    $assign_me   = !empty($payload['assign_me']);
-    $assignee_wp_id = isset($payload['assignee_id']) ? intval($payload['assignee_id']) : 0;
-
-    $due_date = null;
-    if ($due_raw !== '') {
-        try {
-            $due_date = (new DateTime($due_raw))->format('Y-m-d H:i:s');
-        } catch (Exception $e) {
-            $due_date = null;
-        }
-    }
-
-    $errors = [];
-    if ($name === '') { $errors['name'] = 'required'; }
-    if ($content === '') { $errors['content'] = 'required'; }
-    if ($cat_id <= 0) { $errors['category'] = 'required'; }
-    if ($loc_id <= 0) { $errors['location'] = 'required'; }
-    if (!$due_date) { $errors['due'] = 'required'; }
-    if (!$assign_me && $assignee_wp_id <= 0) { $errors['assignee'] = 'required'; }
-    if (!empty($errors)) {
-        gexe_ajax_error_compat('INVALID_INPUT', 'validation', ['details' => $errors], 400);
-    }
-
-    $assignee_glpi = $glpi_uid;
-    if (!$assign_me) {
-        $assignee_glpi = gexe_get_current_glpi_user_id($assignee_wp_id);
-    }
-
-    $resp = create_ticket_sql([
-        'name'             => $name,
-        'content'          => $content,
-        'requester_id'     => $glpi_uid,
-        'assignee_id'      => $assignee_glpi,
-        'itilcategories_id'=> $cat_id,
-        'locations_id'     => $loc_id,
-        'due_date'         => $due_date,
-    ]);
-
-    if (!empty($resp['ok'])) {
-        gexe_ajax_success_compat(['ticket_id' => $resp['ticket_id']]);
-    }
-
-    gexe_ajax_error_compat($resp['code'] ?? 'SQL_OP_FAILED', $resp['message'] ?? 'Не удалось создать заявку', [], 500);
 }
+
+// -------- Dictionaries --------
+add_action('wp_ajax_glpi_get_categories', 'glpi_ajax_get_categories');
+function glpi_ajax_get_categories() {
+    glpi_nt_verify_nonce();
+    $res = glpi_db_get_categories();
+    wp_send_json($res);
+}
+
+add_action('wp_ajax_glpi_get_locations', 'glpi_ajax_get_locations');
+function glpi_ajax_get_locations() {
+    glpi_nt_verify_nonce();
+    $res = glpi_db_get_locations();
+    wp_send_json($res);
+}
+
+add_action('wp_ajax_glpi_get_executors', 'glpi_ajax_get_executors');
+function glpi_ajax_get_executors() {
+    glpi_nt_verify_nonce();
+    if (!is_user_logged_in()) {
+        wp_send_json(['ok' => false, 'code' => 'not_logged_in']);
+    }
+    $map = gexe_require_glpi_user(get_current_user_id());
+    if (!$map['ok']) {
+        wp_send_json(['ok' => false, 'code' => $map['code']]);
+    }
+    $res = glpi_db_get_executors();
+    wp_send_json($res);
+}
+
+// -------- Create ticket --------
+add_action('wp_ajax_glpi_create_ticket', 'glpi_ajax_create_ticket');
+function glpi_ajax_create_ticket() {
+    glpi_nt_verify_nonce();
+    if (!is_user_logged_in()) {
+        wp_send_json(['ok' => false, 'code' => 'not_logged_in']);
+    }
+    $map = gexe_require_glpi_user(get_current_user_id());
+    if (!$map['ok']) {
+        wp_send_json(['ok' => false, 'code' => $map['code']]);
+    }
+
+    $payload = [
+        'name'        => sanitize_text_field($_POST['name'] ?? ''),
+        'content'     => sanitize_textarea_field($_POST['description'] ?? ''),
+        'category_id' => (int) ($_POST['category_id'] ?? 0),
+        'location_id' => (int) ($_POST['location_id'] ?? 0),
+        'executor_id' => (int) ($_POST['executor_id'] ?? 0),
+        'assign_me'   => !empty($_POST['assign_me']),
+        'requester_id'=> $map['id'],
+        'entities_id' => (int) ($_POST['entities_id'] ?? 0),
+    ];
+
+    $res = glpi_db_create_ticket($payload);
+    wp_send_json($res);
+}
+

--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -34,3 +34,20 @@ function gexe_get_glpi_user_id($wp_user_id) {
     $cache[$wp_user_id] = $id;
     return $id;
 }
+
+/**
+ * Resolve GLPI mapping for a given WordPress user.
+ *
+ * Returns a structured array so callers can easily branch on the
+ * `not_mapped` condition without replicating the lookup logic.
+ *
+ * @param int $wp_user_id
+ * @return array{ok:bool,id?:int,code?:string}
+ */
+function gexe_require_glpi_user($wp_user_id) {
+    $id = gexe_get_glpi_user_id($wp_user_id);
+    if ($id > 0) {
+        return ['ok' => true, 'id' => $id];
+    }
+    return ['ok' => false, 'code' => 'not_mapped'];
+}


### PR DESCRIPTION
## Summary
- expose dedicated AJAX endpoints for categories, locations, executors and ticket creation
- load dictionaries in the new ticket modal via parallel fetches with retry support
- style modal fields for loading, empty and error states

## Testing
- `npm test` *(fails: Error: no test specified)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bcf64ddc888328aafab4bc40b441f8