### PR TITLE
feat: load GLPI dictionaries via SQL

### DIFF
--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -55,7 +55,7 @@ function glpi_ajax_get_executors() {
     if (!$map['ok']) {
         wp_send_json(['ok' => false, 'code' => $map['code']]);
     }
-    $res = glpi_db_get_executors();
+    $res = gexe_get_executors_list();
     wp_send_json($res);
 }
 
@@ -76,7 +76,7 @@ function glpi_ajax_create_ticket() {
         'content'     => sanitize_textarea_field($_POST['description'] ?? ''),
         'category_id' => (int) ($_POST['category_id'] ?? 0),
         'location_id' => (int) ($_POST['location_id'] ?? 0),
-        'executor_id' => (int) ($_POST['executor_id'] ?? 0),
+        'executor_glpi_id' => (int) ($_POST['executor_glpi_id'] ?? 0),
         'assign_me'   => !empty($_POST['assign_me']),
         'requester_id'=> $map['id'],
         'entities_id' => (int) ($_POST['entities_id'] ?? 0),


### PR DESCRIPTION
## Summary
- fetch executors from WordPress users mapped to GLPI
- expose categories and locations as leaf nodes with unified JSON codes
- create tickets with fixed 17:30 due date and duplicate guard

## Testing
- `npm test`
- `php -l glpi-new-task.php inc/user-map.php glpi-db-setup.php`

------
https://chatgpt.com/codex/tasks/task_e_68bcfa72385483289760d943c103a4d7