### PR TITLE
Clamp ticket card titles on mobile

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -51,14 +51,13 @@ body {
 .glpi-card:hover { box-shadow: 0 0 12px 2px #3b82f6; transform: translateY(-2px); }
 
 .glpi-card-header { display: flex; justify-content: space-between; align-items: flex-start; padding-top: 28px; margin-bottom: 12px; }
+/* Заголовок карточки (ссылка) */
 .glpi-topic {
   color: #fff;
   font-weight: 700;
   font-size: 15px;
   line-height: 1.2;
   text-decoration: none;
-  flex: 1 1 auto;
-  margin-right: 8px;
   max-width: 100%;
   overflow: visible;
   white-space: normal;
@@ -68,15 +67,45 @@ body {
 @media (max-width:576px){
   .glpi-topic{font-size:14px;}
 }
-/* Cards: limit title to 2 lines with ellipsis */
-.glpi-card .glpi-card-header .glpi-topic {
+/* Обёртка заголовка карточки */
+.ticket-card__title {
+  margin: 0 8px 0 0;
+  flex: 1 1 auto;
+  max-width: 100%;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-break: break-word;
+}
+
+@media (max-width:480px){
+  .ticket-card__title{
+    -webkit-line-clamp:2;
+    line-clamp:2;
+  }
+}
+@media (min-width:481px) and (max-width:768px){
+  .ticket-card__title{
+    -webkit-line-clamp:3;
+    line-clamp:3;
+  }
+}
+@media (min-width:769px){
+  .ticket-card__title{
+    -webkit-line-clamp:unset;
+    line-clamp:unset;
+  }
+}
+
+/* Заголовок карточки внутри модалки */
+.modal-ticket__title {
+  margin: 0 8px 0 0;
+  flex: 1 1 auto;
+  max-width: 100%;
+  overflow: visible;
   white-space: normal;
-  max-height: calc(1.2em * 2); /* fallback if line-clamp unsupported */
+  word-break: break-word;
 }
 .glpi-ticket-id { font-size: 13px; color: #64748b; }
 .glpi-card-body { font-size: 14px; color: #cbd5e1; line-height: 1.4; margin-bottom: 12px; max-height: 2.8em; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -605,6 +605,11 @@
       if (full) desc.textContent = full;
     }
     const chip = $('.glpi-comments-chip', clone); if (chip) chip.remove();
+    const titleWrap = $('.ticket-card__title', clone);
+    if (titleWrap) {
+      titleWrap.classList.remove('ticket-card__title');
+      titleWrap.classList.add('modal-ticket__title');
+    }
 
     const id = Number(clone.getAttribute('data-ticket-id') || '0');
     const bar = document.createElement('div');

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -248,7 +248,9 @@ function gexe_cat_slug($leaf) {
            data-author="<?php echo intval($t['author_id'] ?? 0); ?>">
         <div class="glpi-badge <?php echo esc_attr($cat_slug); ?>"><?php echo $icon; ?> <?php echo esc_html($leaf_cat); ?></div>
         <div class="glpi-card-header<?php echo $is_late ? ' late':''; ?>">
-          <a href="<?php echo esc_url($link); ?>" class="glpi-topic" target="_blank" rel="noopener noreferrer"><?php echo $name; ?></a>
+          <h3 class="ticket-card__title" title="<?php echo esc_attr($name); ?>">
+            <a href="<?php echo esc_url($link); ?>" class="glpi-topic" target="_blank" rel="noopener noreferrer"><?php echo $name; ?></a>
+          </h3>
           <div class="glpi-ticket-id">#<?php echo intval($t['id']); ?></div>
         </div>
         <div class="glpi-card-body">


### PR DESCRIPTION
## Summary
- truncate ticket card titles on mobile and tablet viewports
- expose full ticket title via tooltip and in modal

## Testing
- `php -l templates/glpi-cards-template.php`
- `npx eslint gexe-filter.js` *(fails: many style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfb7a24548328a6f84d8be544ed6a