### PR TITLE
Clamp card titles and show full text in modal

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -64,9 +64,7 @@ body {
   word-break: break-word;
   display: block;
 }
-@media (max-width:576px){
-  .glpi-topic{font-size:14px;}
-}
+/* font-size and weight remain consistent across breakpoints */
 /* Обёртка заголовка карточки */
 .ticket-card__title {
   margin: 0 8px 0 0;
@@ -77,24 +75,14 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
 }
 
-@media (max-width:480px){
-  .ticket-card__title{
-    -webkit-line-clamp:2;
-    line-clamp:2;
-  }
-}
-@media (min-width:481px) and (max-width:768px){
-  .ticket-card__title{
-    -webkit-line-clamp:3;
-    line-clamp:3;
-  }
-}
-@media (min-width:769px){
-  .ticket-card__title{
-    -webkit-line-clamp:unset;
-    line-clamp:unset;
+@supports not (-webkit-line-clamp: 2) {
+  .ticket-card__title {
+    max-height: calc(2 * 1.2em);
+    overflow: hidden;
   }
 }
 
@@ -104,6 +92,9 @@ body {
   flex: 1 1 auto;
   max-width: 100%;
   overflow: visible;
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  -webkit-box-orient: initial;
   white-space: normal;
   word-break: break-word;
 }

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -201,7 +201,7 @@ function gexe_cat_slug($leaf) {
       $is_unassigned = empty($t['executors']);
 
       $name_raw      = trim((string)$t['name']);
-      $name          = esc_html(mb_strimwidth($name_raw, 0, 120, '…'));
+      $name          = esc_html($name_raw);
 
       $clean_desc    = gexe_clean_html_text($t['content']);
       $desc_short    = esc_html(gexe_trim_words($clean_desc, 40, '…'));
@@ -248,7 +248,7 @@ function gexe_cat_slug($leaf) {
            data-author="<?php echo intval($t['author_id'] ?? 0); ?>">
         <div class="glpi-badge <?php echo esc_attr($cat_slug); ?>"><?php echo $icon; ?> <?php echo esc_html($leaf_cat); ?></div>
         <div class="glpi-card-header<?php echo $is_late ? ' late':''; ?>">
-          <h3 class="ticket-card__title" title="<?php echo esc_attr($name); ?>">
+          <h3 class="ticket-card__title" title="<?php echo esc_attr($name_raw); ?>">
             <a href="<?php echo esc_url($link); ?>" class="glpi-topic" target="_blank" rel="noopener noreferrer"><?php echo $name; ?></a>
           </h3>
           <div class="glpi-ticket-id">#<?php echo intval($t['id']); ?></div>


### PR DESCRIPTION
## Summary
- Always clamp card titles to two lines with ellipsis and keep fonts unchanged
- Remove server-side truncation so modal shows full ticket title
- Ensure modal titles are unclamped and display complete text

## Testing
- `php -l templates/glpi-cards-template.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfe6ed4ac832882f7a03c26f4a8b7