### PR TITLE
Stack status modal buttons and hide current state

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -320,9 +320,9 @@ body {
 #gexe-cmnt-send.glpi-act:hover{background:#334155}
 .glpi-status-btn.glpi-act{background:#475569;border:1px solid #334155;color:#fff;border-radius:10px;font-weight:700;padding:10px 16px;min-width:120px}
 .glpi-status-btn.glpi-act:hover{background:#334155}
-.gexe-status__top{display:flex;gap:12px;margin-bottom:12px}
-.gexe-status__bottom{margin-top:12px;padding-top:12px;border-top:1px solid #334155;display:flex;flex-direction:column;gap:8px}
-.gexe-status__hint{font-size:12px;color:#94a3b8;text-align:center}
+.status-action{display:block;width:100%}
+.gexe-status__actions{display:flex;flex-direction:column;gap:8px}
+.gexe-status__hint{font-size:12px;color:#94a3b8;text-align:center;margin-top:12px;padding-top:12px;border-top:1px solid #334155}
 .gexe-status__alert{margin-top:8px;padding:8px;border-radius:8px;font-size:14px;}
 .gexe-status__alert.error{background:#7f1d1d;color:#fef2f2}
 .gexe-status__alert.success{background:#14532d;color:#ecfdf5}

--- a/partials/glpi-modal.php
+++ b/partials/glpi-modal.php
@@ -1,12 +1,10 @@
 <div class="gexe-status">
-  <div class="gexe-status__top">
-    <button class="glpi-status-btn" data-status="2">В работе</button>
-    <button class="glpi-status-btn" data-status="3">В плане</button>
-    <button class="glpi-status-btn" data-status="4">В стопе</button>
+  <div class="gexe-status__actions">
+    <button id="btn-status-work" class="glpi-act glpi-status-btn status-action" data-status="2">В работе</button>
+    <button id="btn-status-plan" class="glpi-act glpi-status-btn status-action" data-status="3">В плане</button>
+    <button id="btn-status-stop" class="glpi-act glpi-status-btn status-action" data-status="4">В стопе</button>
+    <button id="btn-status-resolved" class="glpi-act glpi-status-btn glpi-status-resolve status-action" data-status="6">Решить</button>
   </div>
-  <div class="gexe-status__bottom">
-    <button class="glpi-status-btn glpi-status-resolve" data-status="6">Решить</button>
-    <p class="gexe-status__hint">Требуется двойное подтверждение</p>
-  </div>
+  <p class="gexe-status__hint">Требуется двойное подтверждение</p>
   <div class="gexe-status__alert" style="display:none" aria-live="polite"></div>
 </div>


### PR DESCRIPTION
## Summary
- Stack status action buttons vertically and make them full width
- Hide button for current ticket status and log debug details
- Add styling helpers for full-width status buttons

## Testing
- `php -l partials/glpi-modal.php`
- `npx eslint gexe-filter.js` *(fails: numerous style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bcffc98db08328ab996a95e3e7f87c