### PR TITLE
fix: implement new ticket creation flow

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -188,6 +188,15 @@ body {
 textarea.disabled,
 button.disabled{opacity:.5;cursor:not-allowed;}
 
+/* Submit button states */
+.gnt-submit{display:inline-flex;align-items:center;gap:8px;padding:10px 16px;border-radius:6px;background:#1f2937;color:#e5e7eb;border:1px solid #334155;cursor:pointer;transition:background-color .15s ease;}
+.gnt-submit:hover{background:#273447;}
+.gnt-submit:active{background:#334155;}
+.gnt-submit[disabled]{opacity:.5;cursor:not-allowed;}
+.gnt-submit.is-loading{position:relative;}
+.gnt-submit.is-loading::after{content:"";width:16px;height:16px;border:2px solid #f1f5f9;border-top-color:transparent;border-radius:50%;position:absolute;top:50%;left:50%;margin:-8px 0 0 -8px;animation:gnt-spin 1s linear infinite;}
+@keyframes gnt-spin{to{transform:rotate(360deg);}}
+
 /* Инлайн-категории */
 .glpi-categories-inline{
   display:flex;


### PR DESCRIPTION
## Summary
- add loader, submit handler and ticket list refresh for new ticket modal
- create SQL-only GLPI ticket endpoint with validation and idempotency
- style submit button for dark theme

## Testing
- `php -l wp-glpi-plugin/glpi-new-task.php`
- `php -l wp-glpi-plugin/glpi-db-setup.php`
- `node --check wp-glpi-plugin/gexe-filter.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd04f3450883289717c75194823ea5