### PR TITLE
Harden executor feature behind runtime flag

### DIFF
--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -256,17 +256,27 @@ function glpi_db_get_categories() {
  */
 function glpi_db_get_executors() {
     global $glpi_db, $wpdb;
-    $sql = $glpi_db->prepare(
-        "SELECT u.id AS glpi_user_id, u.realname, u.firstname\n"
-        . "FROM glpi_users u\n"
-        . "INNER JOIN {$wpdb->usermeta} m ON m.meta_key = %s AND CAST(m.meta_value AS UNSIGNED) = u.id\n"
-        . "INNER JOIN {$wpdb->users} w ON w.ID = m.user_id\n"
-        . "WHERE u.is_active = 1\n"
-        . "ORDER BY u.realname, u.firstname",
-        'glpi_user_id'
-    );
-    $rows = $glpi_db->get_results($sql, ARRAY_A);
-    return $rows ? $rows : [];
+    try {
+        $sql = $glpi_db->prepare(
+            "SELECT u.id AS glpi_user_id, u.realname, u.firstname\n"
+            . "FROM glpi_users u\n"
+            . "INNER JOIN {$wpdb->usermeta} m ON m.meta_key = %s AND CAST(m.meta_value AS UNSIGNED) = u.id\n"
+            . "INNER JOIN {$wpdb->users} w ON w.ID = m.user_id\n"
+            . "WHERE u.is_active = 1\n"
+            . "ORDER BY u.realname, u.firstname",
+            'glpi_user_id'
+        );
+        $rows = $glpi_db->get_results($sql, ARRAY_A);
+        if ($glpi_db->last_error) {
+            return [];
+        }
+        return $rows ? $rows : [];
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('glpi_db_get_executors: ' . $e->getMessage());
+        }
+        return [];
+    }
 }
 
 /**
@@ -278,31 +288,41 @@ function glpi_db_get_executors() {
  */
 function glpi_db_get_tickets_by_executor($executor_id, $current_id) {
     global $glpi_db;
-    $where_status = " t.status IN (1,2,3,4) AND t.is_deleted = 0 ";
-    $join_assignee = " LEFT JOIN glpi_tickets_users tu ON t.id = tu.tickets_id AND tu.type = 2 ";
-    if ($executor_id !== 'all') {
-        $where_status .= $glpi_db->prepare(' AND tu.users_id = %d ', (int) $executor_id);
+    try {
+        $where_status = " t.status IN (1,2,3,4) AND t.is_deleted = 0 ";
+        $join_assignee = " LEFT JOIN glpi_tickets_users tu ON t.id = tu.tickets_id AND tu.type = 2 ";
+        if ($executor_id !== 'all') {
+            $where_status .= $glpi_db->prepare(' AND tu.users_id = %d ', (int) $executor_id);
+        }
+        $sql = "
+            SELECT  t.id, t.status, t.time_to_resolve,
+                    t.name, t.content, t.date,
+                    tu.users_id AS assignee_id,
+                    tu_req.users_id AS author_id,
+                    u.realname, u.firstname,
+                    c.completename AS category_name,
+                    l.completename AS location_name
+            FROM glpi_tickets t
+            $join_assignee
+            LEFT JOIN glpi_tickets_users tu_req ON t.id = tu_req.tickets_id AND tu_req.type = 1
+            LEFT JOIN glpi_users u ON tu.users_id = u.id
+            LEFT JOIN glpi_itilcategories c ON t.itilcategories_id = c.id
+            LEFT JOIN glpi_locations l ON t.locations_id = l.id
+            WHERE $where_status
+            ORDER BY t.date DESC
+            LIMIT 500
+        ";
+        $rows = $glpi_db->get_results($sql, ARRAY_A);
+        if ($glpi_db->last_error) {
+            return [];
+        }
+        return $rows ? $rows : [];
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('glpi_db_get_tickets_by_executor: ' . $e->getMessage());
+        }
+        return [];
     }
-    $sql = "
-        SELECT  t.id, t.status, t.time_to_resolve,
-                t.name, t.content, t.date,
-                tu.users_id AS assignee_id,
-                tu_req.users_id AS author_id,
-                u.realname, u.firstname,
-                c.completename AS category_name,
-                l.completename AS location_name
-        FROM glpi_tickets t
-        $join_assignee
-        LEFT JOIN glpi_tickets_users tu_req ON t.id = tu_req.tickets_id AND tu_req.type = 1
-        LEFT JOIN glpi_users u ON tu.users_id = u.id
-        LEFT JOIN glpi_itilcategories c ON t.itilcategories_id = c.id
-        LEFT JOIN glpi_locations l ON t.locations_id = l.id
-        WHERE $where_status
-        ORDER BY t.date DESC
-        LIMIT 500
-    ";
-    $rows = $glpi_db->get_results($sql, ARRAY_A);
-    return $rows ? $rows : [];
 }
 
 /**

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -9,6 +9,30 @@ require_once __DIR__ . '/glpi-utils.php';
 require_once __DIR__ . '/includes/glpi-sql.php';
 require_once __DIR__ . '/includes/glpi-auth-map.php';
 
+// Localize runtime configuration for front-end scripts.
+add_action('wp_enqueue_scripts', 'gexe_glpi_localize_runtime', 20);
+function gexe_glpi_localize_runtime() {
+    if (!function_exists('wp_localize_script')) return;
+    if (!wp_script_is('gexe-filter', 'enqueued')) return;
+
+    $current = function_exists('glpi_current_user_id') ? glpi_current_user_id() : 0;
+    $can_view_all = false;
+    if (is_user_logged_in() && function_exists('get_current_user_id')) {
+        $can_view_all = (get_user_meta(get_current_user_id(), 'glpi_show_all_cards', true) === '1');
+    }
+    $features = [
+        'executors' => ($current === 2),
+    ];
+
+    wp_localize_script('gexe-filter', 'GLPI_RUNTIME', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('gexe_actions'),
+        'current_glpi_user_id' => $current,
+        'can_view_all' => $can_view_all,
+        'features' => $features,
+    ]);
+}
+
 function gexe_action_response($ok, $code, $ticket_id, $action, $msg = '', $extra = []) {
     $payload = array_merge([
         'ok'        => (bool) $ok,
@@ -740,10 +764,20 @@ gexe_action_response(true, 'ok', $ticket_id, $action, '', ['extra' => ['followup
 }
 
 function gexe_glpi_executors() {
-    if (gexe_get_current_glpi_uid() !== 2) {
+    if (function_exists('glpi_current_user_id') ? glpi_current_user_id() !== 2 : true) {
         wp_send_json_error(['ok' => false, 'code' => 'no_rights'], 403);
     }
-    $rows = glpi_db_get_executors();
+    try {
+        $rows = glpi_db_get_executors();
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('gexe_glpi_executors: ' . $e->getMessage());
+        }
+        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
+    }
+    if (!is_array($rows)) {
+        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
+    }
     $list = [];
     foreach ($rows as $r) {
         $list[] = [
@@ -759,21 +793,26 @@ function gexe_glpi_filter_tickets() {
         wp_send_json_error(['ok' => false, 'code' => 'not_logged_in'], 403);
     }
     $executor = isset($_POST['executor_id']) ? trim((string) wp_unslash($_POST['executor_id'])) : '';
-    $current  = gexe_get_current_glpi_uid();
+    $current  = function_exists('glpi_current_user_id') ? glpi_current_user_id() : 0;
     if ($executor === '' || $executor === 'all') {
-        if ($current !== 2) {
-            $executor = $current;
-        } else {
-            $executor = 'all';
-        }
+        $executor = ($current === 2) ? 'all' : $current;
     } elseif (!ctype_digit($executor) || (int) $executor <= 0) {
         wp_send_json_error(['ok' => false, 'code' => 'validation'], 400);
     }
     if ($executor === 'all' && $current !== 2) {
         wp_send_json_error(['ok' => false, 'code' => 'no_rights'], 403);
     }
-    $rows = glpi_db_get_tickets_by_executor($executor, $current);
-    if (!is_array($rows)) $rows = [];
+    try {
+        $rows = glpi_db_get_tickets_by_executor($executor, $current);
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('gexe_glpi_filter_tickets: ' . $e->getMessage());
+        }
+        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
+    }
+    if (!is_array($rows)) {
+        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
+    }
     $tickets = [];
     foreach ($rows as $r) {
         $id = (int) ($r['id'] ?? 0);

--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -53,6 +53,33 @@ function gexe_require_glpi_user($wp_user_id) {
 }
 
 /**
+ * Return GLPI user id associated with the current WordPress user.
+ *
+ * Falls back to `0` when the mapping is missing or invalid. The function is
+ * intentionally defensive: it performs capability checks and avoids throwing
+ * exceptions so template code can safely call it without additional guards.
+ *
+ * @return int GLPI users.id or 0 when not mapped or user not logged in.
+ */
+function glpi_current_user_id() {
+    if (!function_exists('is_user_logged_in') || !is_user_logged_in()) {
+        return 0;
+    }
+    if (!function_exists('get_current_user_id')) {
+        return 0;
+    }
+    try {
+        $gid = gexe_get_glpi_user_id(get_current_user_id());
+        return ($gid > 0) ? $gid : 0;
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('glpi_current_user_id: ' . $e->getMessage());
+        }
+        return 0;
+    }
+}
+
+/**
  * Fetch list of executors from WordPress users mapped to GLPI.
  *
  * Returns a unified JSON-style response used by AJAX handlers. Each list

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -130,10 +130,10 @@ function gexe_cat_slug($leaf) {
         <div class="glpi-category-block">
           <button type="button" class="glpi-cat-toggle" aria-expanded="false" aria-controls="glpi-categories-inline">Категории</button>
         </div>
-        <?php if (function_exists('gexe_get_current_glpi_uid') && gexe_get_current_glpi_uid() === 2): ?>
-          <div class="glpi-executor-block">
-            <select id="glpi-executor-filter" class="glpi-executor-select"></select>
-          </div>
+        <?php
+        $show_executors = function_exists('glpi_current_user_id') && glpi_current_user_id() === 2;
+        if ($show_executors): ?>
+          <div class="glpi-executor-block" data-executors-menu></div>
         <?php endif; ?>
       </div>
 


### PR DESCRIPTION
## Summary
- expose `GLPI_RUNTIME` with feature flags and current user mapping
- guard executor queries against DB errors
- init executor menu only when feature is enabled

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd06fc2e048328910d9c889b7714e4