### PR TITLE
fix: stabilise plugin by isolating executor feature

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -519,11 +519,15 @@
       });
     };
 
-    Promise.all([
+    const dictPromises = [
       loadOne('categories', catSel),
-      loadOne('locations', locSel),
-      loadOne('executors', execSel)
-    ]).then(([cat, loc]) => {
+      loadOne('locations', locSel)
+    ];
+    const rt = window.GLPI_RUNTIME || {};
+    if (rt.features && rt.features.executors) {
+      dictPromises.push(loadOne('executors', execSel));
+    }
+    Promise.all(dictPromises).then(([cat, loc]) => {
       // Enable common fields once dictionaries have finished loading
       $$('input,select,textarea', modal).forEach(el => {
         if (el === catSel || el === locSel || el === execSel) return; // handled above
@@ -773,9 +777,8 @@
   }
 
   function initExecutorFilter(){
+    if (!window.GLPI_RUNTIME || !GLPI_RUNTIME.features || !GLPI_RUNTIME.features.executors) return;
     try {
-      const rt = window.GLPI_RUNTIME || {};
-      if (!rt.features || !rt.features.executors) return;
       const block = document.querySelector('.glpi-executor-block');
       if (!block) return;
       block.innerHTML = '<select id="glpi-executor-filter" class="glpi-executor-select" disabled><option value="all">no filter</option></select><span class="glpi-executor-badge" hidden></span>';

--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -30,10 +30,24 @@ function gexe_glpi_api_headers(array $extra = []): array {
     return array_merge($base, $extra);
 }
 
+/**
+ * Trigger helpers retained for backwards compatibility.
+ * They intentionally avoid privileged queries on page load.
+ */
 function gexe_glpi_triggers_present() {
-    global $glpi_db;
-    $sql = "SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA='glpi' AND TRIGGER_NAME IN ('glpi_followups_ai','glpi_followups_ad')";
-    return (int)$glpi_db->get_var($sql) === 2;
+    return false;
+}
+
+function gexe_glpi_install_triggers($force = false) {
+    // no-op: triggers are not managed automatically
+}
+
+function gexe_glpi_remove_triggers() {
+    delete_option('glpi_triggers_version');
+}
+
+function gexe_glpi_triggers_status() {
+    return [];
 }
 
 /** Whether followups_count column is available. */
@@ -52,114 +66,7 @@ function gexe_glpi_use_followups_count() {
     return $cached;
 }
 
-function gexe_glpi_install_triggers($force = false) {
-    global $glpi_db;
-
-    if (!$force && get_option('glpi_triggers_version') === GEXE_TRIGGERS_VERSION) {
-        return;
-    }
-
-    $existing = gexe_glpi_triggers_present();
-
-    $grants = $glpi_db->get_col('SHOW GRANTS');
-    $has_trigger = false;
-    $has_alter   = false;
-    if ($grants) {
-        foreach ($grants as $g) {
-            if (preg_match('~GRANT (ALL PRIVILEGES|.*TRIGGER.*) ON `?glpi`?\.\\*~i', $g)) {
-                $has_trigger = true;
-            }
-            if (preg_match('~GRANT (ALL PRIVILEGES|.*ALTER.*) ON `?glpi`?\.\\*~i', $g)) {
-                $has_alter = true;
-            }
-        }
-    }
-    if (!$has_trigger) {
-        error_log('gexe/triggers: missing TRIGGER privilege on glpi schema');
-        update_option('glpi_triggers_version', GEXE_TRIGGERS_VERSION);
-        update_option('glpi_use_followups_count', 0);
-        return;
-    }
-
-    $glpi_db->query('SET sql_notes=0');
-    $glpi_db->query('START TRANSACTION');
-    $ok = true;
-
-    $col = $glpi_db->get_var("SHOW COLUMNS FROM glpi.glpi_tickets LIKE 'last_followup_at'");
-    if (!$col) {
-        $glpi_db->query("ALTER TABLE glpi.glpi_tickets ADD COLUMN last_followup_at DATETIME NULL AFTER date_mod");
-        if ($glpi_db->last_error) $ok = false;
-        if ($ok) {
-            $glpi_db->query("UPDATE glpi.glpi_tickets t LEFT JOIN (SELECT items_id, MAX(date) AS d FROM glpi.glpi_itilfollowups WHERE itemtype='Ticket' GROUP BY items_id) f ON t.id = f.items_id SET t.last_followup_at = f.d");
-            if ($glpi_db->last_error) $ok = false;
-        }
-    }
-
-    $use_counter = (bool)$glpi_db->get_var("SHOW COLUMNS FROM glpi.glpi_tickets LIKE 'followups_count'");
-    if (!$use_counter && $has_alter && $ok) {
-        $glpi_db->query("ALTER TABLE glpi.glpi_tickets ADD COLUMN followups_count INT UNSIGNED NOT NULL DEFAULT 0 AFTER last_followup_at");
-        if ($glpi_db->last_error) {
-            $ok = false;
-        } else {
-            $glpi_db->query("UPDATE glpi.glpi_tickets t LEFT JOIN (SELECT items_id, COUNT(*) c FROM glpi.glpi_itilfollowups WHERE itemtype='Ticket' GROUP BY items_id) f ON f.items_id = t.id SET t.followups_count = COALESCE(f.c,0)");
-            if ($glpi_db->last_error) $ok = false; else $use_counter = true;
-        }
-    }
-    if (!$use_counter && !$has_alter) {
-        error_log('gexe/triggers: no ALTER privilege, falling back to COUNT(*)');
-    }
-    if ($use_counter && $ok) {
-        $idx = $glpi_db->get_var("SHOW INDEX FROM glpi.glpi_itilfollowups WHERE Key_name='idx_followups_item'");
-        if (!$idx) {
-            $glpi_db->query("CREATE INDEX idx_followups_item ON glpi.glpi_itilfollowups (itemtype, items_id)");
-            if ($glpi_db->last_error) $ok = false;
-        }
-    }
-
-    if ($ok) {
-        if ($use_counter) {
-            $glpi_db->query("CREATE OR REPLACE TRIGGER glpi.glpi_followups_ai AFTER INSERT ON glpi.glpi_itilfollowups FOR EACH ROW BEGIN IF NEW.itemtype='Ticket' THEN UPDATE glpi.glpi_tickets SET last_followup_at = NEW.date, followups_count = followups_count + 1 WHERE id = NEW.items_id; END IF; END;");
-        } else {
-            $glpi_db->query("CREATE OR REPLACE TRIGGER glpi.glpi_followups_ai AFTER INSERT ON glpi.glpi_itilfollowups FOR EACH ROW BEGIN IF NEW.itemtype='Ticket' THEN UPDATE glpi.glpi_tickets SET last_followup_at = NEW.date WHERE id = NEW.items_id; END IF; END;");
-        }
-        if ($glpi_db->last_error) $ok = false;
-    }
-    if ($ok) {
-        if ($use_counter) {
-            $glpi_db->query("CREATE OR REPLACE TRIGGER glpi.glpi_followups_ad AFTER DELETE ON glpi.glpi_itilfollowups FOR EACH ROW BEGIN IF OLD.itemtype='Ticket' THEN UPDATE glpi.glpi_tickets t SET last_followup_at = (SELECT MAX(f.date) FROM glpi.glpi_itilfollowups f WHERE f.itemtype='Ticket' AND f.items_id = t.id), followups_count = (SELECT COUNT(*) FROM glpi.glpi_itilfollowups f WHERE f.itemtype='Ticket' AND f.items_id = t.id) WHERE t.id = OLD.items_id; END IF; END;");
-        } else {
-            $glpi_db->query("CREATE OR REPLACE TRIGGER glpi.glpi_followups_ad AFTER DELETE ON glpi.glpi_itilfollowups FOR EACH ROW BEGIN IF OLD.itemtype='Ticket' THEN UPDATE glpi.glpi_tickets t SET last_followup_at = (SELECT MAX(f.date) FROM glpi.glpi_itilfollowups f WHERE f.itemtype='Ticket' AND f.items_id = t.id) WHERE t.id = OLD.items_id; END IF; END;");
-        }
-        if ($glpi_db->last_error) $ok = false;
-    }
-
-    if ($ok) {
-        $glpi_db->query('COMMIT');
-        update_option('glpi_triggers_installed', time());
-        update_option('glpi_triggers_version', GEXE_TRIGGERS_VERSION);
-        update_option('glpi_use_followups_count', $use_counter ? 1 : 0);
-        error_log('gexe/triggers: installation completed');
-    } else {
-        $glpi_db->query('ROLLBACK');
-        error_log('gexe/triggers: install failed: ' . $glpi_db->last_error);
-        update_option('glpi_triggers_version', GEXE_TRIGGERS_VERSION);
-        update_option('glpi_use_followups_count', $use_counter ? 1 : 0);
-    }
-}
-
-function gexe_glpi_remove_triggers() {
-    global $glpi_db;
-    $glpi_db->query('SET sql_notes=0');
-    $glpi_db->query('DROP TRIGGER IF EXISTS glpi.glpi_followups_ai');
-    $glpi_db->query('DROP TRIGGER IF EXISTS glpi.glpi_followups_ad');
-    delete_option('glpi_triggers_installed');
-    delete_option('glpi_triggers_version');
-}
-
-function gexe_glpi_triggers_status() {
-    global $glpi_db;
-    return $glpi_db->get_results("SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA='glpi' AND TRIGGER_NAME IN ('glpi_followups_ai','glpi_followups_ad')");
-}
+// legacy trigger management removed
 
 /**
  * Insert a followup for a ticket.
@@ -247,82 +154,6 @@ function glpi_db_get_categories() {
     }, $rows);
 
     return ['ok' => true, 'code' => 'ok', 'list' => $list];
-}
-
-/**
- * Fetch list of executors (users).
- *
- * @return array<array{glpi_user_id:int,realname:string,firstname:string}>
- */
-function glpi_db_get_executors() {
-    global $glpi_db, $wpdb;
-    try {
-        $sql = $glpi_db->prepare(
-            "SELECT u.id AS glpi_user_id, u.realname, u.firstname\n"
-            . "FROM glpi_users u\n"
-            . "INNER JOIN {$wpdb->usermeta} m ON m.meta_key = %s AND CAST(m.meta_value AS UNSIGNED) = u.id\n"
-            . "INNER JOIN {$wpdb->users} w ON w.ID = m.user_id\n"
-            . "WHERE u.is_active = 1\n"
-            . "ORDER BY u.realname, u.firstname",
-            'glpi_user_id'
-        );
-        $rows = $glpi_db->get_results($sql, ARRAY_A);
-        if ($glpi_db->last_error) {
-            return [];
-        }
-        return $rows ? $rows : [];
-    } catch (Throwable $e) {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            error_log('glpi_db_get_executors: ' . $e->getMessage());
-        }
-        return [];
-    }
-}
-
-/**
- * Fetch tickets filtered by executor id.
- *
- * @param string|int $executor_id 'all' or GLPI user id
- * @param int        $current_id  current GLPI user id for permission check
- * @return array<int,array>
- */
-function glpi_db_get_tickets_by_executor($executor_id, $current_id) {
-    global $glpi_db;
-    try {
-        $where_status = " t.status IN (1,2,3,4) AND t.is_deleted = 0 ";
-        $join_assignee = " LEFT JOIN glpi_tickets_users tu ON t.id = tu.tickets_id AND tu.type = 2 ";
-        if ($executor_id !== 'all') {
-            $where_status .= $glpi_db->prepare(' AND tu.users_id = %d ', (int) $executor_id);
-        }
-        $sql = "
-            SELECT  t.id, t.status, t.time_to_resolve,
-                    t.name, t.content, t.date,
-                    tu.users_id AS assignee_id,
-                    tu_req.users_id AS author_id,
-                    u.realname, u.firstname,
-                    c.completename AS category_name,
-                    l.completename AS location_name
-            FROM glpi_tickets t
-            $join_assignee
-            LEFT JOIN glpi_tickets_users tu_req ON t.id = tu_req.tickets_id AND tu_req.type = 1
-            LEFT JOIN glpi_users u ON tu.users_id = u.id
-            LEFT JOIN glpi_itilcategories c ON t.itilcategories_id = c.id
-            LEFT JOIN glpi_locations l ON t.locations_id = l.id
-            WHERE $where_status
-            ORDER BY t.date DESC
-            LIMIT 500
-        ";
-        $rows = $glpi_db->get_results($sql, ARRAY_A);
-        if ($glpi_db->last_error) {
-            return [];
-        }
-        return $rows ? $rows : [];
-    } catch (Throwable $e) {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            error_log('glpi_db_get_tickets_by_executor: ' . $e->getMessage());
-        }
-        return [];
-    }
 }
 
 /**

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -27,6 +27,7 @@ function gexe_glpi_localize_runtime() {
     wp_localize_script('gexe-filter', 'GLPI_RUNTIME', [
         'ajax_url' => admin_url('admin-ajax.php'),
         'nonce'    => wp_create_nonce('gexe_actions'),
+        'user_glpi_id' => $current,
         'current_glpi_user_id' => $current,
         'can_view_all' => $can_view_all,
         'features' => $features,
@@ -700,8 +701,6 @@ function gexe_check_mapping() {
 
 /* -------- AJAX: добавить комментарий -------- */
 add_action('wp_ajax_glpi_comment_add', 'gexe_glpi_comment_add');
-add_action('wp_ajax_glpi_executors', 'gexe_glpi_executors');
-add_action('wp_ajax_glpi_filter_tickets', 'gexe_glpi_filter_tickets');
 function gexe_glpi_comment_add($action = 'comment', $content_override = null) {
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     if ($content_override !== null) {
@@ -763,139 +762,3 @@ function gexe_glpi_comment_add($action = 'comment', $content_override = null) {
 gexe_action_response(true, 'ok', $ticket_id, $action, '', ['extra' => ['followup' => $res['followup']]]);
 }
 
-function gexe_glpi_executors() {
-    if (function_exists('glpi_current_user_id') ? glpi_current_user_id() !== 2 : true) {
-        wp_send_json_error(['ok' => false, 'code' => 'no_rights'], 403);
-    }
-    try {
-        $rows = glpi_db_get_executors();
-    } catch (Throwable $e) {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            error_log('gexe_glpi_executors: ' . $e->getMessage());
-        }
-        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
-    }
-    if (!is_array($rows)) {
-        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
-    }
-    $list = [];
-    foreach ($rows as $r) {
-        $list[] = [
-            'id'   => (int) ($r['glpi_user_id'] ?? 0),
-            'name' => gexe_compose_short_name($r['realname'] ?? '', $r['firstname'] ?? ''),
-        ];
-    }
-    wp_send_json_success(['ok' => true, 'list' => $list]);
-}
-
-function gexe_glpi_filter_tickets() {
-    if (!is_user_logged_in()) {
-        wp_send_json_error(['ok' => false, 'code' => 'not_logged_in'], 403);
-    }
-    $executor = isset($_POST['executor_id']) ? trim((string) wp_unslash($_POST['executor_id'])) : '';
-    $current  = function_exists('glpi_current_user_id') ? glpi_current_user_id() : 0;
-    if ($executor === '' || $executor === 'all') {
-        $executor = ($current === 2) ? 'all' : $current;
-    } elseif (!ctype_digit($executor) || (int) $executor <= 0) {
-        wp_send_json_error(['ok' => false, 'code' => 'validation'], 400);
-    }
-    if ($executor === 'all' && $current !== 2) {
-        wp_send_json_error(['ok' => false, 'code' => 'no_rights'], 403);
-    }
-    try {
-        $rows = glpi_db_get_tickets_by_executor($executor, $current);
-    } catch (Throwable $e) {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            error_log('gexe_glpi_filter_tickets: ' . $e->getMessage());
-        }
-        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
-    }
-    if (!is_array($rows)) {
-        wp_send_json_error(['ok' => false, 'code' => 'db'], 500);
-    }
-    $tickets = [];
-    foreach ($rows as $r) {
-        $id = (int) ($r['id'] ?? 0);
-        if (!$id) continue;
-        if (!isset($tickets[$id])) {
-            $tickets[$id] = [
-                'id'           => $id,
-                'status'       => (int) ($r['status'] ?? 0),
-                'name'         => (string) ($r['name'] ?? ''),
-                'content'      => (string) ($r['content'] ?? ''),
-                'date'         => (string) ($r['date'] ?? ''),
-                'category'     => (string) ($r['category_name'] ?? ''),
-                'location'     => (string) ($r['location_name'] ?? ''),
-                'executors'    => [],
-                'assignee_ids' => [],
-                'author_id'    => (int) ($r['author_id'] ?? 0),
-                'late'         => ($r['time_to_resolve'] && strtotime($r['time_to_resolve']) < time()),
-            ];
-        }
-        if (!empty($r['realname']) || !empty($r['firstname'])) {
-            $who = gexe_compose_short_name($r['realname'] ?? '', $r['firstname'] ?? '');
-            if ($who && !in_array($who, $tickets[$id]['executors'], true)) {
-                $tickets[$id]['executors'][] = $who;
-            }
-        }
-        $aid = (int) ($r['assignee_id'] ?? 0);
-        if ($aid && !in_array($aid, $tickets[$id]['assignee_ids'], true)) {
-            $tickets[$id]['assignee_ids'][] = $aid;
-        }
-    }
-
-    $status_counts = [1 => 0, 2 => 0, 3 => 0, 4 => 0];
-    $category_counts = [];
-    foreach ($tickets as $t) {
-        $s = (int) $t['status'];
-        if (isset($status_counts[$s])) $status_counts[$s]++;
-        $leaf = gexe_leaf_category($t['category']);
-        if (!isset($category_counts[$leaf])) $category_counts[$leaf] = 0;
-        $category_counts[$leaf]++;
-    }
-    ksort($category_counts, SORT_NATURAL);
-
-    $categories = [];
-    foreach ($category_counts as $leaf => $cnt) {
-        $slug = gexe_cat_slug($leaf);
-        $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf)) : '<i class="fa-solid fa-tag"></i>';
-        $categories[] = [
-            'slug'  => strtolower($slug),
-            'label' => $leaf,
-            'count' => (int) $cnt,
-            'icon'  => $icon,
-            'depth' => 0,
-        ];
-    }
-
-    ob_start();
-    foreach ($tickets as $t) {
-        $assignees_str = implode(',', $t['assignee_ids']);
-        $leaf_cat = gexe_leaf_category($t['category']);
-        $cat_slug = gexe_cat_slug($leaf_cat);
-        $icon = function_exists('glpi_get_icon_by_category') ? glpi_get_icon_by_category(mb_strtolower($leaf_cat)) : '';
-        $clean_desc = gexe_clean_html_text($t['content']);
-        $desc_short = esc_html(gexe_trim_words($clean_desc, 40, '…'));
-        $link = gexe_glpi_web_base() . '/front/ticket.form.php?id=' . $t['id'];
-        $executors_html = '';
-        if (!empty($t['executors'])) {
-            $exec_names = array_map('esc_html', $t['executors']);
-            $executors_html = '<span class="glpi-executors"><i class="fa-solid fa-user-tie glpi-executor"></i> ' . implode(', ', $exec_names) . '</span>';
-        }
-        echo '<div class="glpi-card" data-ticket-id="' . intval($t['id']) . '" data-assignees="' . esc_attr($assignees_str) . '" data-category="' . esc_attr(strtolower($cat_slug)) . '" data-late="' . ($t['late'] ? '1' : '0') . '" data-status="' . esc_attr((string) $t['status']) . '" data-unassigned="' . (empty($t['executors']) ? '1' : '0') . '" data-author="' . intval($t['author_id']) . '">';
-        echo '<div class="glpi-badge ' . esc_attr($cat_slug) . '">' . $icon . ' ' . esc_html($leaf_cat) . '</div>';
-        echo '<div class="glpi-card-header"><h3 class="ticket-card__title"><a href="' . esc_url($link) . '" class="glpi-topic" target="_blank" rel="noopener noreferrer">' . esc_html($t['name']) . '</a></h3><div class="glpi-ticket-id">#' . intval($t['id']) . '</div></div>';
-        echo '<div class="glpi-card-body"><p class="glpi-desc" data-full="' . esc_attr($clean_desc) . '">' . $desc_short . '</p></div>';
-        echo '<div class="glpi-executor-footer">' . $executors_html . '</div>';
-        echo '<div class="glpi-date-footer" data-date="' . esc_attr($t['date']) . '"></div>';
-        echo '</div>';
-    }
-    $html = ob_get_clean();
-
-    wp_send_json_success([
-        'ok'            => true,
-        'html'          => $html,
-        'status_counts' => $status_counts,
-        'categories'    => $categories,
-    ]);
-}

--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -27,7 +27,7 @@ function gexe_get_glpi_user_id($wp_user_id) {
     }
 
     // Read raw meta, cast to integer and ensure positivity.
-    $raw = get_user_meta($wp_user_id, 'glpi_user_id', true);
+    $raw = function_exists('get_user_meta') ? get_user_meta($wp_user_id, 'glpi_user_id', true) : 0;
     $id  = (int) $raw;
     $id  = $id > 0 ? $id : 0;
 

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -130,11 +130,6 @@ function gexe_cat_slug($leaf) {
         <div class="glpi-category-block">
           <button type="button" class="glpi-cat-toggle" aria-expanded="false" aria-controls="glpi-categories-inline">Категории</button>
         </div>
-        <?php
-        $show_executors = function_exists('glpi_current_user_id') && glpi_current_user_id() === 2;
-        if ($show_executors): ?>
-          <div class="glpi-executor-block" data-executors-menu></div>
-        <?php endif; ?>
       </div>
 
       <div class="glpi-header-center">
@@ -204,8 +199,7 @@ function gexe_cat_slug($leaf) {
       $assignees     = array_values(array_unique($assignees, SORT_NUMERIC));
       $assignees_str = implode(',', $assignees);
 
-      $is_late       = !empty($t['late']); 
-      $is_unassigned = empty($t['executors']);
+      $is_late       = !empty($t['late']);
 
       $name_raw      = trim((string)$t['name']);
       $name          = esc_html($name_raw);
@@ -228,22 +222,7 @@ function gexe_cat_slug($leaf) {
       // Прямая ссылка в GLPI
       $link = 'http://192.168.100.12/glpi/front/ticket.form.php?id=' . intval($t['id']);
 
-        $executors_html = '';
-        if (!empty($t['executors'])) {
-          $exec_names = $t['executors'];
-          if ($is_logged_in) {
-            // Hide executor icon and initials for authorized users
-            $exec_names = [];
-          }
-          $exec_names = array_map('esc_html', $exec_names);
-          $exec_names = array_filter($exec_names, 'strlen');
-          if (!empty($exec_names)) {
-            $names = implode(', ', $exec_names);
-            $executors_html = '<span class="glpi-executors"><i class="fa-solid fa-user-tie glpi-executor"></i> ' . $names . '</span>';
-          }
-        }
-
-      $footer_html = $location_html . $executors_html;
+      $footer_html = $location_html;
     ?>
       <div class="glpi-card"
            data-ticket-id="<?php echo intval($t['id']); ?>"
@@ -251,7 +230,6 @@ function gexe_cat_slug($leaf) {
            data-category="<?php echo esc_attr(strtolower($cat_slug)); ?>"
            data-late="<?php echo $is_late ? '1':'0'; ?>"
            data-status="<?php echo esc_attr((string)$t['status']); ?>"
-           data-unassigned="<?php echo $is_unassigned ? '1':'0'; ?>"
            data-author="<?php echo intval($t['author_id'] ?? 0); ?>">
         <div class="glpi-badge <?php echo esc_attr($cat_slug); ?>"><?php echo $icon; ?> <?php echo esc_html($leaf_cat); ?></div>
         <div class="glpi-card-header<?php echo $is_late ? ' late':''; ?>">


### PR DESCRIPTION
## Summary
- remove trigger installation and executor queries from GLPI DB setup
- localise runtime with default flags and drop executor-specific AJAX handlers
- omit executors UI and guard client code behind feature flags

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-modal-actions.php`
- `php -l templates/glpi-cards-template.php`
- `php -l inc/user-map.php`
- `composer validate`
- `npm test` *(fails: Error: no test specified)*
- `npx eslint --parser-options=ecmaVersion:2020 gexe-filter.js` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd097a66a483289b33931e4fd21461