### PR TITLE
Harden runtime and disable executor feature behind flag

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -101,8 +101,8 @@ body {
 .glpi-ticket-id { font-size: 13px; color: #64748b; }
 .glpi-card-body { font-size: 14px; color: #cbd5e1; line-height: 1.4; margin-bottom: 12px; max-height: 2.8em; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 
-.glpi-executor-footer { position: absolute; bottom: .5rem; left: .75rem; font-size: 12px; color: #94a3b8; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.glpi-executor-footer i { margin-right: 4px; opacity: .6; }
+.glpi-location-footer { position: absolute; bottom: .5rem; left: .75rem; font-size: 12px; color: #94a3b8; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.glpi-location-footer i { margin-right: 4px; opacity: .6; }
 .glpi-date-footer { position: absolute; bottom: .5rem; right: .75rem; font-size: 12px; font-weight: 500; color: #9ca3af; }
 .glpi-date-footer.age-green  { color: #28a745 !important; }
 .glpi-date-footer.age-red    { color: #dc3545 !important; }
@@ -330,7 +330,7 @@ button.disabled{opacity:.5;cursor:not-allowed;}
   text-overflow:unset;
   display:block;
 }
-.glpi-card--in-modal .glpi-executor-footer,
+.glpi-card--in-modal .glpi-location-footer,
 .glpi-card--in-modal .glpi-date-footer{ position:static; display:inline-block; margin:6px 12px 0 0; }
 
 /* ======= Модалки комментария и статусов ======= */
@@ -367,4 +367,6 @@ button[disabled]{cursor:not-allowed;opacity:.6;}
 
 /* Утилиты */
 .glpi-card.gexe-hide{display:none!important;}
-.gexe-hide-executors{display:none!important;}
+.gexe-hide-executors,
+.gexe-hide-executors .glpi-executor-block,
+.gexe-hide-executors .glpi-location-footer{display:none!important;}

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -9,8 +9,9 @@
 (function () {
   'use strict';
 
-  // Ensure AJAX settings are available under both legacy and new globals
-  const ajaxConfig = window.GLPI_RUNTIME || window.gexeAjax || window.glpiAjax || {};
+  const R = window.GLPI_RUNTIME || { features: {} };
+  window.GLPI_RUNTIME = R;
+  const ajaxConfig = (R.ajax_url && R.nonce) ? R : {};
   if (ajaxConfig.current_glpi_user_id && !ajaxConfig.user_glpi_id) {
     ajaxConfig.user_glpi_id = ajaxConfig.current_glpi_user_id;
   }
@@ -21,6 +22,7 @@
   window.gexeAjax = ajaxConfig;
   const glpiAjax = ajaxConfig;
   window.GEXE_DEBUG = window.GEXE_DEBUG || false;
+  const EXEC_FEATURE = !!(R.features && R.features.executors === true && R.current_glpi_user_id === 2);
 
   const ERROR_MAP = {
     csrf: 'Сессия устарела. Обновите страницу.',
@@ -523,8 +525,7 @@
       loadOne('categories', catSel),
       loadOne('locations', locSel)
     ];
-    const rt = window.GLPI_RUNTIME || {};
-    if (rt.features && rt.features.executors) {
+    if (EXEC_FEATURE) {
       dictPromises.push(loadOne('executors', execSel));
     }
     Promise.all(dictPromises).then(([cat, loc]) => {
@@ -625,7 +626,12 @@
   let categoriesLoaded = false;
 
   /* ========================= ФИЛЬТР ИСПОЛНИТЕЛЕЙ ========================= */
-  let selectedExecutor = localStorage.getItem('glpi.executor_id') || 'all';
+  let selectedExecutor = 'all';
+  if (EXEC_FEATURE) {
+    try {
+      selectedExecutor = localStorage.getItem('glpi.executor_id') || 'all';
+    } catch (e) {}
+  }
 
   function resetCategories(){
     selectedCategories = [];
@@ -770,14 +776,21 @@
       if (sel) sel.disabled = false;
       if (res && res.ok) {
         applyExecutorResponse(res.data);
-      } else if (res && res.code) {
-        showError(res.code);
+      } else {
+        showError(res && res.code ? res.code : 'network_error');
       }
+    }).catch(() => {
+      if (sel) sel.disabled = false;
+      showError('network_error');
     });
   }
 
   function initExecutorFilter(){
-    if (!window.GLPI_RUNTIME || !GLPI_RUNTIME.features || !GLPI_RUNTIME.features.executors) return;
+    if (!EXEC_FEATURE) {
+      const b = document.querySelector('.glpi-executor-block');
+      if (b) b.classList.add('gexe-hide-executors');
+      return;
+    }
     try {
       const block = document.querySelector('.glpi-executor-block');
       if (!block) return;
@@ -795,13 +808,19 @@
           select.value = selectedExecutor;
           updateExecutorBadge(select);
           if (selectedExecutor !== 'all') loadTicketsForExecutor(selectedExecutor, select);
+        } else {
+          select.disabled = false;
+          showError(res && res.code ? res.code : 'network_error');
         }
+      }).catch(() => {
+        select.disabled = false;
+        showError('network_error');
       });
       select.addEventListener('change', () => {
         const val = select.value;
         if (val === selectedExecutor) return;
         selectedExecutor = val;
-        localStorage.setItem('glpi.executor_id', val);
+        try { localStorage.setItem('glpi.executor_id', val); } catch(e){}
         updateExecutorBadge(select);
         loadTicketsForExecutor(val, select);
       });
@@ -1380,7 +1399,7 @@
       card.insertBefore(bar, card.firstChild);
 
       // чип со счётчиком комментариев (в левом футере)
-      const foot = card.querySelector('.glpi-executor-footer');
+      const foot = card.querySelector('.glpi-location-footer');
       if (foot && !foot.querySelector('.glpi-comments-chip')) {
         const chip = document.createElement('span');
         chip.className = 'glpi-comments-chip';
@@ -1665,7 +1684,11 @@
     injectCardActionButtons();
     applyActionVisibility();
     bindCardOpen();
-    initExecutorFilter();
+    if (EXEC_FEATURE) initExecutorFilter();
+    else {
+      const b = document.querySelector('.glpi-executor-block');
+      if (b) b.classList.add('gexe-hide-executors');
+    }
 
     bindStatusAndSearch();
     recalcStatusCounts();

--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -204,6 +204,59 @@ function glpi_db_get_locations() {
 }
 
 /**
+ * Safely fetch list of active executors.
+ *
+ * @return array<int,array{id:int,name:string}>
+ */
+function glpi_db_get_executors() {
+    global $glpi_db;
+    try {
+        $sql  = "SELECT id, realname AS name FROM glpi_users WHERE is_active=1 ORDER BY realname";
+        $rows = $glpi_db->get_results($sql, ARRAY_A);
+        if (!$rows) return [];
+        return array_map(function ($r) {
+            return [
+                'id'   => (int) ($r['id'] ?? 0),
+                'name' => (string) ($r['name'] ?? ''),
+            ];
+        }, $rows);
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('glpi_db_get_executors: ' . $e->getMessage());
+        }
+        return [];
+    }
+}
+
+/**
+ * Safely fetch ticket identifiers assigned to an executor.
+ *
+ * @param int $executor_id
+ * @return array<int>
+ */
+function glpi_db_get_tasks_by_executor($executor_id) {
+    global $glpi_db;
+    $executor_id = (int) $executor_id;
+    if ($executor_id <= 0) return [];
+    try {
+        $sql  = $glpi_db->prepare(
+            "SELECT t.id FROM glpi_tickets_users tu JOIN glpi_tickets t ON t.id = tu.tickets_id WHERE tu.users_id=%d AND tu.type=2",
+            $executor_id
+        );
+        $rows = $glpi_db->get_results($sql, ARRAY_A);
+        if (!$rows) return [];
+        return array_map(function ($r) {
+            return (int) ($r['id'] ?? 0);
+        }, $rows);
+    } catch (Throwable $e) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('glpi_db_get_tasks_by_executor: ' . $e->getMessage());
+        }
+        return [];
+    }
+}
+
+/**
  * Create ticket transaction.
  *
  * @param array $payload

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -15,23 +15,19 @@ function gexe_glpi_localize_runtime() {
     if (!function_exists('wp_localize_script')) return;
     if (!wp_script_is('gexe-filter', 'enqueued')) return;
 
-    $current = function_exists('glpi_current_user_id') ? glpi_current_user_id() : 0;
+    $current = function_exists('glpi_current_user_id') ? (int) glpi_current_user_id() : 0;
     $can_view_all = false;
     if (is_user_logged_in() && function_exists('get_current_user_id')) {
         $can_view_all = (get_user_meta(get_current_user_id(), 'glpi_show_all_cards', true) === '1');
     }
-    $features = [
-        'executors' => ($current === 2),
-    ];
-
-    wp_localize_script('gexe-filter', 'GLPI_RUNTIME', [
-        'ajax_url' => admin_url('admin-ajax.php'),
-        'nonce'    => wp_create_nonce('gexe_actions'),
-        'user_glpi_id' => $current,
+    $runtime = [
+        'ajax_url'             => admin_url('admin-ajax.php'),
+        'nonce'                => wp_create_nonce('gexe_actions'),
         'current_glpi_user_id' => $current,
-        'can_view_all' => $can_view_all,
-        'features' => $features,
-    ]);
+        'can_view_all'         => (bool) $can_view_all,
+        'features'             => ['executors' => false],
+    ];
+    wp_localize_script('gexe-filter', 'GLPI_RUNTIME', $runtime);
 }
 
 function gexe_action_response($ok, $code, $ticket_id, $action, $msg = '', $extra = []) {
@@ -411,7 +407,7 @@ function gexe_glpi_get_comments() {
     $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
     $page      = isset($_POST['page']) ? intval($_POST['page']) : 1;
     $per_page  = isset($_POST['per_page']) ? intval($_POST['per_page']) : 20;
-    wp_send_json(gexe_render_comments($ticket_id, $page, $per_page));
+    wp_send_json_success(gexe_render_comments($ticket_id, $page, $per_page));
 }
 
 function gexe_render_followup($id) {
@@ -485,7 +481,7 @@ function gexe_glpi_count_comments_batch() {
     $ids_raw = isset($_POST['ticket_ids']) ? (string)$_POST['ticket_ids'] : '';
     $ids = array_filter(array_map('intval', explode(',', $ids_raw)));
     if (empty($ids)) {
-        wp_send_json(['counts' => []]);
+        wp_send_json_success(['counts' => []]);
     }
 
     $out = [];
@@ -526,7 +522,7 @@ function gexe_glpi_count_comments_batch() {
         }
     }
 
-    wp_send_json(['counts' => $out]);
+    wp_send_json_success(['counts' => $out]);
 }
 
 /* -------- AJAX: проверка "Принято в работу" -------- */

--- a/inc/user-map.php
+++ b/inc/user-map.php
@@ -55,27 +55,30 @@ function gexe_require_glpi_user($wp_user_id) {
 /**
  * Return GLPI user id associated with the current WordPress user.
  *
- * Falls back to `0` when the mapping is missing or invalid. The function is
- * intentionally defensive: it performs capability checks and avoids throwing
- * exceptions so template code can safely call it without additional guards.
+ * Read-only helper. Falls back to `0` when the mapping is missing or invalid.
+ * The function is intentionally defensive: it performs capability checks and
+ * avoids throwing exceptions so template code can safely call it without
+ * additional guards.
  *
  * @return int GLPI users.id or 0 when not mapped or user not logged in.
  */
-function glpi_current_user_id() {
-    if (!function_exists('is_user_logged_in') || !is_user_logged_in()) {
-        return 0;
-    }
-    if (!function_exists('get_current_user_id')) {
-        return 0;
-    }
-    try {
-        $gid = gexe_get_glpi_user_id(get_current_user_id());
-        return ($gid > 0) ? $gid : 0;
-    } catch (Throwable $e) {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            error_log('glpi_current_user_id: ' . $e->getMessage());
+if (!function_exists('glpi_current_user_id')) {
+    function glpi_current_user_id() {
+        if (!function_exists('is_user_logged_in') || !is_user_logged_in()) {
+            return 0;
         }
-        return 0;
+        if (!function_exists('get_current_user_id')) {
+            return 0;
+        }
+        try {
+            $gid = gexe_get_glpi_user_id(get_current_user_id());
+            return ($gid > 0) ? $gid : 0;
+        } catch (Throwable $e) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('glpi_current_user_id: ' . $e->getMessage());
+            }
+            return 0;
+        }
     }
 }
 

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -195,10 +195,6 @@ function gexe_cat_slug($leaf) {
   <!-- Карточки -->
   <div class="glpi-wrapper">
     <?php foreach ($tickets as $t):
-      $assignees     = array_map('intval', $t['assignee_ids'] ?? []);
-      $assignees     = array_values(array_unique($assignees, SORT_NUMERIC));
-      $assignees_str = implode(',', $assignees);
-
       $is_late       = !empty($t['late']);
 
       $name_raw      = trim((string)$t['name']);
@@ -226,7 +222,6 @@ function gexe_cat_slug($leaf) {
     ?>
       <div class="glpi-card"
            data-ticket-id="<?php echo intval($t['id']); ?>"
-           data-assignees="<?php echo esc_attr($assignees_str); ?>"
            data-category="<?php echo esc_attr(strtolower($cat_slug)); ?>"
            data-late="<?php echo $is_late ? '1':'0'; ?>"
            data-status="<?php echo esc_attr((string)$t['status']); ?>"
@@ -241,7 +236,9 @@ function gexe_cat_slug($leaf) {
         <div class="glpi-card-body">
           <p class="glpi-desc" data-full="<?php echo esc_attr($clean_desc); ?>"><?php echo $desc_short; ?></p>
         </div>
-        <div class="glpi-executor-footer"><?php echo $footer_html; ?></div>
+        <?php if ($footer_html !== ''): ?>
+          <div class="glpi-location-footer"><?php echo $footer_html; ?></div>
+        <?php endif; ?>
         <div class="glpi-date-footer" data-date="<?php echo esc_attr((string)$t['date']); ?>"></div>
       </div>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Localize GLPI_RUNTIME with safe defaults and disable executors by default
- Strip executor markup from cards and guard executor UI behind feature flag
- Add resilient DB helpers and CSS/JS fallbacks when feature is off

## Testing
- `php -l templates/glpi-cards-template.php`
- `php -l glpi-modal-actions.php`
- `php -l glpi-db-setup.php`
- `php -l inc/user-map.php`
- `node -c gexe-filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0e86785c8328883138943e3003f1