### PR TITLE
fix: ensure card title color remains white

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -58,7 +58,7 @@ body {
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.4;
-  color: inherit;
+  color: #fff;
   text-transform: none;
   letter-spacing: normal;
 }
@@ -72,6 +72,11 @@ body {
   white-space: normal;
   word-break: break-word;
   display: block;
+}
+.glpi-topic:hover,
+.glpi-topic:active,
+.glpi-topic:visited {
+  color: inherit;
 }
 /* font-size and weight remain consistent across breakpoints */
 /* Обёртка заголовка карточки */


### PR DESCRIPTION
## Summary
- force white text for card headers
- prevent link state colors from overriding card titles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd202f866c832888b1eb16abf48a58