### PR TITLE
feat: allow assignee selection on ticket creation

### DIFF
--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -14,6 +14,7 @@
 .glpi-create-modal .gnt-select { width: 100%; background: #0b1220; border: 1px solid #1f2937; border-radius: 10px; color: #e5e7eb; padding: 10px 12px; }
 .glpi-create-modal .gnt-textarea { resize: vertical; min-height: 120px; }
 .glpi-create-modal .gnt-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 8px; }
+.glpi-create-modal .gnt-row.gnt-assign-row { grid-template-columns: auto 1fr; align-items: center; }
 .glpi-create-modal .gnt-check { display: flex; align-items: center; gap: 8px; margin: 12px auto 0; font-size: 14px; color: #e5e7eb; }
 .glpi-create-modal .gnt-footer { padding: 14px 16px; background: #0b1220; }
 .glpi-create-modal .gnt-submit { width: 100%; background: #2563eb; border: 0; color: #fff; padding: 10px 14px; border-radius: 10px; cursor: pointer; display: block; }

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -17,10 +17,14 @@ add_action('wp_enqueue_scripts', function () {
 
     wp_register_script('glpi-new-task-js', plugin_dir_url(__FILE__) . 'glpi-new-task.js', [], '1.0.0', true);
     wp_enqueue_script('glpi-new-task-js');
-    wp_localize_script('glpi-new-task-js', 'glpiAjax', [
-        'url'   => admin_url('admin-ajax.php'),
-        'nonce' => wp_create_nonce('glpi_new_task'),
-    ]);
+
+    $data = [
+        'url'          => admin_url('admin-ajax.php'),
+        'nonce'        => wp_create_nonce('glpi_new_task'),
+        'user_glpi_id' => (int) gexe_get_current_glpi_uid(),
+        'assignees'    => function_exists('gexe_get_assignee_options') ? gexe_get_assignee_options() : [],
+    ];
+    wp_localize_script('glpi-new-task-js', 'glpiAjax', $data);
 });
 
 /** Verify AJAX nonce. */


### PR DESCRIPTION
## Summary
- enable assignee selection when creating GLPI tickets
- expose assignee list to the new ticket modal
- style and wire assignee selector with self-assignment support

## Testing
- `npm test` *(fails: no test specified)*
- `node --check gexe-filter.js`

------
https://chatgpt.com/codex/tasks/task_e_68bd1f2699cc83288e47a4026e113527