### PR TITLE
feat: load GLPI dictionaries in new ticket modal

### DIFF
--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -12,12 +12,17 @@
 .glpi-create-modal .gnt-input,
 .glpi-create-modal .gnt-textarea,
 .glpi-create-modal .gnt-select { width: 100%; background: #0b1220; border: 1px solid #1f2937; border-radius: 10px; color: #e5e7eb; padding: 10px 12px; }
-.glpi-create-modal .gnt-textarea { resize: vertical; min-height: 120px; }
+.glpi-create-modal #gnt-name,
+.glpi-create-modal #gnt-content { height:130px; }
+.glpi-create-modal #gnt-content { resize:none; }
 .glpi-create-modal .gnt-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 8px; }
 .glpi-create-modal .gnt-check { display: flex; align-items: center; gap: 8px; margin: 12px auto 0; font-size: 14px; color: #e5e7eb; }
 .glpi-create-modal .gnt-footer { padding: 14px 16px; background: #0b1220; }
 .glpi-create-modal .gnt-submit { width: 100%; background: #2563eb; border: 0; color: #fff; padding: 10px 14px; border-radius: 10px; cursor: pointer; display: block; }
 .glpi-create-modal .gnt-submit:disabled { opacity: .7; cursor: default; }
+.glpi-create-modal .gnt-input:disabled,
+.glpi-create-modal .gnt-textarea:disabled,
+.glpi-create-modal .gnt-select:disabled { opacity:.6; cursor:not-allowed; }
 .glpi-create-modal .gnt-path { margin-top: 4px; font-size: 12px; color: #94a3b8; }
 .glpi-create-modal .gnt-field-error { color:#f87171; font-size:12px; margin-top:4px; }
 .glpi-create-modal .gnt-input.gnt-invalid,
@@ -30,10 +35,10 @@
 /* Loader and busy state */
 .glpi-create-modal .gnt-dialog[aria-busy="true"] { cursor: wait; }
 .glpi-create-modal .gnt-dialog[aria-busy="true"] .gnt-body { opacity: .6; }
-.glpi-create-modal .glpi-form-loader { display: flex; align-items: center; gap: 8px; justify-content: center; margin-bottom: 12px; }
-.glpi-create-modal .glpi-form-loader .spinner { width:16px; height:16px; border:2px solid #94a3b8; border-top-color:#2563eb; border-radius:50%; animation: gnt-spin .6s linear infinite; }
-.glpi-create-modal .glpi-form-loader .error { color:#f87171; }
-.glpi-create-modal .glpi-form-loader .gnt-retry { background:#2563eb; border:0; color:#fff; padding:4px 8px; border-radius:6px; cursor:pointer; }
+.glpi-create-modal .gexe-dict-status { display:flex; align-items:center; gap:8px; justify-content:center; margin-bottom:12px; }
+.glpi-create-modal .gexe-dict-status .spinner { width:16px; height:16px; border:2px solid #94a3b8; border-top-color:#2563eb; border-radius:50%; animation:gnt-spin .6s linear infinite; }
+.glpi-create-modal .gexe-dict-status .error { color:#f87171; }
+.glpi-create-modal .gexe-dict-status .gnt-retry { background:#2563eb; border:0; color:#fff; padding:4px 8px; border-radius:6px; cursor:pointer; }
 @keyframes gnt-spin { to { transform: rotate(360deg); } }
 
 /* Success modal */

--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -27,7 +27,7 @@
         <button type="button" class="gnt-close" aria-label="Закрыть">×</button>
       </div>
         <div class="gnt-body">
-          <div class="glpi-form-loader" role="status" aria-live="polite" hidden></div>
+          <div class="gexe-dict-status glpi-form-loader" role="status" aria-live="polite" hidden></div>
           <label for="gnt-name" class="gnt-label">Тема</label>
           <input id="gnt-name" type="text" class="gnt-input" />
           <div id="gnt-name-err" class="gnt-field-error" hidden></div>
@@ -63,7 +63,7 @@
           </div>
         </div>
         <div class="gnt-footer">
-          <button type="button" class="gnt-submit">Создать</button>
+          <button type="button" class="gnt-submit">Создать заявку</button>
         </div>
       </div>
     `;
@@ -119,21 +119,21 @@
   }
 
   function showLoading(){
-    const box = modal.querySelector('.glpi-form-loader');
+    const box = modal.querySelector('.gexe-dict-status');
     if (!box) return;
     box.innerHTML = '<span class="spinner"></span><span>Загружаем справочники…</span>';
     box.hidden = false;
   }
 
   function hideLoader(){
-    const box = modal.querySelector('.glpi-form-loader');
+    const box = modal.querySelector('.gexe-dict-status');
     if (!box) return;
     box.hidden = true;
     box.innerHTML = '';
   }
 
   function showError(message){
-    const box = modal.querySelector('.glpi-form-loader');
+    const box = modal.querySelector('.gexe-dict-status');
     if (!box) return;
     const msg = 'Не удалось загрузить справочники категорий и местоположений. ' + (message || 'Попробуйте ещё раз.');
     box.innerHTML = '<span class="error">' + msg + '</span><button type="button" class="gnt-retry">Повторить</button>';
@@ -146,7 +146,7 @@
   }
 
   function showSubmitError(message){
-    const box = modal.querySelector('.glpi-form-loader');
+    const box = modal.querySelector('.gexe-dict-status');
     if (!box) return;
     box.innerHTML = '<span class="error">' + (message || 'Ошибка создания заявки') + '</span>';
     box.hidden = false;
@@ -199,7 +199,8 @@
     buildModal();
     modal.classList.add('open');
     document.body.classList.add('glpi-modal-open');
-    lockForm(false);
+    lockForm(true);
+    window.dispatchEvent(new CustomEvent('gexe:newtask:open'));
     updatePaths();
   }
 


### PR DESCRIPTION
## Summary
- fetch GLPI categories and locations in one cached AJAX endpoint
- lock and populate New Ticket modal after dictionary load with retry on errors
- adjust modal UI: dedicated status area, equal field heights, and new button text

## Testing
- `php -l glpi-modal-actions.php`
- `npx eslint glpi-new-task.js gexe-filter.js` *(fails: Parsing error)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2156d4948328820baefa9fb0b24e