### PR TITLE
feat: load GLPI dictionaries in new ticket modal

### DIFF
--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -465,7 +465,7 @@
     const execSel = modal.querySelector('#gnt-assignee');
     const assignChk = modal.querySelector('#gnt-assign-me');
     const submit = modal.querySelector('.gnt-submit');
-    const loader = modal.querySelector('.glpi-form-loader');
+    const loader = modal.querySelector('.gexe-dict-status');
 
     if (loader) {
       loader.innerHTML = '<span class="spinner"></span><span>Загрузка…</span>';

--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -12,13 +12,17 @@
 .glpi-create-modal .gnt-input,
 .glpi-create-modal .gnt-textarea,
 .glpi-create-modal .gnt-select { width: 100%; background: #0b1220; border: 1px solid #1f2937; border-radius: 10px; color: #e5e7eb; padding: 10px 12px; }
-.glpi-create-modal .gnt-textarea { resize: vertical; min-height: 120px; }
+.glpi-create-modal .gnt-textarea { resize: none; }
+.glpi-create-modal #gnt-name,
+.glpi-create-modal #gnt-content { height:130px; }
 .glpi-create-modal .gnt-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 8px; }
 .glpi-create-modal .gnt-row.gnt-assign-row { grid-template-columns: auto 1fr; align-items: center; }
 .glpi-create-modal .gnt-check { display: flex; align-items: center; gap: 8px; margin: 12px auto 0; font-size: 14px; color: #e5e7eb; }
 .glpi-create-modal .gnt-footer { padding: 14px 16px; background: #0b1220; }
 .glpi-create-modal .gnt-submit { width: 100%; background: #2563eb; border: 0; color: #fff; padding: 10px 14px; border-radius: 10px; cursor: pointer; display: block; }
 .glpi-create-modal .gnt-submit:disabled { opacity: .7; cursor: default; }
+.glpi-create-modal .gnt-submit.is-loading { position:relative; color:transparent; }
+.glpi-create-modal .gnt-submit.is-loading::after { content:''; position:absolute; top:50%; left:50%; width:16px; height:16px; margin:-8px 0 0 -8px; border:2px solid #fff; border-top-color:transparent; border-radius:50%; animation:gnt-spin .6s linear infinite; }
 .glpi-create-modal .gnt-path { margin-top: 4px; font-size: 12px; color: #94a3b8; }
 .glpi-create-modal .gnt-field-error { color:#f87171; font-size:12px; margin-top:4px; }
 .glpi-create-modal .gnt-input.gnt-invalid,
@@ -31,10 +35,10 @@
 /* Loader and busy state */
 .glpi-create-modal .gnt-dialog[aria-busy="true"] { cursor: wait; }
 .glpi-create-modal .gnt-dialog[aria-busy="true"] .gnt-body { opacity: .6; }
-.glpi-create-modal .glpi-form-loader { display: flex; align-items: center; gap: 8px; justify-content: center; margin-bottom: 12px; }
-.glpi-create-modal .glpi-form-loader .spinner { width:16px; height:16px; border:2px solid #94a3b8; border-top-color:#2563eb; border-radius:50%; animation: gnt-spin .6s linear infinite; }
-.glpi-create-modal .glpi-form-loader .error { color:#f87171; }
-.glpi-create-modal .glpi-form-loader .gnt-retry { background:#2563eb; border:0; color:#fff; padding:4px 8px; border-radius:6px; cursor:pointer; }
+.glpi-create-modal .gexe-dict-status { display: flex; align-items: center; gap: 8px; justify-content: center; margin-bottom: 12px; }
+.glpi-create-modal .gexe-dict-status .spinner { width:16px; height:16px; border:2px solid #94a3b8; border-top-color:#2563eb; border-radius:50%; animation: gnt-spin .6s linear infinite; }
+.glpi-create-modal .gexe-dict-status .error { color:#f87171; }
+.glpi-create-modal .gexe-dict-status .gnt-retry { background:#2563eb; border:0; color:#fff; padding:4px 8px; border-radius:6px; cursor:pointer; }
 @keyframes gnt-spin { to { transform: rotate(360deg); } }
 
 /* Success modal */

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -20,7 +20,7 @@ add_action('wp_enqueue_scripts', function () {
 
     $data = [
         'url'          => admin_url('admin-ajax.php'),
-        'nonce'        => wp_create_nonce('glpi_new_task'),
+        'nonce'        => wp_create_nonce('gexe_actions'),
         'user_glpi_id' => (int) gexe_get_current_glpi_uid(),
         'assignees'    => function_exists('gexe_get_assignee_options') ? gexe_get_assignee_options() : [],
     ];
@@ -29,7 +29,7 @@ add_action('wp_enqueue_scripts', function () {
 
 /** Verify AJAX nonce. */
 function glpi_nt_verify_nonce() {
-    if (!check_ajax_referer('glpi_new_task', 'nonce', false)) {
+    if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
         wp_send_json(['ok' => false, 'code' => 'csrf']);
     }
 }


### PR DESCRIPTION
## Summary
- add cached SQL endpoint returning GLPI categories and locations
- lock new ticket modal until dictionaries load and show retryable errors
- align theme and description field heights and update button text

## Testing
- `npm test` *(fails: no test specified)*
- `composer test` *(fails: command not defined)*
- `php -l glpi-modal-actions.php glpi-new-task.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd2339441c83288db23e873003bfcf