### PR TITLE
feat: add planned status actions

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -358,6 +358,7 @@ button.disabled{opacity:.5;cursor:not-allowed;}
 #gexe-cmnt-send.glpi-act:hover{background:#334155}
 .glpi-status-btn.glpi-act{background:#475569;border:1px solid #334155;color:#fff;border-radius:10px;font-weight:700;padding:10px 16px;min-width:120px}
 .glpi-status-btn.glpi-act:hover{background:#334155}
+.glpi-status-btn.glpi-act:disabled{background:#1e293b;color:#64748b;border-color:#334155;cursor:not-allowed}
 .gexe-assignee-block{display:flex;gap:8px;align-items:center}
 .gexe-assignee-select{flex:1;padding:8px 10px;border-radius:10px;background:#1e293b;color:#e5e7eb;border:1px solid #334155}
 .gexe-assignee-select:disabled{opacity:.5}

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -61,6 +61,7 @@ add_action('wp_enqueue_scripts', function () {
         'solvedStatus'      => (int) get_option('glpi_solved_status', 6),
         'webBase'           => gexe_glpi_web_base(),
         'assignees'         => gexe_get_assignee_options(),
+        'planned_status_id' => (int) gexe_glpi_status_map()['planned'],
     ]);
 });
 

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -605,7 +605,11 @@ function gexe_glpi_change_status($legacy = false) {
     $followup = $texts[$status_id] ?? '';
     $res = sql_ticket_set_status($ticket_id, $glpi_uid, $status_id, $followup);
     if (!$res['ok']) {
-        gexe_action_response(false, $res['code'] ?? 'sql_error', $ticket_id, $action, '', ['extra' => $res['extra'] ?? []]);
+        $code = $res['code'] ?? 'sql_error';
+        if ($code === 'already_done' && $status_id === $map['planned']) {
+            $code = 'already_planned';
+        }
+        gexe_action_response(false, $code, $ticket_id, $action, '', ['extra' => $res['extra'] ?? []]);
     }
     gexe_clear_comments_cache($ticket_id);
     gexe_action_response(true, 'ok', $ticket_id, $action, '', ['extra' => $res['extra'] ?? []]);


### PR DESCRIPTION
## Summary
- localize planned status ID for frontend
- handle already_planned status on server
- add plan/"Запланировать" button and UI handling
- style disabled status action buttons

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint gexe-filter.js` *(fails: Parsing error: Unexpected token .)*
- `php -l gexe-copy.php`
- `php -l glpi-modal-actions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd235c0c2c832881fcd4ee09772072