### PR TITLE
feat: add manager view switcher for tickets

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -147,7 +147,7 @@ body {
  .glpi-status-row{display:flex;justify-content:center;}
  .glpi-status-blocks{display:flex;flex-wrap:nowrap;gap:12px;}
  .glpi-status-block,
- .glpi-newfilter-block{display:flex;flex-direction:column;justify-content:center;align-items:center;min-width:120px;min-height:72px;padding:12px 14px;border-radius:12px;background:#1f2937;color:#e5e7eb;box-shadow:0 2px 8px rgba(0,0,0,.25);cursor:pointer;user-select:none;transition:transform .08s ease, background-color .15s ease, box-shadow .15s ease;}
+.glpi-newfilter-block{display:flex;flex-direction:column;justify-content:center;align-items:center;min-width:120px;min-height:72px;padding:12px 14px;border-radius:12px;background:#1f2937;color:#e5e7eb;box-shadow:0 2px 8px rgba(0,0,0,.25);cursor:pointer;user-select:none;transition:transform .08s ease, background-color .15s ease, box-shadow .15s ease;}
  .glpi-status-block .status-count,
  .glpi-newfilter-block .status-count{font-size:28px;line-height:1;font-weight:800;}
  .glpi-status-block .status-label,
@@ -159,7 +159,15 @@ body {
  .glpi-status-block.active .status-count,
  .glpi-newfilter-block.active .status-count{color:#111827;}
  .glpi-status-block.active .status-label,
- .glpi-newfilter-block.active .status-label{color:#111827;opacity:1;font-weight:700;}
+.glpi-newfilter-block.active .status-label{color:#111827;opacity:1;font-weight:700;}
+
+/* [manager-switcher] dropdown исполнителей */
+.glpi-executors{position:relative;display:inline-block;margin-left:8px;}
+.glpi-executors__btn{background:#1f2937;border:1px solid #374151;color:#e5e7eb;padding:6px 10px;border-radius:6px;cursor:pointer;}
+.glpi-executors__menu{display:none;position:absolute;right:0;top:100%;background:#1f2937;border:1px solid #374151;border-radius:6px;margin-top:4px;min-width:160px;z-index:1000;list-style:none;padding:4px 0;}
+.glpi-executors.open .glpi-executors__menu{display:block;}
+.glpi-executors__menu li{padding:6px 12px;cursor:pointer;}
+.glpi-executors__menu li:hover{background:#273447;}
 .glpi-search-block{flex:1;display:flex;flex-direction:column;position:relative;}
 .glpi-search-input{all:unset;width:100%;max-width:400px;box-sizing:border-box;background:#1e293b!important;color:#f8fafc!important;padding:10px 34px 10px 14px;border:1px solid #334155;border-radius:6px;font-size:14px;}
 .gexe-search-clear{position:absolute;right:8px;top:50%;transform:translateY(-50%);background:transparent;border:0;color:#94a3b8;width:32px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;}

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -54,6 +54,10 @@ add_action('wp_enqueue_scripts', function () {
     wp_localize_script('gexe-filter', 'glpiAjax', [
         'url'               => admin_url('admin-ajax.php'),
         'nonce'             => wp_create_nonce('gexe_actions'),
+        // [manager-switcher] дополнительные флаги
+        'ajax_url'          => admin_url('admin-ajax.php'),
+        'ajax_nonce'        => wp_create_nonce('gexe_actions'),
+        'is_manager'        => gexe_is_manager() ? 1 : 0,
         'user_glpi_id'      => (int) gexe_get_current_glpi_uid(),
         'current_wp_user_id'=> (int) get_current_user_id(),
         'rest'              => esc_url_raw(rest_url('glpi/v1/')),
@@ -127,6 +131,18 @@ function gexe_glpi_cards_shortcode($atts) {
     if ($current_user && $current_user->ID) {
         $glpi_user_id  = trim((string) get_user_meta($current_user->ID, 'glpi_user_id', true));
         $glpi_show_all = (get_user_meta($current_user->ID, 'glpi_show_all_cards', true) === '1');
+    }
+
+    // [manager-switcher] обработка временного просмотра
+    $view_as = isset($_REQUEST['view_as']) ? trim((string) $_REQUEST['view_as']) : '';
+    if (gexe_is_manager()) {
+        if ($view_as === 'all') {
+            $glpi_show_all = true;
+            $glpi_user_id  = '';
+        } elseif ($view_as !== '' && ctype_digit($view_as)) {
+            $glpi_user_id  = $view_as;
+            $glpi_show_all = false;
+        }
     }
 
     // ---- Базовый запрос по активным тикетам ----

--- a/gexe-filter.js
+++ b/gexe-filter.js
@@ -1777,6 +1777,65 @@
     }
   }
 
+  // [manager-switcher] запрос карточек с переключением исполнителя
+  function reloadTickets(viewAs) {
+    ajaxPost({ action: 'gexe_get_tickets', view_as: viewAs }).then(res => {
+      if (!(res && res.ok && res.data && res.data.html)) {
+        showNotice('error', 'Не удалось применить фильтр исполнителя');
+        return;
+      }
+      const tmp = document.createElement('div');
+      tmp.innerHTML = res.data.html;
+      const newCont = tmp.querySelector('.glpi-container');
+      const oldCont = document.querySelector('.glpi-container');
+      if (newCont && oldCont) {
+        oldCont.replaceWith(newCont);
+        injectCardActionButtons();
+        applyActionVisibility();
+        bindCardOpen();
+        bindStatusAndSearch();
+        recalcStatusCounts();
+        recalcCategoryVisibility();
+        filterCards();
+        updateAgeFooters();
+      }
+    }).catch(() => {
+      showNotice('error', 'Не удалось применить фильтр исполнителя');
+    });
+  }
+
+  // [manager-switcher] инициализация выпадающего списка исполнителей
+  function initManagerSwitcher() {
+    if (!glpiAjax || !glpiAjax.is_manager) return;
+    const panel = document.querySelector('.glpi-filtering-panel');
+    if (!panel) return;
+    const wrap = document.createElement('div');
+    wrap.className = 'glpi-executors';
+    wrap.innerHTML = '<button class="glpi-executors__btn">Исполнители</button><ul class="glpi-executors__menu"></ul>';
+    panel.appendChild(wrap);
+    const menu = wrap.querySelector('.glpi-executors__menu');
+    const btn = wrap.querySelector('.glpi-executors__btn');
+    btn.addEventListener('click', () => { wrap.classList.toggle('open'); });
+    document.addEventListener('click', (e) => { if (!wrap.contains(e.target)) wrap.classList.remove('open'); });
+    ajaxPost({ action: 'gexe_get_executors_list' }).then(res => {
+      if (!(res && res.ok && res.data && Array.isArray(res.data.executors))) return;
+      const addItem = (id, text) => {
+        const li = document.createElement('li');
+        li.dataset.id = id;
+        li.textContent = text;
+        menu.appendChild(li);
+      };
+      addItem('all', 'Без фильтров');
+      res.data.executors.forEach(ex => addItem(String(ex.id), ex.name));
+      menu.addEventListener('click', (e) => {
+        const id = e.target && e.target.dataset ? e.target.dataset.id : '';
+        if (!id) return;
+        wrap.classList.remove('open');
+        reloadTickets(id);
+      });
+    });
+  }
+
   /* ========================= ИНИЦИАЛИЗАЦИЯ ========================= */
   document.addEventListener('DOMContentLoaded', function () {
     ensureOverdueBlock();
@@ -1789,6 +1848,7 @@
 
 
     bindStatusAndSearch();
+    initManagerSwitcher();
     recalcStatusCounts();
     recalcCategoryVisibility();
     filterCards();

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -9,6 +9,17 @@ require_once __DIR__ . '/glpi-utils.php';
 require_once __DIR__ . '/includes/glpi-sql.php';
 require_once __DIR__ . '/includes/glpi-auth-map.php';
 
+// [manager-switcher] Проверка привилегий начальника
+function gexe_is_manager($user = null) {
+    $user = $user ?: wp_get_current_user();
+    if (!$user || !($user->ID ?? 0)) {
+        return false;
+    }
+    $login   = $user->user_login ?? '';
+    $glpi_id = (int) get_user_meta($user->ID, 'glpi_user_id', true);
+    return ($login === 'vks_m5_local') || ($glpi_id === 2);
+}
+
 function gexe_action_response($ok, $code, $ticket_id, $action, $msg = '', $extra = []) {
     $payload = array_merge([
         'ok'        => (bool) $ok,
@@ -1000,4 +1011,28 @@ function gexe_get_glpi_dicts() {
     }
 
     wp_send_json(array_merge(['ok' => true], $data));
+}
+
+// [manager-switcher] Список исполнителей для начальника
+add_action('wp_ajax_gexe_get_executors_list', 'gexe_get_executors_list');
+function gexe_get_executors_list() {
+    check_ajax_referer('gexe_actions', 'nonce');
+    if (!gexe_is_manager()) {
+        wp_send_json_error(['code' => 'forbidden']);
+    }
+    $list = gexe_get_assignee_options();
+    wp_send_json_success(['executors' => $list]);
+}
+
+// [manager-switcher] Получение карточек с учётом view_as
+add_action('wp_ajax_gexe_get_tickets', 'gexe_get_tickets');
+function gexe_get_tickets() {
+    check_ajax_referer('gexe_actions', 'nonce');
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['code' => 'not_logged_in']);
+    }
+    $view_as = isset($_POST['view_as']) ? sanitize_text_field(wp_unslash($_POST['view_as'])) : '';
+    $_REQUEST['view_as'] = $view_as;
+    $html = gexe_glpi_cards_shortcode([]);
+    wp_send_json_success(['html' => $html]);
 }


### PR DESCRIPTION
## Summary
- allow managers to toggle ticket list by executor
- expose manager flag and executors list via AJAX
- add dropdown UI and styling for switching executors

## Testing
- `php -l glpi-modal-actions.php`
- `php -l gexe-copy.php`
- `npm test` *(fails: no test specified)*
- `npx eslint gexe-filter.js` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8eba89508328864220a798f503f7