### PR TITLE
Align category cloud with status filters

### DIFF
--- a/gee.css
+++ b/gee.css
@@ -144,8 +144,9 @@ body {
  .glpi-header-row{position:sticky;top:0;z-index:100;display:flex;flex-direction:column;gap:16px;padding:16px 24px;background:#111827;}
  .glpi-top-row{display:flex;align-items:center;gap:16px;}
  .glpi-top-left{display:flex;align-items:center;gap:16px;}
- .glpi-status-row{display:flex;justify-content:center;}
- .glpi-status-blocks{display:flex;flex-wrap:nowrap;gap:12px;}
+ .glpi-topbar-center{max-width:1200px;margin:0 auto;display:flex;flex-direction:column;gap:16px;padding:0 16px;box-sizing:border-box;}
+ .glpi-status-row,.glpi-category-row{display:flex;justify-content:center;flex-wrap:wrap;gap:16px;}
+.glpi-status-blocks{display:flex;flex-wrap:nowrap;gap:12px;}
  .glpi-status-block,
  .glpi-newfilter-block{display:flex;flex-direction:column;justify-content:center;align-items:center;min-width:120px;min-height:72px;padding:12px 14px;border-radius:12px;background:#1f2937;color:#e5e7eb;box-shadow:0 2px 8px rgba(0,0,0,.25);cursor:pointer;user-select:none;transition:transform .08s ease, background-color .15s ease, box-shadow .15s ease;}
  .glpi-status-block .status-count,
@@ -206,22 +207,17 @@ button.disabled{opacity:.5;cursor:not-allowed;}
 @keyframes gnt-spin{to{transform:rotate(360deg);}}
 
 /* Инлайн-категории */
-.glpi-categories-inline{
+ .glpi-categories-inline{
   display:flex;
   flex-wrap:wrap;
   gap:8px;
-  margin:8px 0;
+  margin:0;
   padding:12px;
   background:#0f172a;
   border:1px solid #334155;
   border-radius:12px;
   box-shadow:0 2px 4px rgba(0,0,0,.3);
-  margin-bottom:var(--glpi-gap-lg);
-}
-
-@media (min-width:1280px){
-  .glpi-categories-inline{margin-bottom:var(--glpi-gap-xl);}
-}
+ }
 .glpi-cat-chip{display:flex;align-items:center;gap:6px;padding:6px 10px;border-radius:8px;background:#1e293b;color:#e5e7eb;font-size:14px;cursor:pointer;white-space:nowrap;}
 .glpi-cat-chip:hover{box-shadow:0 0 0 1px #475569;}
 .glpi-cat-chip.active{background:#facc15;color:#1e1e1e;font-weight:700;}
@@ -231,7 +227,7 @@ button.disabled{opacity:.5;cursor:not-allowed;}
 @media (max-width:768px){
   .glpi-top-row{flex-direction:column;align-items:stretch;}
   .glpi-top-left{width:100%;justify-content:flex-start;}
-  .glpi-status-row{justify-content:flex-start;}
+  .glpi-status-row,.glpi-category-row{justify-content:flex-start;}
   .glpi-search-input{max-width:100%;}
 }
 

--- a/templates/glpi-cards-template.php
+++ b/templates/glpi-cards-template.php
@@ -127,7 +127,6 @@ function gexe_cat_slug($leaf) {
     <?php include __DIR__ . '/glpi-header.php'; ?>
   </div>
 
-  <div class="glpi-categories-inline" id="glpi-categories-inline" aria-label="Категории" hidden></div>
 
   <script>
     // Предзагруженные категории (slug, label, count)

--- a/templates/glpi-header.php
+++ b/templates/glpi-header.php
@@ -19,29 +19,34 @@ if (!defined('ABSPATH')) exit;
       <button type="button" class="gexe-search-clear" aria-label="Очистить поиск" hidden>&times;</button>
     </div>
   </div>
+  <div class="glpi-topbar-center">
+    <div class="glpi-status-row">
+      <div class="glpi-status-blocks">
+        <div class="glpi-status-block status-filter-btn" data-status="all" data-label="Все задачи">
+          <span class="status-count"><?php echo intval($total_count); ?></span>
+          <span class="status-label">Все задачи</span>
+        </div>
+        <div class="glpi-status-block status-filter-btn active" data-status="2" data-label="В работе">
+          <span class="status-count"><?php echo intval($status_counts[2] ?? 0); ?></span>
+          <span class="status-label">В работе</span>
+        </div>
+        <div class="glpi-status-block status-filter-btn" data-status="3" data-label="В плане">
+          <span class="status-count"><?php echo intval($status_counts[3] ?? 0); ?></span>
+          <span class="status-label">В плане</span>
+        </div>
+        <div class="glpi-status-block status-filter-btn" data-status="4" data-label="В стопе">
+          <span class="status-count"><?php echo intval($status_counts[4] ?? 0); ?></span>
+          <span class="status-label">В стопе</span>
+        </div>
+        <div class="glpi-status-block status-filter-btn" data-status="1" data-label="Новые">
+          <span class="status-count"><?php echo intval($status_counts[1] ?? 0); ?></span>
+          <span class="status-label">Новые</span>
+        </div>
+      </div>
+    </div>
 
-  <div class="glpi-status-row">
-    <div class="glpi-status-blocks">
-      <div class="glpi-status-block status-filter-btn" data-status="all" data-label="Все задачи">
-        <span class="status-count"><?php echo intval($total_count); ?></span>
-        <span class="status-label">Все задачи</span>
-      </div>
-      <div class="glpi-status-block status-filter-btn active" data-status="2" data-label="В работе">
-        <span class="status-count"><?php echo intval($status_counts[2] ?? 0); ?></span>
-        <span class="status-label">В работе</span>
-      </div>
-      <div class="glpi-status-block status-filter-btn" data-status="3" data-label="В плане">
-        <span class="status-count"><?php echo intval($status_counts[3] ?? 0); ?></span>
-        <span class="status-label">В плане</span>
-      </div>
-      <div class="glpi-status-block status-filter-btn" data-status="4" data-label="В стопе">
-        <span class="status-count"><?php echo intval($status_counts[4] ?? 0); ?></span>
-        <span class="status-label">В стопе</span>
-      </div>
-      <div class="glpi-status-block status-filter-btn" data-status="1" data-label="Новые">
-        <span class="status-count"><?php echo intval($status_counts[1] ?? 0); ?></span>
-        <span class="status-label">Новые</span>
-      </div>
+    <div class="glpi-category-row">
+      <div class="glpi-categories-inline" id="glpi-categories-inline" aria-label="Категории" hidden></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Center align status filters and category cloud within new `.glpi-topbar-center` container
- Move category cloud markup into header and remove duplicate container from cards template
- Add responsive styles for unified top bar

## Testing
- `npm test` *(fails: no test specified)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bd929c31248328b6a076de13d4c1ac