### PR TITLE
Improve dictionary load error messages

### DIFF
--- a/assets/css/gee.css
+++ b/assets/css/gee.css
@@ -192,6 +192,7 @@ body {
 .dict-loading{color:#94a3b8;}
 .dict-error{color:#f87171;}
 .dict-empty{color:#94a3b8;}
+.gexe-dict-status .error{color:#f87171;}
 
 /* Selected completename path under inputs */
 .gnt-path{font-size:12px;margin-top:4px;color:#94a3b8;}


### PR DESCRIPTION
## Summary
- Return detailed error info for categories, locations and executors in AJAX endpoints
- Add frontend handling to show SQL, empty and mapping errors when loading dictionaries
- Style dictionary error message in red

## Testing
- ✅ `php -l glpi-new-task.php`
- ⚠️ `npx eslint glpi-new-task.js` (style errors)
- ⚠️ `npm test` (no tests configured)


------
https://chatgpt.com/codex/tasks/task_e_68bd982059d88328bfa7c96d3fd6aeab