### PR TITLE
feat: add gradient backgrounds for active status buttons

### DIFF
--- a/assets/css/gee.css
+++ b/assets/css/gee.css
@@ -156,11 +156,43 @@ body {
  .glpi-status-block:hover,
  .glpi-newfilter-block:hover{transform:translateY(-2px);background:#273447;box-shadow:0 4px 14px rgba(0,0,0,.3);}
  .glpi-status-block.active,
- .glpi-newfilter-block.active{background:#facc15;color:#1f2937;}
+ .glpi-status-block.active:hover,
+ .glpi-status-block.active:focus,
+ .glpi-status-block.active:focus-visible,
+ .glpi-newfilter-block.active,
+ .glpi-newfilter-block.active:hover,
+ .glpi-newfilter-block.active:focus,
+ .glpi-newfilter-block.active:focus-visible{color:#f1f5f9;box-shadow:0 4px 14px rgba(0,0,0,.3);}
  .glpi-status-block.active .status-count,
- .glpi-newfilter-block.active .status-count{color:#111827;}
  .glpi-status-block.active .status-label,
- .glpi-newfilter-block.active .status-label{color:#111827;opacity:1;font-weight:700;}
+ .glpi-newfilter-block.active .status-count,
+ .glpi-newfilter-block.active .status-label{color:#f1f5f9;opacity:1;font-weight:700;}
+
+ /* Активные статусы с градиентными фонами */
+ .glpi-status-block[data-status="2"].active,
+ .glpi-status-block[data-status="2"].active:hover,
+ .glpi-status-block[data-status="2"].active:focus,
+ .glpi-status-block[data-status="2"].active:focus-visible{background:linear-gradient(135deg,#2563eb 0%,#1e3a8a 100%);}
+ .glpi-newfilter-block.active,
+ .glpi-newfilter-block.active:hover,
+ .glpi-newfilter-block.active:focus,
+ .glpi-newfilter-block.active:focus-visible{background:linear-gradient(135deg,#ef4444 0%,#991b1b 100%);}
+ .glpi-status-block[data-status="3"].active,
+ .glpi-status-block[data-status="3"].active:hover,
+ .glpi-status-block[data-status="3"].active:focus,
+ .glpi-status-block[data-status="3"].active:focus-visible{background:linear-gradient(135deg,#22c55e 0%,#15803d 100%);}
+ .glpi-status-block[data-status="4"].active,
+ .glpi-status-block[data-status="4"].active:hover,
+ .glpi-status-block[data-status="4"].active:focus,
+ .glpi-status-block[data-status="4"].active:focus-visible{background:linear-gradient(135deg,#6b7280 0%,#374151 100%);}
+ .glpi-status-block[data-status="1"].active,
+ .glpi-status-block[data-status="1"].active:hover,
+ .glpi-status-block[data-status="1"].active:focus,
+ .glpi-status-block[data-status="1"].active:focus-visible{background:linear-gradient(135deg,#8b5cf6 0%,#4c1d95 100%);}
+ .glpi-status-block[data-status="all"].active,
+ .glpi-status-block[data-status="all"].active:hover,
+ .glpi-status-block[data-status="all"].active:focus,
+ .glpi-status-block[data-status="all"].active:focus-visible{background:linear-gradient(135deg,#f59e0b 0%,#b45309 100%);}
 .glpi-search-block{flex:1;display:flex;flex-direction:column;}
 .glpi-search-wrap{position:relative;display:block;}
 .glpi-search-input{all:unset;width:100%;max-width:400px;box-sizing:border-box;background:#1e293b!important;color:#f8fafc!important;padding:10px 40px 10px 14px;border:1px solid #334155;border-radius:6px;font-size:14px;}


### PR DESCRIPTION
## Summary
- enhance active status buttons with dark-theme gradients per status
- ensure active styles override hover and focus states

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb3e2187c83289ce49b82fe691004