### PR TITLE
Fix GLPI new task dictionary loading with robust error handling

### DIFF
--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -11,6 +11,24 @@ if (!isset($glpi_db) || !($glpi_db instanceof wpdb)) {
     );
 }
 
+if (!defined('WP_GLPI_DEBUG')) {
+    define('WP_GLPI_DEBUG', false);
+}
+
+function glpi_get_pdo(): PDO {
+    static $pdo = null;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+    $dsn = 'mysql:host=192.168.100.12;dbname=glpi;charset=utf8mb4';
+    $pdo = new PDO($dsn, 'wp_glpi', 'xapetVD4OWZqw8f', [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_TIMEOUT            => 5,
+    ]);
+    return $pdo;
+}
+
 define('GEXE_TRIGGERS_VERSION', '2');
 
 define('GEXE_GLPI_API_URL', 'http://192.168.100.12/glpi/apirest.php');


### PR DESCRIPTION
## Summary
- switch database helper to PDO with exceptions
- add unified endpoint for loading categories, locations and executors
- enhance frontend to show detailed errors and retry loading

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-new-task.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcc2adbb08328bcf71c574b343882