### PR TITLE
Handle GLPI entity access for dictionaries

### DIFF
--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -15,6 +15,10 @@ if (!defined('WP_GLPI_DEBUG')) {
     define('WP_GLPI_DEBUG', false);
 }
 
+if (!defined('WP_GLPI_DISABLE_ENTITY_CHECK')) {
+    define('WP_GLPI_DISABLE_ENTITY_CHECK', false);
+}
+
 function glpi_get_pdo(): PDO {
     static $pdo = null;
     if ($pdo instanceof PDO) {
@@ -27,6 +31,12 @@ function glpi_get_pdo(): PDO {
         PDO::ATTR_TIMEOUT            => 5,
     ]);
     return $pdo;
+}
+
+if (!function_exists('wp_glpi_get_connection')) {
+    function wp_glpi_get_connection(): PDO {
+        return glpi_get_pdo();
+    }
 }
 
 define('GEXE_TRIGGERS_VERSION', '2');

--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -162,7 +162,7 @@
       if (btn) btn.addEventListener('click', function(){
         box.innerHTML = '';
         box.hidden = true;
-        retry();
+        setTimeout(retry, 500);
       });
     }
   }
@@ -267,7 +267,15 @@
         if (gexeAjax && gexeAjax.debug) {
           console.error('wp-glpi:new-task', err);
         }
-        showError(err.message || 'Не удалось загрузить справочники', () => startDictLoad(true), err.details);
+        let msg = err.message || 'Не удалось загрузить справочники';
+        let details = err.details;
+        if (err.type === 'ENTITY_ACCESS') {
+          msg = 'Нет доступа к сущности';
+        }
+        if (details && typeof details !== 'string') {
+          try { details = JSON.stringify(details); } catch(e) { details = String(details); }
+        }
+        showError(msg, () => startDictLoad(true), details);
       }
     });
   }


### PR DESCRIPTION
## Summary
- compute allowed GLPI entities per user and filter categories and locations
- add debug/rollback constants and connection helper
- surface ENTITY_ACCESS errors in the new ticket modal

## Testing
- `php -l glpi-new-task.php`
- `php -l glpi-db-setup.php`
- `npx eslint glpi-new-task.js` *(fails: 274 problems)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4f1de64832892102cc65cf41037