### PR TITLE
Handle GLPI entity fallbacks with detailed debug

### DIFF
--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -15,8 +15,12 @@ if (!defined('WP_GLPI_DEBUG')) {
     define('WP_GLPI_DEBUG', false);
 }
 
-if (!defined('WP_GLPI_DISABLE_ENTITY_CHECK')) {
-    define('WP_GLPI_DISABLE_ENTITY_CHECK', false);
+if (!defined('WP_GLPI_ALLOW_FALLBACK_USER_ENTITY')) {
+    define('WP_GLPI_ALLOW_FALLBACK_USER_ENTITY', true);
+}
+
+if (!defined('WP_GLPI_DISABLE_ENTITY_FILTER')) {
+    define('WP_GLPI_DISABLE_ENTITY_FILTER', false);
 }
 
 if (!defined('WP_GLPI_DISABLE_MAPPING_CHECK')) {


### PR DESCRIPTION
## Summary
- Compute allowed GLPI entities via user profiles with caching and optional fallback to user entity
- Add debug/diagnostic constants and include empty-catalog metadata in responses
- Expose dictionary loading warnings in the New Task modal

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-new-task.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bddb8d1868832880027d45f4f68d76