### PR TITLE
Fix entity access in new ticket modal

### DIFF
--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -15,16 +15,9 @@ if (!defined('WP_GLPI_DEBUG')) {
     define('WP_GLPI_DEBUG', false);
 }
 
-if (!defined('WP_GLPI_ALLOW_FALLBACK_USER_ENTITY')) {
-    define('WP_GLPI_ALLOW_FALLBACK_USER_ENTITY', true);
-}
-
-if (!defined('WP_GLPI_DISABLE_ENTITY_FILTER')) {
-    define('WP_GLPI_DISABLE_ENTITY_FILTER', false);
-}
-
-if (!defined('WP_GLPI_DISABLE_MAPPING_CHECK')) {
-    define('WP_GLPI_DISABLE_MAPPING_CHECK', false);
+// Entity filtering mode: 'profiles', 'user_fallback' or 'all'
+if (!defined('WP_GLPI_ENTITY_MODE')) {
+    define('WP_GLPI_ENTITY_MODE', 'user_fallback');
 }
 
 function glpi_get_pdo(): PDO {

--- a/glpi-new-task.js
+++ b/glpi-new-task.js
@@ -162,7 +162,7 @@
       if (btn) btn.addEventListener('click', function(){
         box.innerHTML = '';
         box.hidden = true;
-        setTimeout(retry, 500);
+        setTimeout(retry, 400);
       });
     }
   }


### PR DESCRIPTION
## Summary
- add `WP_GLPI_ENTITY_MODE` constant to control entity filtering
- compute allowed entities via `ancestors_cache` and support diagnostic modes
- debounce retry button to 400ms

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-new-task.php`
- `npx eslint glpi-new-task.js` *(fails: many lint errors)*
- `npm test` *(fails: no test specified)*
- `php -r 'PDO...ancestors_cache'` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfcc39108328a41a17f5f1676e95