### PR TITLE
Fix category load SQL and logging

### DIFF
--- a/docs/form-data-loading.md
+++ b/docs/form-data-loading.md
@@ -4,7 +4,7 @@ Endpoint `gexe_get_form_data` returns lists of categories, locations and executo
 
 * Primary source: GLPI MySQL database (`glpi_itilcategories` and `glpi_locations`).
   * SQL:
-    * `SELECT id, name FROM \`glpi\`.\`glpi_itilcategories\` WHERE is_deleted = 0 ORDER BY name ASC LIMIT 1000`
+    * `SELECT id, name FROM \`glpi\`.\`glpi_itilcategories\` WHERE is_helpdeskvisible = 1 ORDER BY name ASC LIMIT 1000`
     * `SELECT id, completename AS name FROM \`glpi\`.\`glpi_locations\` WHERE is_deleted = 0 ORDER BY completename ASC LIMIT 2000`
 * Fallback: GLPI REST API
   * `GET /ITILCategory/?range=0-1000&order=ASC&sort=name`

--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -246,7 +246,7 @@ function glpi_db_get_categories($entity_id = 0) {
 
     $sql = "SELECT c.id, c.name, c.completename, c.level, c.ancestors_cache\n"
          . "FROM glpi_itilcategories c\n"
-         . "WHERE c.is_deleted = 0 AND c.is_helpdeskvisible = 1";
+         . "WHERE c.is_helpdeskvisible = 1";
 
     if ($entity_id > 0) {
         $sql .= $glpi_db->prepare(" AND (c.entities_id = %d OR c.is_recursive = 1)", $entity_id);
@@ -343,7 +343,7 @@ function glpi_db_create_ticket(array $payload) {
     $glpi_db->query('START TRANSACTION');
 
     $is_leaf = (int)$glpi_db->get_var($glpi_db->prepare(
-        "SELECT COUNT(*) FROM glpi_itilcategories c WHERE c.id=%d AND c.is_deleted=0 AND c.is_helpdeskvisible=1 AND NOT EXISTS (SELECT 1 FROM glpi_itilcategories ch WHERE ch.is_deleted=0 AND ch.completename LIKE CONCAT(c.completename, ' > %%'))",
+        "SELECT COUNT(*) FROM glpi_itilcategories c WHERE c.id=%d AND c.is_helpdeskvisible=1 AND NOT EXISTS (SELECT 1 FROM glpi_itilcategories ch WHERE ch.completename LIKE CONCAT(c.completename, ' > %%'))",
         $cat
     ));
     if (!$is_leaf) {

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -105,7 +105,7 @@ function glpi_ajax_load_dicts() {
         */
 
         $categories = $pdo->query(
-            "SELECT c.id, c.name, c.completename FROM glpi_itilcategories AS c WHERE c.is_deleted = 0 AND c.is_helpdeskvisible = 1 ORDER BY c.completename ASC"
+            "SELECT c.id, c.name, c.completename FROM glpi_itilcategories AS c WHERE c.is_helpdeskvisible = 1 ORDER BY c.completename ASC"
         )->fetchAll(PDO::FETCH_ASSOC);
 
         $scope = 'locations';
@@ -118,7 +118,7 @@ function glpi_ajax_load_dicts() {
         $executors = glpi_get_wp_executors();
         $meta = ['empty' => ['categories' => empty($categories), 'locations' => empty($locations)]];
 
-        error_log('[wp-glpi:new-task] catalogs cats=' . count($categories) . ' locs=' . count($locations) . ')');
+        error_log('[wp-glpi:new-task] catalogs: cats=' . count($categories) . ', locs=' . count($locations));
 
         wp_send_json_success([
             'categories' => $categories,
@@ -130,7 +130,7 @@ function glpi_ajax_load_dicts() {
         if (isset($pdo) && $pdo->inTransaction()) {
             $pdo->rollBack();
         }
-        error_log('[wp-glpi:new-task] SQL ERROR (' . ($scope ?? 'all') . '): ' . $e->getMessage());
+        error_log('[wp-glpi:new-task] SQL ' . ($scope ?? 'unknown') . ': ' . $e->getMessage());
         wp_send_json_error([
             'type'    => 'SQL',
             'scope'   => $scope ?? 'all',

--- a/includes/glpi-form-data.php
+++ b/includes/glpi-form-data.php
@@ -58,9 +58,6 @@ function gexe_get_form_data() {
             }
 
             $cat_where = [];
-            if (gexe_glpi_has_column('glpi_itilcategories', 'is_deleted')) {
-                $cat_where[] = 'is_deleted = 0';
-            }
             if (gexe_glpi_has_column('glpi_itilcategories', 'is_active')) {
                 $cat_where[] = 'is_active = 1';
             }


### PR DESCRIPTION
## Summary
- remove `is_deleted` check from ITIL category queries
- clarify logging and SQL error reporting
- update docs to match current category schema

## Testing
- `php -l glpi-new-task.php`
- `php -l glpi-db-setup.php`
- `php -l includes/glpi-form-data.php`
- `composer validate`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdeee426108328a4f962c8083286e3