### PR TITLE
fix: remove invalid location filter

### DIFF
--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -93,7 +93,6 @@ function glpi_ajax_load_dicts() {
     try {
         $pdo = glpi_get_pdo();
         $pdo->beginTransaction();
-        $scope = 'categories';
 
         // Entity-based filtering temporarily disabled. Legacy code preserved below for future restoration.
         /*
@@ -108,9 +107,8 @@ function glpi_ajax_load_dicts() {
             "SELECT c.id, c.name, c.completename FROM glpi_itilcategories AS c WHERE c.is_helpdeskvisible = 1 ORDER BY c.completename ASC"
         )->fetchAll(PDO::FETCH_ASSOC);
 
-        $scope = 'locations';
         $locations = $pdo->query(
-            "SELECT l.id, l.name, l.completename FROM glpi_locations AS l WHERE l.is_deleted = 0 ORDER BY l.completename ASC"
+            "SELECT l.id, l.name, l.completename FROM glpi_locations AS l ORDER BY l.completename ASC"
         )->fetchAll(PDO::FETCH_ASSOC);
 
         $pdo->commit();
@@ -118,7 +116,7 @@ function glpi_ajax_load_dicts() {
         $executors = glpi_get_wp_executors();
         $meta = ['empty' => ['categories' => empty($categories), 'locations' => empty($locations)]];
 
-        error_log('[wp-glpi:new-task] catalogs: cats=' . count($categories) . ', locs=' . count($locations));
+        error_log('[wp-glpi:new-task] catalogs loaded: cats=' . count($categories) . ', locs=' . count($locations));
 
         wp_send_json_success([
             'categories' => $categories,
@@ -130,11 +128,11 @@ function glpi_ajax_load_dicts() {
         if (isset($pdo) && $pdo->inTransaction()) {
             $pdo->rollBack();
         }
-        error_log('[wp-glpi:new-task] SQL ' . ($scope ?? 'unknown') . ': ' . $e->getMessage());
+        error_log('[wp-glpi:new-task] SQL locations: ' . $e->getMessage());
         wp_send_json_error([
             'type'    => 'SQL',
-            'scope'   => $scope ?? 'all',
-            'message' => 'Ошибка SQL при загрузке ' . ($scope === 'categories' ? 'категорий' : 'локаций'),
+            'scope'   => 'locations',
+            'message' => 'Ошибка SQL при загрузке локаций',
             'details' => $e->getMessage(),
         ]);
     }


### PR DESCRIPTION
## Summary
- drop nonexistent `is_deleted` filter when loading locations
- log SQL exceptions for locations and return informative JSON errors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68bdf3911f6c83288fcff7a43d028be9