### PR TITLE
feat: create tickets through GLPI API

### DIFF
--- a/assets/css/gee.css
+++ b/assets/css/gee.css
@@ -235,6 +235,9 @@ body {
 /* Selected completename path under inputs */
 .gnt-path{font-size:12px;margin-top:4px;color:#94a3b8;}
 
+/* Compact subject field */
+.glpi-create-modal #gnt-name{min-height:56px;max-height:64px;height:60px;line-height:1.4;padding:8px 12px;resize:vertical;}
+
 /* Disabled state for modal controls */
 .gnt-input.disabled,
 .gnt-select.disabled,

--- a/assets/js/gexe-new-task.js
+++ b/assets/js/gexe-new-task.js
@@ -1,0 +1,87 @@
+(function () {
+  if (typeof window === 'undefined') return;
+
+  const ajax = window.glpiAjax || {};
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.querySelector('.glpi-create-modal');
+    if (!modal) return;
+    const submitBtn = modal.querySelector('.gnt-submit');
+    if (!submitBtn) return;
+
+    let busy = false;
+
+    submitBtn.addEventListener('click', () => {
+      if (busy) return;
+
+      const subjectEl = modal.querySelector('#gnt-name');
+      const contentEl = modal.querySelector('#gnt-content');
+      const categoryEl = modal.querySelector('#gnt-category');
+      const locationEl = modal.querySelector('#gnt-location');
+      const assignMeEl = modal.querySelector('#gnt-assign-me');
+      const assigneeEl = modal.querySelector('#gnt-assignee');
+
+      const subject = subjectEl.value.trim();
+      const description = contentEl.value.trim();
+      const category = categoryEl ? parseInt(categoryEl.value, 10) || '' : '';
+      const location = locationEl ? parseInt(locationEl.value, 10) || '' : '';
+      const assignMe = assignMeEl ? assignMeEl.checked : false;
+      const executor = assigneeEl ? parseInt(assigneeEl.value, 10) || 0 : 0;
+
+      if (subject.length < 3 || subject.length > 255) {
+        alert('Введите тему (3-255 символов)');
+        return;
+      }
+      if (description.length > 5000) {
+        alert('Описание слишком длинное');
+        return;
+      }
+
+      const body = new URLSearchParams();
+      body.append('action', 'gexe_create_ticket_api');
+      body.append('nonce', ajax.nonce || '');
+      body.append('subject', subject);
+      body.append('description', description);
+      if (category) body.append('category_id', category);
+      if (location) body.append('location_id', location);
+      if (assignMe) body.append('assign_me', '1');
+      if (!assignMe && executor) body.append('executor_id', executor);
+
+      busy = true;
+      submitBtn.disabled = true;
+      submitBtn.classList.add('is-loading');
+      submitBtn.textContent = 'Создаю…';
+
+      fetch(ajax.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      }).then((r) => r.json())
+        .then((data) => {
+          submitBtn.disabled = false;
+          submitBtn.classList.remove('is-loading');
+          submitBtn.textContent = 'Создать заявку';
+          busy = false;
+
+          if (data && data.success) {
+            alert(`Заявка №${data.id} создана`);
+            subjectEl.value = '';
+            contentEl.value = '';
+            if (assigneeEl) assigneeEl.value = '';
+          } else {
+            const msg = data && data.error && data.error.message ? data.error.message : 'Неизвестная ошибка';
+            alert(`Ошибка API: ${msg}`);
+          }
+        })
+        .catch((err) => {
+          submitBtn.disabled = false;
+          submitBtn.classList.remove('is-loading');
+          submitBtn.textContent = 'Создать заявку';
+          busy = false;
+          alert(`Ошибка API: ${err.message}`);
+        });
+
+      setTimeout(() => { busy = false; }, 10000);
+    });
+  });
+}());

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -72,18 +72,20 @@ function gexe_compose_short_name($realname, $firstname) {
 }
 
 /** Список доступных исполнителей (GLPI user id + short name) */
-function gexe_get_assignee_options() {
-    $users = get_users(['meta_key' => 'glpi_user_id']);
-    $out   = [];
-    foreach ($users as $u) {
-        $gid = (int) get_user_meta($u->ID, 'glpi_user_id', true);
-        if ($gid <= 0) continue;
-        $out[] = [
-            'id'   => $gid,
-            'name' => gexe_compose_short_name($u->last_name ?? '', $u->first_name ?? ''),
-        ];
+if (!function_exists('gexe_get_assignee_options')) {
+    function gexe_get_assignee_options() {
+        $users = get_users(['meta_key' => 'glpi_user_id']);
+        $out   = [];
+        foreach ($users as $u) {
+            $gid = (int) get_user_meta($u->ID, 'glpi_user_id', true);
+            if ($gid <= 0) continue;
+            $out[] = [
+                'id'   => $gid,
+                'name' => gexe_compose_short_name($u->last_name ?? '', $u->first_name ?? ''),
+            ];
+        }
+        return $out;
     }
-    return $out;
 }
 
 /** Очистка HTML комментария (текст в карточке модалки) */

--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -13,7 +13,7 @@
 .glpi-create-modal .gnt-textarea,
 .glpi-create-modal .gnt-select { width: 100%; background: #0b1220; border: 1px solid #1f2937; border-radius: 10px; color: #e5e7eb; padding: 10px 12px; }
 .glpi-create-modal .gnt-textarea { resize: none; }
-.glpi-create-modal #gnt-name,
+.glpi-create-modal #gnt-name { height:60px; min-height:56px; max-height:96px; line-height:1.4; padding:8px 12px; resize:vertical; }
 .glpi-create-modal #gnt-content { height:130px; }
 .glpi-create-modal .gnt-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 8px; }
 .glpi-create-modal .gnt-row.gnt-assign-row { grid-template-columns: auto 1fr; align-items: center; }

--- a/includes/glpi-ajax.php
+++ b/includes/glpi-ajax.php
@@ -1,0 +1,84 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/glpi-api-client.php';
+require_once __DIR__ . '/glpi-new-task.php';
+
+add_action('wp_ajax_gexe_create_ticket_api', 'gexe_create_ticket_api');
+function gexe_create_ticket_api() {
+    if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
+        wp_send_json_error(['error' => ['type' => 'SECURITY', 'code' => 'NO_CSRF', 'message' => 'Ошибка безопасности']], 200);
+    }
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['error' => ['type' => 'AUTH', 'code' => 'NO_AUTH', 'message' => 'Пользователь не авторизован']], 200);
+    }
+    $wp_uid = get_current_user_id();
+    $glpi_uid = (int) get_user_meta($wp_uid, 'glpi_user_id', true);
+    if ($glpi_uid <= 0) {
+        wp_send_json_error(['error' => ['type' => 'MAPPING', 'code' => 'MAPPING_NOT_SET', 'message' => 'Профиль WordPress не привязан к GLPI пользователю']], 200);
+    }
+
+    $subject = trim((string)($_POST['subject'] ?? ''));
+    $description = trim((string)($_POST['description'] ?? ''));
+    $category_id = isset($_POST['category_id']) ? (int)$_POST['category_id'] : 0;
+    $location_id = isset($_POST['location_id']) ? (int)$_POST['location_id'] : 0;
+    $assign_me   = !empty($_POST['assign_me']);
+    $executor_id = isset($_POST['executor_id']) ? (int)$_POST['executor_id'] : 0;
+
+    if (mb_strlen($subject) < 3 || mb_strlen($subject) > 255) {
+        wp_send_json_error(['error' => ['type' => 'VALIDATION', 'code' => 'BAD_SUBJECT', 'message' => 'Неверная тема']], 200);
+    }
+    if (mb_strlen($description) > 5000) {
+        wp_send_json_error(['error' => ['type' => 'VALIDATION', 'code' => 'BAD_DESCRIPTION', 'message' => 'Описание слишком длинное']], 200);
+    }
+
+    if ($assign_me) {
+        $executor_id = $glpi_uid;
+    }
+    if ($executor_id) {
+        $allowed = wp_list_pluck(gexe_get_assignee_options(), 'id');
+        if (!in_array($executor_id, $allowed, true)) {
+            wp_send_json_error(['error' => ['type' => 'VALIDATION', 'code' => 'BAD_EXECUTOR', 'message' => 'Исполнитель недоступен']], 200);
+        }
+    }
+
+    $hash = md5($wp_uid . '|' . $subject . '|' . $category_id . '|' . $location_id);
+    $lock_key = 'gexe_ticket_' . $hash;
+    $cached = get_transient($lock_key);
+    if (is_array($cached)) {
+        wp_send_json($cached);
+    }
+
+    $input = [
+        'name'                 => $subject,
+        'content'              => $description,
+        '_users_id_requester'  => $glpi_uid,
+    ];
+    if ($category_id > 0) $input['itilcategories_id'] = $category_id;
+    if ($location_id > 0) $input['locations_id'] = $location_id;
+
+    $result = gexe_glpi_api_create_ticket($input);
+    if (!$result['ok']) {
+        delete_transient($lock_key);
+        error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=' . ($result['code'] ?? 'fail'));
+        wp_send_json_error(['error' => ['type' => 'API', 'code' => $result['code'], 'message' => $result['message'] ?? 'API error']], 200);
+    }
+
+    $ticket_id = (int)$result['id'];
+    $assign_warning = null;
+    if ($executor_id > 0) {
+        $a = gexe_glpi_api_assign_ticket($ticket_id, $executor_id);
+        if (!$a['ok']) {
+            $assign_warning = $a['message'] ?? 'assign_failed';
+        }
+    }
+
+    $out = ['success' => true, 'id' => $ticket_id];
+    if ($assign_warning) {
+        $out['assign_warning'] = $assign_warning;
+    }
+    set_transient($lock_key, $out, 10);
+
+    error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=' . $ticket_id);
+    wp_send_json($out);
+}

--- a/includes/glpi-api-client.php
+++ b/includes/glpi-api-client.php
@@ -1,0 +1,78 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Simple GLPI REST API client for ticket operations.
+ */
+function gexe_glpi_api_base() {
+    if (defined('GLPI_API_URL')) {
+        return rtrim(GLPI_API_URL, '/');
+    }
+    if (defined('GEXE_GLPI_API_URL')) {
+        return rtrim(GEXE_GLPI_API_URL, '/');
+    }
+    return '';
+}
+
+function gexe_glpi_api_headers() {
+    $app  = defined('GLPI_APP_TOKEN') ? GLPI_APP_TOKEN : (defined('GEXE_GLPI_APP_TOKEN') ? GEXE_GLPI_APP_TOKEN : '');
+    $user = defined('GLPI_USER_TOKEN') ? GLPI_USER_TOKEN : (defined('GEXE_GLPI_USER_TOKEN') ? GEXE_GLPI_USER_TOKEN : '');
+    return [
+        'App-Token'    => $app,
+        'Authorization'=> 'user_token ' . $user,
+        'Content-Type' => 'application/json',
+    ];
+}
+
+/**
+ * Create ticket via GLPI REST API.
+ * @param array $input Ticket payload inside `input`.
+ * @return array
+ */
+function gexe_glpi_api_create_ticket(array $input) {
+    $url = gexe_glpi_api_base() . '/Ticket';
+    $args = [
+        'method'  => 'POST',
+        'headers' => gexe_glpi_api_headers(),
+        'body'    => wp_json_encode(['input' => $input]),
+        'timeout' => 15,
+    ];
+    $resp = wp_remote_request($url, $args);
+    if (is_wp_error($resp)) {
+        return ['ok' => false, 'code' => 'HTTP', 'message' => $resp->get_error_message()];
+    }
+    $code = wp_remote_retrieve_response_code($resp);
+    $body = json_decode(wp_remote_retrieve_body($resp), true);
+    if ($code >= 200 && $code < 300 && isset($body['id'])) {
+        return ['ok' => true, 'id' => (int)$body['id']];
+    }
+    return ['ok' => false, 'code' => $code, 'message' => wp_remote_retrieve_body($resp)];
+}
+
+/**
+ * Assign executor to ticket via GLPI REST API.
+ */
+function gexe_glpi_api_assign_ticket($ticket_id, $user_id) {
+    $ticket_id = (int) $ticket_id;
+    $user_id   = (int) $user_id;
+    if ($ticket_id <= 0 || $user_id <= 0) {
+        return ['ok' => false, 'code' => 'VALIDATION'];
+    }
+    $url = gexe_glpi_api_base() . '/Ticket/' . $ticket_id . '/Ticket_User';
+    $payload = ['input' => ['tickets_id' => $ticket_id, 'users_id' => $user_id, 'type' => 2]];
+    $args = [
+        'method'  => 'POST',
+        'headers' => gexe_glpi_api_headers(),
+        'body'    => wp_json_encode($payload),
+        'timeout' => 15,
+    ];
+    $resp = wp_remote_request($url, $args);
+    if (is_wp_error($resp)) {
+        return ['ok' => false, 'code' => 'HTTP', 'message' => $resp->get_error_message()];
+    }
+    $code = wp_remote_retrieve_response_code($resp);
+    if ($code >= 200 && $code < 300) {
+        return ['ok' => true];
+    }
+    return ['ok' => false, 'code' => $code, 'message' => wp_remote_retrieve_body($resp)];
+}

--- a/includes/glpi-new-task.php
+++ b/includes/glpi-new-task.php
@@ -1,0 +1,50 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/../glpi-db-setup.php';
+
+/**
+ * Build list of executors from GLPI users based on WP mappings.
+ * @return array<int,array{id:int,label:string}>
+ */
+function gexe_get_assignee_options() {
+    global $wpdb, $glpi_db;
+
+    // Fetch mapped GLPI user ids from WP usermeta
+    $rows = $wpdb->get_results(
+        "SELECT DISTINCT meta_value FROM {$wpdb->usermeta} WHERE meta_key='glpi_user_id' AND meta_value<>''",
+        ARRAY_A
+    );
+    if (!$rows) return [];
+    $ids = [];
+    foreach ($rows as $r) {
+        $gid = (int)$r['meta_value'];
+        if ($gid > 0) $ids[] = $gid;
+    }
+    if (empty($ids)) return [];
+
+    $place = implode(',', array_fill(0, count($ids), '%d'));
+    $sql = $glpi_db->prepare(
+        "SELECT id, name, realname, firstname FROM glpi_users WHERE id IN ($place) ORDER BY realname COLLATE utf8mb4_unicode_ci ASC, firstname COLLATE utf8mb4_unicode_ci ASC",
+        ...$ids
+    );
+    $users = $glpi_db->get_results($sql, ARRAY_A);
+    if (!$users) return [];
+
+    $out = [];
+    foreach ($users as $u) {
+        $id   = (int)($u['id'] ?? 0);
+        $login = trim($u['name'] ?? '');
+        $real  = trim($u['realname'] ?? '');
+        $first = trim($u['firstname'] ?? '');
+        $label = trim($real . ' ' . $first);
+        if ($login === 'vks_m5_local' || $label === '') {
+            $label = 'Куткин Павел';
+        } elseif ($label === '') {
+            $label = $login;
+        }
+        if ($label === '') continue;
+        $out[] = ['id' => $id, 'label' => $label];
+    }
+    return $out;
+}


### PR DESCRIPTION
## Summary
- style new ticket modal subject field for compact height
- submit tickets via GLPI REST API with executor assignment and feedback
- load executors from GLPI with proper names and sorting

## Testing
- `php -l includes/glpi-api-client.php`
- `php -l includes/glpi-new-task.php`
- `php -l includes/glpi-ajax.php`
- `php -l glpi-modal-actions.php`
- `php -l gexe-copy.php`
- `npx eslint assets/js/gexe-new-task.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9e120c48328b5bb69dffa4808ef