### PR TITLE
Use GLPI API for ticket creation and update executors

### DIFF
--- a/assets/css/gee.css
+++ b/assets/css/gee.css
@@ -298,6 +298,15 @@ button.disabled{opacity:.5;cursor:not-allowed;}
 }
 .glpi-create-modal .gnt-retry:hover { background: #273447; }
 
+/* Smaller subject field */
+.glpi-create-modal #gnt-name.gnt-textarea{
+  height:60px;
+  min-height:56px;
+  line-height:1.4;
+  padding:8px 12px;
+  resize:vertical;
+}
+
 /* Выпадающие (общие) */
 .glpi-filter-dropdown .glpi-filter-menu{ background:#0f172a; border:1px solid #334155; border-radius:8px; box-shadow:0 6px 12px rgba(0,0,0,.3); }
 


### PR DESCRIPTION
## Summary
- shrink new-ticket subject field
- add status feedback and debounce on ticket creation
- create tickets through GLPI REST API and sort executors list

## Testing
- `node --check assets/js/gexe-new-task.js`
- `php -l glpi-new-task.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff60e3a88328b09352d1029bd867