### PR TITLE
Fix executor dropdown and add ticket creation via GLPI API

### DIFF
--- a/assets/css/gee.css
+++ b/assets/css/gee.css
@@ -250,6 +250,9 @@ button.disabled{opacity:.5;cursor:not-allowed;}
 .gnt-submit.is-loading::after{content:"";width:16px;height:16px;border:2px solid #f1f5f9;border-top-color:transparent;border-radius:50%;position:absolute;top:50%;left:50%;margin:-8px 0 0 -8px;animation:gnt-spin 1s linear infinite;}
 @keyframes gnt-spin{to{transform:rotate(360deg);}}
 
+/* Inline form alert */
+.form-alert{margin-top:8px;padding:8px 12px;border-radius:6px;background:#7f1d1d;color:#fca5a5;font-size:14px;}
+
 /* Инлайн-категории */
  .glpi-categories-inline{
   display:flex;

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -57,53 +57,41 @@ function glpi_db_get_executors() { old implementation }
 */
 
 add_action('wp_ajax_glpi_load_dicts', 'glpi_ajax_load_dicts');
+add_action('wp_ajax_wpglpi_load_catalogs', 'glpi_ajax_load_dicts');
 
-function glpi_get_wp_executors(): array {
+function glpi_get_wp_executors() {
     global $wpdb, $glpi_db;
-    $rows = $wpdb->get_results(
-        "SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key='glpi_user_id' AND meta_value <> ''",
-        ARRAY_A
-    );
-    if (!$rows) {
-        return [];
-    }
-    $map = [];
-    $ids = [];
-    foreach ($rows as $r) {
-        $gid = (int) ($r['meta_value'] ?? 0);
-        if ($gid > 0) {
-            $map[$gid] = (int) ($r['user_id'] ?? 0);
-            $ids[] = $gid;
+    try {
+        $sql = "SELECT u.id AS id, u.name AS login, TRIM(CONCAT(COALESCE(u.realname,''),' ',COALESCE(u.firstname,''))) AS fio
+                FROM glpi_users u
+                JOIN {$wpdb->usermeta} m ON m.meta_value = u.id AND m.meta_key = 'glpi_user_id'
+                ORDER BY u.realname COLLATE utf8mb4_unicode_ci ASC, u.firstname COLLATE utf8mb4_unicode_ci ASC";
+        $rows = $glpi_db->get_results($sql, ARRAY_A);
+        if ($glpi_db->last_error) {
+            throw new Exception($glpi_db->last_error);
         }
-    }
-    if (empty($ids)) {
-        return [];
-    }
-    $place = implode(',', array_fill(0, count($ids), '%d'));
-    $sql = $glpi_db->prepare(
-        "SELECT u.id, u.name, u.realname, u.firstname FROM glpi_users u WHERE u.id IN ($place) ORDER BY u.realname COLLATE utf8mb4_unicode_ci ASC, u.firstname COLLATE utf8mb4_unicode_ci ASC",
-        ...$ids
-    );
-    $grows = $glpi_db->get_results($sql, ARRAY_A);
-    $out = [];
-    foreach ($grows as $g) {
-        $gid = (int) ($g['id'] ?? 0);
-        if (!$gid || !isset($map[$gid])) continue;
-        $label = trim(($g['realname'] ?? '') . ' ' . ($g['firstname'] ?? ''));
-        $uname = $g['name'] ?? '';
-        if ($uname === 'vks_m5_local' || $label === '') {
-            $label = 'Куткин Павел';
+        $out = [];
+        foreach ($rows as $r) {
+            $id = isset($r['id']) ? (int) $r['id'] : 0;
+            if ($id <= 0) continue;
+            $login = isset($r['login']) ? $r['login'] : '';
+            $label = trim($r['fio'] ?? '');
+            $label = $label !== '' ? $label : $login;
+            if ($login === 'vks_m5_local') {
+                $label = 'Куткин Павел';
+            }
+            $out[] = ['id' => $id, 'label' => $label];
         }
-        $out[] = [
-            'user_id'      => $map[$gid],
-            'display_name' => $label,
-            'glpi_user_id' => $gid,
-        ];
+        usort($out, function ($a, $b) {
+            return strcmp(mb_strtolower($a['label'], 'UTF-8'), mb_strtolower($b['label'], 'UTF-8'));
+        });
+        array_unshift($out, ['id' => 0, 'label' => '—']);
+        error_log('[wp-glpi:executors] count=' . count($out));
+        return $out;
+    } catch (Exception $e) {
+        error_log('[wp-glpi:executors] SQL ERROR: ' . $e->getMessage());
+        return new WP_Error('sql_error', $e->getMessage());
     }
-    usort($out, function ($a, $b) {
-        return strcmp(mb_strtolower($a['display_name'], 'UTF-8'), mb_strtolower($b['display_name'], 'UTF-8'));
-    });
-    return $out;
 }
 
 function glpi_ajax_load_dicts() {
@@ -142,6 +130,14 @@ function glpi_ajax_load_dicts() {
         $pdo->commit();
 
         $executors = glpi_get_wp_executors();
+        if (is_wp_error($executors)) {
+            wp_send_json_error([
+                'type'    => 'SQL',
+                'scope'   => 'executors',
+                'message' => 'Ошибка SQL при загрузке исполнителей',
+                'details' => $executors->get_error_message(),
+            ]);
+        }
         $meta = ['empty' => ['categories' => empty($categories), 'locations' => empty($locations)]];
 
         error_log('[wp-glpi:new-task] catalogs loaded: cats=' . count($categories) . ', locs=' . count($locations));
@@ -168,15 +164,16 @@ function glpi_ajax_load_dicts() {
 
 // -------- Create ticket --------
 add_action('wp_ajax_glpi_create_ticket', 'glpi_ajax_create_ticket');
+add_action('wp_ajax_wpglpi_create_ticket_api', 'glpi_ajax_create_ticket');
 function glpi_ajax_create_ticket() {
     glpi_nt_verify_nonce();
     if (!is_user_logged_in()) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'SECURITY', 'message' => 'Пользователь не авторизован']]);
+        wp_send_json_error(['type' => 'SECURITY', 'message' => 'Пользователь не авторизован']);
     }
     $wp_uid = get_current_user_id();
     $map = gexe_require_glpi_user($wp_uid);
     if (!$map['ok']) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'MAPPING', 'message' => 'Профиль WordPress не привязан к GLPI пользователю']]);
+        wp_send_json_error(['type' => 'MAPPING', 'message' => 'Профиль WordPress не привязан к GLPI пользователю']);
     }
     $glpi_uid = (int) $map['id'];
 
@@ -184,8 +181,8 @@ function glpi_ajax_create_ticket() {
     $desc = sanitize_textarea_field($_POST['description'] ?? '');
     $cat = isset($_POST['category_id']) ? (int) $_POST['category_id'] : 0;
     $loc = isset($_POST['location_id']) ? (int) $_POST['location_id'] : 0;
-    $assign_me = !empty($_POST['assign_me']);
-    $executor_wp = isset($_POST['executor_id']) ? (int) $_POST['executor_id'] : 0;
+    $assign_me = !empty($_POST['iam_executor']);
+    $executor_glpi = isset($_POST['executor_id']) ? (int) $_POST['executor_id'] : 0;
 
     $errors = [];
     if (mb_strlen($subject, 'UTF-8') < 3 || mb_strlen($subject, 'UTF-8') > 255) {
@@ -195,23 +192,21 @@ function glpi_ajax_create_ticket() {
         $errors['content'] = 'Описание 1-5000 символов';
     }
     $executors = glpi_get_wp_executors();
+    if (is_wp_error($executors)) {
+        wp_send_json_error(['type' => 'SQL', 'message' => 'Ошибка SQL при загрузке исполнителей', 'details' => $executors->get_error_message()]);
+    }
     $allowed = [];
     foreach ($executors as $e) {
-        $allowed[$e['user_id']] = $e['glpi_user_id'];
+        $allowed[$e['id']] = true;
     }
-    $executor_glpi = 0;
-    if ($executor_wp > 0) {
-        if (!isset($allowed[$executor_wp])) {
-            $errors['assignee'] = 'Недопустимый исполнитель';
-        } else {
-            $executor_glpi = (int) $allowed[$executor_wp];
-        }
+    if ($executor_glpi > 0 && !isset($allowed[$executor_glpi])) {
+        $errors['assignee'] = 'Недопустимый исполнитель';
     }
     if (!$assign_me && $executor_glpi === 0) {
         $errors['assignee'] = 'Обязательное поле';
     }
     if (!empty($errors)) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'VALIDATION', 'message' => 'Validation failed', 'details' => $errors]]);
+        wp_send_json_error(['type' => 'VALIDATION', 'message' => 'Validation failed', 'details' => $errors]);
     }
     if ($assign_me) {
         $executor_glpi = $glpi_uid;
@@ -221,15 +216,14 @@ function glpi_ajax_create_ticket() {
     $app_token = defined('GEXE_GLPI_APP_TOKEN') ? GEXE_GLPI_APP_TOKEN : (defined('GLPI_APP_TOKEN') ? GLPI_APP_TOKEN : '');
     $user_token = defined('GEXE_GLPI_USER_TOKEN') ? GEXE_GLPI_USER_TOKEN : (defined('GLPI_USER_TOKEN') ? GLPI_USER_TOKEN : '');
     if (!$api_url || !$app_token || !$user_token) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'CONFIG', 'message' => 'GLPI API not configured']]);
+        wp_send_json_error(['type' => 'CONFIG', 'message' => 'GLPI API not configured']);
     }
 
-    $lock_key = 'gexe_ticket_' . sha1($wp_uid . '|' . $subject . '|' . $cat . '|' . $loc);
-    $cached = get_transient($lock_key);
-    if ($cached !== false) {
-        wp_send_json($cached);
+    $lock_key = 'wpglpi_create_lock_' . $wp_uid;
+    if (get_transient($lock_key)) {
+        wp_send_json_error(['type' => 'BUSY', 'message' => 'Запрос уже выполняется...']);
     }
-    set_transient($lock_key, ['error' => ['type' => 'LOCK']], 10);
+    set_transient($lock_key, 1, 10);
 
     $headers = [
         'Content-Type' => 'application/json',
@@ -251,26 +245,24 @@ function glpi_ajax_create_ticket() {
         'timeout' => 15,
     ]);
     if (is_wp_error($resp)) {
-        $data = ['success' => false, 'error' => ['type' => 'API', 'message' => $resp->get_error_message()]];
-        set_transient($lock_key, $data, 10);
-        error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:api');
-        wp_send_json($data);
+        delete_transient($lock_key);
+        error_log('[wp-glpi:create] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:api');
+        wp_send_json_error(['type' => 'API', 'message' => $resp->get_error_message()]);
     }
     $code = wp_remote_retrieve_response_code($resp);
     $body = json_decode(wp_remote_retrieve_body($resp), true);
     if ($code >= 400 || !isset($body['id'])) {
+        delete_transient($lock_key);
         $msg = 'Ошибка API: ' . $code;
         if (isset($body['message'])) {
             $msg .= ' ' . $body['message'];
         }
-        $data = ['success' => false, 'error' => ['type' => 'API', 'code' => $code, 'message' => $msg]];
-        set_transient($lock_key, $data, 10);
-        error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:' . $code);
-        wp_send_json($data);
+        error_log('[wp-glpi:create] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:' . $code);
+        wp_send_json_error(['type' => 'API', 'code' => $code, 'message' => $msg]);
     }
     $ticket_id = (int) $body['id'];
 
-    $warning = false;
+    $warning = null;
     if ($executor_glpi > 0) {
         $resp2 = wp_remote_post(rtrim($api_url, '/') . '/Ticket/' . $ticket_id . '/Ticket_User', [
             'headers' => $headers,
@@ -278,15 +270,15 @@ function glpi_ajax_create_ticket() {
             'timeout' => 15,
         ]);
         if (is_wp_error($resp2) || wp_remote_retrieve_response_code($resp2) >= 400) {
-            $warning = true;
+            $warning = is_wp_error($resp2) ? $resp2->get_error_message() : wp_remote_retrieve_body($resp2);
         }
     }
+    delete_transient($lock_key);
     $out = ['success' => true, 'id' => $ticket_id];
     if ($warning) {
         $out['warning'] = 'assign_failed';
-        $out['message'] = 'Назначение исполнителя не выполнено';
+        $out['message'] = $warning;
     }
-    set_transient($lock_key, $out, 10);
-    error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=ok#' . $ticket_id);
+    error_log('[wp-glpi:create] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=ok#' . $ticket_id);
     wp_send_json($out);
 }


### PR DESCRIPTION
## Summary
- Fetch executors from GLPI database with sorting and special naming
- Add form alert styles and improve executor loading with retry
- Submit new ticket via GLPI REST API with idempotent lock and error handling

## Testing
- `npx eslint assets/js/gexe-new-task.js` *(fails: numerous lint errors)*
- `php -l glpi-new-task.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68be0320599483288ccdfe7d03e2e679