### PR TITLE
Fix executor loading and ticket creation feedback

### DIFF
--- a/assets/js/gexe-new-task.js
+++ b/assets/js/gexe-new-task.js
@@ -30,7 +30,8 @@
         <button type="button" class="gnt-close" aria-label="Закрыть">×</button>
       </div>
         <div class="gnt-body">
-          <div class="gexe-dict-status" role="status" aria-live="polite" hidden></div>
+            <div class="gexe-dict-status" role="status" aria-live="polite" hidden></div>
+            <div class="form-alert" hidden></div>
           <label for="gnt-name" class="gnt-label">Тема</label>
           <textarea id="gnt-name" class="gnt-textarea"></textarea>
           <div id="gnt-name-err" class="gnt-field-error" hidden></div>
@@ -169,19 +170,33 @@
     }
   }
 
-  function showSubmitError(message){
-    showSubmitStatus(message, 'error');
+  function showFormAlert(message, type, details){
+    const box = modal.querySelector('.form-alert');
+    if (!box) return;
+    let html = esc(message || '');
+    if (details) {
+      html += ' <details><code>' + esc(details) + '</code></details>';
+    }
+    box.innerHTML = html;
+    box.className = 'form-alert' + (type ? ' ' + type : '');
+    box.hidden = !message;
   }
 
-  function showSubmitStatus(message, type){
-    const box = modal.querySelector('.gexe-dict-status');
+  function showSubmitError(message){
+    showFormAlert(message, 'error');
+  }
+
+  function showSubmitStatus(message, type, details){
+    const box = modal.querySelector('.form-alert');
     if (!box) return;
     const cls = type === 'error' ? 'error' : (type === 'success' ? 'success' : 'loading');
-    box.className = 'gexe-dict-status ' + cls;
+    box.className = 'form-alert ' + cls;
     if (cls === 'loading') {
       box.innerHTML = '<span class="spinner"></span>' + (message || '');
     } else {
-      box.textContent = message || '';
+      let html = esc(message || '');
+      if (details) html += ' <details><code>' + esc(details) + '</code></details>';
+      box.innerHTML = html;
     }
     box.hidden = false;
   }
@@ -250,6 +265,27 @@
       .catch(() => ({ ok: false, error: { type: 'NETWORK', message: 'Ошибка соединения с сервером' } }));
   }
 
+  function reloadExecutors(){
+    if (isLoading) return;
+    isLoading = true;
+    showLoading();
+    fetchDicts(true).then(res => {
+      isLoading = false;
+      if (res.ok) {
+        fillDropdowns({ executors: res.executors });
+        if (res.executors && res.executors.length) {
+          hideStatus();
+          lockForm(false);
+        } else {
+          showError('Список исполнителей недоступен', reloadExecutors);
+        }
+      } else {
+        const err = res.error || {};
+        showError(err.message || 'Ошибка загрузки исполнителей', reloadExecutors, err.details);
+      }
+    });
+  }
+
   function startDictLoad(force){
     if (isLoading) return;
     const now = Date.now();
@@ -287,8 +323,13 @@
         if (res.meta && res.meta.note === 'fallback_no_entities' && gexeAjax && gexeAjax.debug) {
           console.warn('wp-glpi:new-task', 'entity filter fallback (no entities)');
         }
-        if (warns.length) showError(warns.join('. '));
-        else hideStatus();
+        if (!executorsLoaded) {
+          showError('Список исполнителей недоступен', reloadExecutors);
+        } else if (warns.length) {
+          showError(warns.join('. '));
+        } else {
+          hideStatus();
+        }
       } else {
         const err = res.error || {};
         if (gexeAjax && gexeAjax.debug) {
@@ -315,7 +356,8 @@
         if (err && err.details) {
           try { details = typeof err.details === 'string' ? err.details : JSON.stringify(err.details); } catch(e) { details = String(err.details); }
         }
-        showError(msg, () => startDictLoad(true), details);
+        const retry = err.scope === 'executors' ? reloadExecutors : () => startDictLoad(true);
+        showError(msg, retry, details);
       }
     });
   }
@@ -349,6 +391,8 @@
     assigneeSel.disabled = true;
     ['name','content','category','location','assignee'].forEach(function(f){ setFieldError(f); });
     updatePaths();
+    const alertBox = modal.querySelector('.form-alert');
+    if (alertBox) { alertBox.innerHTML=''; alertBox.hidden = true; }
   }
 
   function ensureSuccessModal(){
@@ -555,7 +599,7 @@
     };
     const makeBody = () => {
       const params = new URLSearchParams();
-      params.append('action','glpi_create_ticket');
+      params.append('action','wpglpi_create_ticket_api');
       params.append('nonce', gexeAjax.nonce);
       Object.keys(payload).forEach(k=>{ if(payload[k] !== undefined && payload[k] !== null) params.append(k, payload[k]); });
       return params.toString();
@@ -588,10 +632,15 @@
           window.dispatchEvent(new CustomEvent('gexe:tickets:refresh', {detail:{ticketId:data.id}}));
         }
       } else {
-        const msg = data && data.error && data.error.message ? data.error.message : 'Ошибка создания заявки';
-        showSubmitStatus(msg,'error');
-        if (data && data.error && data.error.details) {
-          Object.keys(data.error.details).forEach(function(f){ setFieldError(f, data.error.details[f]); });
+        const errObj = (data && data.error) || {};
+        const msg = errObj.message ? errObj.message : 'Ошибка создания заявки';
+        let details = null;
+        if (errObj.details) {
+          try { details = typeof errObj.details === 'string' ? errObj.details : JSON.stringify(errObj.details); } catch(e) { details = String(errObj.details); }
+        }
+        showSubmitStatus(msg,'error', details);
+        if (errObj.details && typeof errObj.details === 'object') {
+          Object.keys(errObj.details).forEach(function(f){ setFieldError(f, errObj.details[f]); });
         }
       }
     }).catch(err=>{

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -59,39 +59,57 @@ function glpi_db_get_executors() { old implementation }
 add_action('wp_ajax_glpi_load_dicts', 'glpi_ajax_load_dicts');
 
 function glpi_get_wp_executors(): array {
-    global $wpdb, $glpi_db;
+    global $wpdb;
     $rows = $wpdb->get_results(
-        "SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key='glpi_user_id' AND meta_value <> ''",
+        $wpdb->prepare(
+            "SELECT user_id, CAST(meta_value AS UNSIGNED) AS glpi_user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value <> ''",
+            'glpi_user_id'
+        ),
         ARRAY_A
     );
-    if (!$rows) {
-        return [];
-    }
     $map = [];
-    $ids = [];
-    foreach ($rows as $r) {
-        $gid = (int) ($r['meta_value'] ?? 0);
-        if ($gid > 0) {
-            $map[$gid] = (int) ($r['user_id'] ?? 0);
-            $ids[] = $gid;
+    $glpiIds = [];
+    if ($rows) {
+        foreach ($rows as $r) {
+            $gid = (int) ($r['glpi_user_id'] ?? 0);
+            if ($gid > 0) {
+                $map[$gid] = (int) ($r['user_id'] ?? 0);
+                $glpiIds[] = $gid;
+            }
         }
     }
-    if (empty($ids)) {
-        return [];
+    $glpiIds = array_values(array_unique($glpiIds));
+    if (empty($glpiIds)) {
+        error_log('[wp-glpi:executors] wp_map=' . count($rows) . ' glpi_ids=0 out=0');
+        return ['list' => [], 'note' => 'no_mappings'];
     }
-    $place = implode(',', array_fill(0, count($ids), '%d'));
-    $sql = $glpi_db->prepare(
-        "SELECT u.id, u.name, u.realname, u.firstname FROM glpi_users u WHERE u.id IN ($place) ORDER BY u.realname COLLATE utf8mb4_unicode_ci ASC, u.firstname COLLATE utf8mb4_unicode_ci ASC",
-        ...$ids
-    );
-    $grows = $glpi_db->get_results($sql, ARRAY_A);
+    try {
+        $pdo = glpi_get_pdo();
+        $holders = [];
+        $params  = [];
+        foreach ($glpiIds as $i => $id) {
+            $ph = ':e' . $i;
+            $holders[] = $ph;
+            $params[$ph] = $id;
+        }
+        $sql = "SELECT u.id, u.name AS login, COALESCE(NULLIF(TRIM(CONCAT(u.realname,' ',u.firstname)),'') , u.name) AS label FROM glpi_users u WHERE u.id IN (" . implode(',', $holders) . ") ORDER BY u.realname COLLATE utf8mb4_unicode_ci ASC, u.firstname COLLATE utf8mb4_unicode_ci ASC";
+        $stmt = $pdo->prepare($sql);
+        foreach ($params as $ph => $val) {
+            $stmt->bindValue($ph, $val, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        $grows = $stmt->fetchAll();
+    } catch (PDOException $e) {
+        error_log('[wp-glpi:executors] SQL ERROR: ' . $e->getMessage());
+        throw $e;
+    }
     $out = [];
     foreach ($grows as $g) {
         $gid = (int) ($g['id'] ?? 0);
         if (!$gid || !isset($map[$gid])) continue;
-        $label = trim(($g['realname'] ?? '') . ' ' . ($g['firstname'] ?? ''));
-        $uname = $g['name'] ?? '';
-        if ($uname === 'vks_m5_local' || $label === '') {
+        $label = trim($g['label'] ?? '');
+        $login = $g['login'] ?? '';
+        if ($login === 'vks_m5_local' || $label === '') {
             $label = 'Куткин Павел';
         }
         $out[] = [
@@ -100,10 +118,21 @@ function glpi_get_wp_executors(): array {
             'glpi_user_id' => $gid,
         ];
     }
+
+    $prevLocale = setlocale(LC_COLLATE, 0);
+    $hasLocale = setlocale(LC_COLLATE, 'ru_RU.UTF-8');
     usort($out, function ($a, $b) {
-        return strcmp(mb_strtolower($a['display_name'], 'UTF-8'), mb_strtolower($b['display_name'], 'UTF-8'));
+        $la = mb_strtolower($a['display_name'], 'UTF-8');
+        $lb = mb_strtolower($b['display_name'], 'UTF-8');
+        return strcoll($la, $lb);
     });
-    return $out;
+    if ($hasLocale && $prevLocale) {
+        setlocale(LC_COLLATE, $prevLocale);
+    }
+
+    error_log('[wp-glpi:executors] wp_map=' . count($rows) . ' glpi_ids=' . count($glpiIds) . ' out=' . count($out));
+
+    return ['list' => $out];
 }
 
 function glpi_ajax_load_dicts() {
@@ -141,8 +170,12 @@ function glpi_ajax_load_dicts() {
 
         $pdo->commit();
 
-        $executors = glpi_get_wp_executors();
+        $exec = glpi_get_wp_executors();
+        $executors = $exec['list'];
         $meta = ['empty' => ['categories' => empty($categories), 'locations' => empty($locations)]];
+        if (!empty($exec['note'])) {
+            $meta['note'] = $exec['note'];
+        }
 
         error_log('[wp-glpi:new-task] catalogs loaded: cats=' . count($categories) . ', locs=' . count($locations));
 
@@ -163,20 +196,29 @@ function glpi_ajax_load_dicts() {
             'message' => 'Ошибка SQL при загрузке локаций',
             'details' => $e->getMessage(),
         ]);
+    } catch (Exception $e) {
+        error_log('[wp-glpi:new-task] SQL executors: ' . $e->getMessage());
+        wp_send_json_error([
+            'type'    => 'SQL',
+            'scope'   => 'executors',
+            'message' => 'Ошибка SQL при загрузке исполнителей',
+            'details' => $e->getMessage(),
+        ]);
     }
 }
 
 // -------- Create ticket --------
 add_action('wp_ajax_glpi_create_ticket', 'glpi_ajax_create_ticket');
+add_action('wp_ajax_wpglpi_create_ticket_api', 'glpi_ajax_create_ticket');
 function glpi_ajax_create_ticket() {
     glpi_nt_verify_nonce();
     if (!is_user_logged_in()) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'SECURITY', 'message' => 'Пользователь не авторизован']]);
+        wp_send_json_error(['type' => 'SECURITY', 'message' => 'Пользователь не авторизован']);
     }
     $wp_uid = get_current_user_id();
     $map = gexe_require_glpi_user($wp_uid);
     if (!$map['ok']) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'MAPPING', 'message' => 'Профиль WordPress не привязан к GLPI пользователю']]);
+        wp_send_json_error(['type' => 'MAPPING', 'message' => 'Профиль WordPress не привязан к GLPI пользователю']);
     }
     $glpi_uid = (int) $map['id'];
 
@@ -189,29 +231,29 @@ function glpi_ajax_create_ticket() {
 
     $errors = [];
     if (mb_strlen($subject, 'UTF-8') < 3 || mb_strlen($subject, 'UTF-8') > 255) {
-        $errors['name'] = 'Тема 3-255 символов';
+        $errors['subject'] = 'Тема 3-255 символов';
     }
-    if (mb_strlen($desc, 'UTF-8') === 0 || mb_strlen($desc, 'UTF-8') > 5000) {
-        $errors['content'] = 'Описание 1-5000 символов';
+    if (mb_strlen($desc, 'UTF-8') > 5000) {
+        $errors['description'] = 'Описание до 5000 символов';
     }
     $executors = glpi_get_wp_executors();
     $allowed = [];
-    foreach ($executors as $e) {
+    foreach ($executors['list'] as $e) {
         $allowed[$e['user_id']] = $e['glpi_user_id'];
     }
     $executor_glpi = 0;
     if ($executor_wp > 0) {
         if (!isset($allowed[$executor_wp])) {
-            $errors['assignee'] = 'Недопустимый исполнитель';
+            $errors['executor_id'] = 'Недопустимый исполнитель';
         } else {
             $executor_glpi = (int) $allowed[$executor_wp];
         }
     }
     if (!$assign_me && $executor_glpi === 0) {
-        $errors['assignee'] = 'Обязательное поле';
+        $errors['executor_id'] = 'Обязательное поле';
     }
     if (!empty($errors)) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'VALIDATION', 'message' => 'Validation failed', 'details' => $errors]]);
+        wp_send_json_error(['type' => 'VALIDATION', 'message' => 'Validation failed', 'details' => $errors]);
     }
     if ($assign_me) {
         $executor_glpi = $glpi_uid;
@@ -221,15 +263,14 @@ function glpi_ajax_create_ticket() {
     $app_token = defined('GEXE_GLPI_APP_TOKEN') ? GEXE_GLPI_APP_TOKEN : (defined('GLPI_APP_TOKEN') ? GLPI_APP_TOKEN : '');
     $user_token = defined('GEXE_GLPI_USER_TOKEN') ? GEXE_GLPI_USER_TOKEN : (defined('GLPI_USER_TOKEN') ? GLPI_USER_TOKEN : '');
     if (!$api_url || !$app_token || !$user_token) {
-        wp_send_json(['success' => false, 'error' => ['type' => 'CONFIG', 'message' => 'GLPI API not configured']]);
+        wp_send_json_error(['type' => 'CONFIG', 'message' => 'GLPI API не настроен (URL/токены)']);
     }
 
-    $lock_key = 'gexe_ticket_' . sha1($wp_uid . '|' . $subject . '|' . $cat . '|' . $loc);
-    $cached = get_transient($lock_key);
-    if ($cached !== false) {
-        wp_send_json($cached);
+    $lock_key = 'wpglpi_create_' . $wp_uid;
+    if (get_transient($lock_key)) {
+        wp_send_json_error(['type' => 'BUSY', 'message' => 'Запрос уже выполняется']);
     }
-    set_transient($lock_key, ['error' => ['type' => 'LOCK']], 10);
+    set_transient($lock_key, 1, 10);
 
     $headers = [
         'Content-Type' => 'application/json',
@@ -251,24 +292,17 @@ function glpi_ajax_create_ticket() {
         'timeout' => 15,
     ]);
     if (is_wp_error($resp)) {
-        $data = ['success' => false, 'error' => ['type' => 'API', 'message' => $resp->get_error_message()]];
-        set_transient($lock_key, $data, 10);
-        error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:api');
-        wp_send_json($data);
+        error_log('[wp-glpi:create] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:api');
+        wp_send_json_error(['type' => 'API', 'message' => $resp->get_error_message()]);
     }
     $code = wp_remote_retrieve_response_code($resp);
-    $body = json_decode(wp_remote_retrieve_body($resp), true);
-    if ($code >= 400 || !isset($body['id'])) {
-        $msg = 'Ошибка API: ' . $code;
-        if (isset($body['message'])) {
-            $msg .= ' ' . $body['message'];
-        }
-        $data = ['success' => false, 'error' => ['type' => 'API', 'code' => $code, 'message' => $msg]];
-        set_transient($lock_key, $data, 10);
-        error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:' . $code);
-        wp_send_json($data);
+    $body = wp_remote_retrieve_body($resp);
+    $decoded = json_decode($body, true);
+    if ($code >= 400 || !isset($decoded['id'])) {
+        error_log('[wp-glpi:create] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=fail:' . $code);
+        wp_send_json_error(['type' => 'API', 'message' => "Ошибка API ({$code})", 'details' => $body]);
     }
-    $ticket_id = (int) $body['id'];
+    $ticket_id = (int) $decoded['id'];
 
     $warning = false;
     if ($executor_glpi > 0) {
@@ -278,15 +312,14 @@ function glpi_ajax_create_ticket() {
             'timeout' => 15,
         ]);
         if (is_wp_error($resp2) || wp_remote_retrieve_response_code($resp2) >= 400) {
-            $warning = true;
+            $warning = wp_remote_retrieve_body($resp2);
         }
     }
-    $out = ['success' => true, 'id' => $ticket_id];
+    $out = ['id' => $ticket_id];
+    error_log('[wp-glpi:create] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=ok#' . $ticket_id);
     if ($warning) {
         $out['warning'] = 'assign_failed';
-        $out['message'] = 'Назначение исполнителя не выполнено';
+        $out['message'] = $warning ? $warning : 'Назначение исполнителя не выполнено';
     }
-    set_transient($lock_key, $out, 10);
-    error_log('[wp-glpi:create-ticket] user=' . $wp_uid . ' glpi=' . $glpi_uid . ' result=ok#' . $ticket_id);
-    wp_send_json($out);
+    wp_send_json_success($out);
 }


### PR DESCRIPTION
## Summary
- query WordPress and GLPI separately for executors and handle missing mappings
- add ticket creation API action with config validation and locking
- surface executor load errors and API feedback in the new-task UI

## Testing
- `php -l glpi-new-task.php`
- `npm test` *(fails: Error: no test specified)*
- `npx eslint assets/js/gexe-new-task.js` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be06fb24408328a1f2c903d0eb1f9e