### PR TITLE
Add skeleton for standalone chief interface

### DIFF
--- a/chief/glpi-chief.css
+++ b/chief/glpi-chief.css
@@ -1,0 +1,23 @@
+/* Basic styles for the Chief page. Real theme should mirror the main plugin. */
+
+.glpi-chief-page {
+    padding: 20px;
+    background: #1e1e1e;
+    color: #eee;
+    min-height: 400px;
+}
+
+.glpi-chief-assignee {
+    margin-top: 20px;
+}
+
+.glpi-chief-assignee-select {
+    padding: 4px 8px;
+    background: #333;
+    color: #fff;
+    border: 1px solid #555;
+}
+
+.glpi-chief-assignee-select:disabled {
+    opacity: 0.5;
+}

--- a/chief/glpi-chief.js
+++ b/chief/glpi-chief.js
@@ -1,0 +1,23 @@
+(function () {
+  'use strict';
+
+  // Namespace for Chief page scripts
+  const GLPIChief = {
+    init() {
+      const select = document.querySelector('.glpi-chief-assignee-select');
+      if (select) {
+        select.addEventListener('change', GLPIChief.handleChange);
+      }
+    },
+
+    handleChange(event) {
+      const value = event.target.value;
+      // TODO: implement AJAX refresh of tickets list
+      if (window.console && console.log) {
+        console.log('GLPIChief assignee changed:', value);
+      }
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', GLPIChief.init);
+})();

--- a/chief/glpi-chief.php
+++ b/chief/glpi-chief.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Template for the "chief" standalone page.
+ *
+ * This is a simplified skeleton clone of the main plugin page. It renders
+ * a container for tickets and an assignee selector. Real logic is expected to
+ * be implemented later.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Restrict access to the specific user only.
+$u = wp_get_current_user();
+$login   = isset($u->user_login) ? (string) $u->user_login : '';
+$glpi_id = (int) get_user_meta($u->ID, 'glpi_user_id', true);
+if ($login !== 'vks_m5_local' && $glpi_id !== 2) {
+    status_header(403);
+    echo 'Доступ ограничен';
+    exit;
+}
+
+?>
+<div class="glpi-chief-page">
+    <div class="glpi-chief-filters"><!-- TODO: filters placeholder --></div>
+    <div class="glpi-chief-list"><!-- TODO: ticket cards placeholder --></div>
+    <div class="glpi-chief-assignee">
+        <label for="glpi-chief-assignee-select">Исполнитель:</label>
+        <select id="glpi-chief-assignee-select" class="glpi-chief-assignee-select">
+            <option value="all" selected>Все заявки</option>
+        </select>
+    </div>
+</div>

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -320,4 +320,6 @@ require_once __DIR__ . '/glpi-solve.php';
 require_once __DIR__ . '/glpi-icon-map.php';
 require_once __DIR__ . '/glpi-new-task.php';
 require_once __DIR__ . '/glpi-settings.php';
+// Loader for the standalone chief interface
+require_once __DIR__ . '/includes/glpi-chief-loader.php';
 

--- a/includes/glpi-chief-endpoints.php
+++ b/includes/glpi-chief-endpoints.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * AJAX endpoints for the chief subsystem.
+ *
+ * Only a minimal skeleton is provided. Actual SQL logic should mirror the
+ * main plugin but filter by assignee when requested.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/** Verify nonce and access rights. */
+function glpi_chief_verify_request() {
+    if (!check_ajax_referer('glpi_chief_actions', 'nonce', false)) {
+        wp_send_json_error(['error' => 'bad_nonce'], 400);
+    }
+    if (!glpi_chief_has_access()) {
+        wp_send_json_error(['error' => 'forbidden'], 403);
+    }
+}
+
+add_action('wp_ajax_glpi_chief_tickets', 'glpi_chief_ajax_tickets');
+
+function glpi_chief_ajax_tickets() {
+    glpi_chief_verify_request();
+
+    $selected = sanitize_text_field($_POST['selected_user_id'] ?? 'all');
+    // TODO: implement SQL fetching similar to main page.
+    wp_send_json_success([
+        'selected' => $selected,
+        'tickets'  => [],
+    ]);
+}

--- a/includes/glpi-chief-loader.php
+++ b/includes/glpi-chief-loader.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Loader for the "chief" subsystem.
+ *
+ * Registers a rewrite rule and hooks into template loading to serve the
+ * custom page. Styles and scripts are enqueued separately. This is only a
+ * skeleton implementation.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Determine if current user has access to the chief page.
+ */
+function glpi_chief_has_access(): bool {
+    $u = wp_get_current_user();
+    if (!$u || !$u->ID) {
+        return false;
+    }
+    $login   = isset($u->user_login) ? (string) $u->user_login : '';
+    $glpi_id = (int) get_user_meta($u->ID, 'glpi_user_id', true);
+    return ($login === 'vks_m5_local') || ($glpi_id === 2);
+}
+
+/** Register rewrite rule and query var. */
+add_action('init', function () {
+    add_rewrite_rule('^glpi-chief/?$', 'index.php?glpi_chief=1', 'top');
+});
+
+add_filter('query_vars', function ($vars) {
+    $vars[] = 'glpi_chief';
+    return $vars;
+});
+
+/** Template loader for the chief page. */
+add_filter('template_include', function ($template) {
+    if (get_query_var('glpi_chief') === '1') {
+        if (!glpi_chief_has_access()) {
+            status_header(403);
+            echo 'Доступ ограничен';
+            exit;
+        }
+        $base = dirname(__DIR__);
+        return $base . '/chief/glpi-chief.php';
+    }
+    return $template;
+});
+
+/** Enqueue assets for the chief page. */
+add_action('wp_enqueue_scripts', function () {
+    if (get_query_var('glpi_chief') !== '1') {
+        return;
+    }
+    $base_dir = dirname(__DIR__);
+    $base_url = plugin_dir_url($base_dir . '/gexe-copy.php');
+    wp_enqueue_style('glpi-chief', $base_url . 'chief/glpi-chief.css', [], '1.0.0');
+    wp_enqueue_script('glpi-chief', $base_url . 'chief/glpi-chief.js', [], '1.0.0', true);
+    wp_localize_script('glpi-chief', 'glpiChiefAjax', [
+        'url'   => admin_url('admin-ajax.php'),
+        'nonce' => wp_create_nonce('glpi_chief_actions'),
+    ]);
+});
+
+// Include AJAX endpoints.
+require_once __DIR__ . '/glpi-chief-endpoints.php';


### PR DESCRIPTION
## Summary
- add loader and endpoints for new `/glpi-chief` page
- create basic template, JS, and CSS for chief page
- wire loader into plugin bootstrap

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bec7e58a0083289547d91635455ea7