### PR TITLE
Add standalone chief interface shortcode

### DIFF
--- a/chief/glpi-chief.css
+++ b/chief/glpi-chief.css
@@ -1,23 +1,15 @@
-/* Basic styles for the Chief page. Real theme should mirror the main plugin. */
+/* Styles specific to the chief interface. */
 
-.glpi-chief-page {
-    padding: 20px;
-    background: #1e1e1e;
-    color: #eee;
-    min-height: 400px;
-}
-
-.glpi-chief-assignee {
-    margin-top: 20px;
-}
-
-.glpi-chief-assignee-select {
+.chief-executors {
     padding: 4px 8px;
     background: #333;
     color: #fff;
     border: 1px solid #555;
+    border-radius: 4px;
+    margin-right: 10px;
 }
 
-.glpi-chief-assignee-select:disabled {
-    opacity: 0.5;
+.chief-executors:disabled {
+    opacity: 0.6;
 }
+

--- a/chief/glpi-chief.js
+++ b/chief/glpi-chief.js
@@ -1,23 +1,51 @@
 (function () {
   'use strict';
 
-  // Namespace for Chief page scripts
-  const GLPIChief = {
-    init() {
-      const select = document.querySelector('.glpi-chief-assignee-select');
-      if (select) {
-        select.addEventListener('change', GLPIChief.handleChange);
-      }
-    },
+  document.addEventListener('DOMContentLoaded', function () {
+    if (typeof glpiChief === 'undefined' || glpiChief.isManager !== 1) {
+      return;
+    }
 
-    handleChange(event) {
-      const value = event.target.value;
-      // TODO: implement AJAX refresh of tickets list
-      if (window.console && console.log) {
-        console.log('GLPIChief assignee changed:', value);
+    var host = document.querySelector('.glpi-top-left');
+    if (!host) {
+      return;
+    }
+
+    var select = document.createElement('select');
+    select.className = 'chief-executors';
+
+    var optAll = document.createElement('option');
+    optAll.value = 'all';
+    optAll.textContent = 'Без фильтров';
+    select.appendChild(optAll);
+
+    (glpiChief.executors || []).forEach(function (ex) {
+      var opt = document.createElement('option');
+      opt.value = String(ex.id);
+      opt.textContent = ex.name;
+      select.appendChild(opt);
+    });
+
+    if (glpiChief.viewAs) {
+      var cur = String(glpiChief.viewAs);
+      if (select.querySelector('option[value="' + cur + '"]')) {
+        select.value = cur;
       }
     }
-  };
 
-  document.addEventListener('DOMContentLoaded', GLPIChief.init);
+    select.addEventListener('change', function () {
+      var val = select.value;
+      var url = new URL(window.location.href);
+      url.searchParams.set('view_as', val);
+      select.disabled = true;
+      window.location.assign(url.toString());
+    });
+
+    host.prepend(select);
+
+    if (glpiChief.viewAs) {
+      history.replaceState(null, '', location.pathname + location.hash);
+    }
+  });
 })();
+

--- a/chief/glpi-chief.php
+++ b/chief/glpi-chief.php
@@ -1,34 +1,264 @@
 <?php
 /**
- * Template for the "chief" standalone page.
+ * Standalone "chief" clone of the main GLPI cards shortcode.
  *
- * This is a simplified skeleton clone of the main plugin page. It renders
- * a container for tickets and an assignee selector. Real logic is expected to
- * be implemented later.
+ * Registers [glpi_cards_chief] shortcode which renders the ticket list using
+ * only assets from the /chief directory. The implementation intentionally does
+ * not rely on front‑end pieces of the main plugin to avoid conflicts.
  */
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
-// Restrict access to the specific user only.
-$u = wp_get_current_user();
-$login   = isset($u->user_login) ? (string) $u->user_login : '';
-$glpi_id = (int) get_user_meta($u->ID, 'glpi_user_id', true);
-if ($login !== 'vks_m5_local' && $glpi_id !== 2) {
-    status_header(403);
-    echo 'Доступ ограничен';
-    exit;
+if (!defined('CHIEF_DEBUG')) {
+    define('CHIEF_DEBUG', false);
 }
 
-?>
-<div class="glpi-chief-page">
-    <div class="glpi-chief-filters"><!-- TODO: filters placeholder --></div>
-    <div class="glpi-chief-list"><!-- TODO: ticket cards placeholder --></div>
-    <div class="glpi-chief-assignee">
-        <label for="glpi-chief-assignee-select">Исполнитель:</label>
-        <select id="glpi-chief-assignee-select" class="glpi-chief-assignee-select">
-            <option value="all" selected>Все заявки</option>
-        </select>
-    </div>
-</div>
+require_once dirname(__DIR__) . '/glpi-db-setup.php';
+require_once dirname(__DIR__) . '/glpi-icon-map.php';
+
+/** Check if current user is a manager. */
+function chief_is_manager(): bool {
+    $u = wp_get_current_user();
+    if (!$u || !$u->ID) {
+        return false;
+    }
+    $login   = isset($u->user_login) ? (string) $u->user_login : '';
+    $glpi_id = (int) get_user_meta($u->ID, 'glpi_user_id', true);
+    return ($login === 'vks_m5_local') || ($glpi_id === 2);
+}
+
+/** Current user's GLPI ID. */
+function chief_current_glpi_id(): int {
+    $u = wp_get_current_user();
+    if (!$u || !$u->ID) return 0;
+    return (int) get_user_meta($u->ID, 'glpi_user_id', true);
+}
+
+/** Compose short name for executors. */
+function chief_compose_short_name($realname, $firstname): string {
+    $realname  = trim((string) $realname);
+    $firstname = trim((string) $firstname);
+    if ($realname && $firstname) return $realname . ' ' . mb_substr($firstname, 0, 1) . '.';
+    if ($realname) return $realname;
+    if ($firstname) return $firstname;
+    return '';
+}
+
+/** List of executors {id, name}. */
+function chief_get_assignee_options(): array {
+    $users = get_users(['meta_key' => 'glpi_user_id']);
+    $out   = [];
+    foreach ($users as $u) {
+        $gid = (int) get_user_meta($u->ID, 'glpi_user_id', true);
+        if ($gid <= 0) continue;
+        $out[] = [
+            'id'   => $gid,
+            'name' => chief_compose_short_name($u->last_name ?? '', $u->first_name ?? ''),
+        ];
+    }
+    return $out;
+}
+
+/** Autoname executor from real/first names with local overrides. */
+function chief_autoname($realname, $firstname): string {
+    $realname  = trim((string) $realname);
+    $firstname = trim((string) $firstname);
+    $joined = mb_strtolower($realname . $firstname);
+    switch ($joined) {
+        case 'кузнецовен': return 'Кузнецов Е.';
+        case 'смирновмо':  return 'Смирнов М.';
+    }
+    if ($realname && $firstname) return $realname . ' ' . mb_substr($firstname, 0, 1) . '.';
+    if ($realname) return $realname;
+    if ($firstname) return $firstname;
+    return 'Без исполнителя';
+}
+
+/** Slugify helper for categories. */
+function chief_slugify($text): string {
+    $text = (string) $text;
+    if (function_exists('transliterator_transliterate')) {
+        $text = transliterator_transliterate('Any-Latin; Latin-ASCII', $text);
+    }
+    $text = strtolower($text);
+    $text = preg_replace('/[^a-z0-9]+/u', '-', $text);
+    return trim($text, '-');
+}
+
+/** Flag used to enqueue assets only when shortcode is present. */
+$GLOBALS['chief_needs_assets'] = false;
+
+/** Enqueue JS/CSS for the chief page. */
+function chief_enqueue_assets() {
+    if (empty($GLOBALS['chief_needs_assets'])) {
+        return;
+    }
+
+    $base_dir = dirname(__DIR__);
+    $base_url = plugin_dir_url($base_dir . '/gexe-copy.php');
+    $css_path = __DIR__ . '/glpi-chief.css';
+    $js_path  = __DIR__ . '/glpi-chief.js';
+    $css_ver  = file_exists($css_path) ? filemtime($css_path) : null;
+    $js_ver   = file_exists($js_path)  ? filemtime($js_path)  : null;
+
+    wp_enqueue_style('glpi-chief', $base_url . 'chief/glpi-chief.css', [], $css_ver);
+    wp_enqueue_script('glpi-chief', $base_url . 'chief/glpi-chief.js', [], $js_ver, true);
+
+    $view_as = isset($_GET['view_as']) ? (string) $_GET['view_as'] : '';
+    wp_localize_script('glpi-chief', 'glpiChief', [
+        'executors' => chief_get_assignee_options(),
+        'isManager' => chief_is_manager() ? 1 : 0,
+        'viewAs'    => $view_as,
+    ]);
+}
+add_action('wp_enqueue_scripts', 'chief_enqueue_assets');
+
+/** Shortcode handler for [glpi_cards_chief]. */
+function chief_glpi_cards_shortcode($atts = []): string {
+    global $glpi_db;
+
+    $GLOBALS['chief_needs_assets'] = true; // ensure assets are loaded
+
+    $current_gid = chief_current_glpi_id();
+    $is_manager  = chief_is_manager();
+    $view_as_raw = isset($_GET['view_as']) ? (string) $_GET['view_as'] : '';
+
+    $where_assignee = '';
+    $branch = 'self';
+
+    if ($is_manager) {
+        if ($view_as_raw === 'all') {
+            $branch = 'all';
+        } elseif (ctype_digit($view_as_raw)) {
+            $branch = 'user';
+            $where_assignee = $glpi_db->prepare(' AND tu.users_id = %d ', (int) $view_as_raw);
+        } elseif ($current_gid > 0) {
+            $where_assignee = $glpi_db->prepare(' AND tu.users_id = %d ', $current_gid);
+        }
+    } else {
+        if ($current_gid > 0) {
+            $where_assignee = $glpi_db->prepare(' AND tu.users_id = %d ', $current_gid);
+        }
+    }
+
+    if (CHIEF_DEBUG) {
+        error_log('[chief] view_as=' . json_encode($view_as_raw) . '; branch=' . $branch);
+    }
+
+    $sql = "SELECT t.id, t.status, t.name, t.content, t.date, t.time_to_resolve,\n"
+        . "       tu.users_id AS assignee_id, u.realname, u.firstname,\n"
+        . "       c.completename AS category_name, l.completename AS location_name\n"
+        . "FROM glpi_tickets t\n"
+        . "LEFT JOIN glpi_tickets_users tu ON tu.tickets_id = t.id AND tu.type = 2\n"
+        . "LEFT JOIN glpi_users u ON tu.users_id = u.id\n"
+        . "LEFT JOIN glpi_itilcategories c ON t.itilcategories_id = c.id\n"
+        . "LEFT JOIN glpi_locations l ON t.locations_id = l.id\n"
+        . "WHERE t.is_deleted = 0 AND t.status IN (1,2,3,4)" . $where_assignee . "\n"
+        . "ORDER BY t.date_mod DESC\n"
+        . "LIMIT 500";
+
+    $rows = $glpi_db->get_results($sql);
+    if (!$rows) {
+        return '<p>Нет активных заявок.</p>';
+    }
+
+    $tickets = [];
+    foreach ($rows as $r) {
+        $id = (int) $r->id;
+        if (!isset($tickets[$id])) {
+            $tickets[$id] = [
+                'id'           => $id,
+                'status'       => (int) $r->status,
+                'name'         => (string) $r->name,
+                'content'      => (string) $r->content,
+                'date'         => (string) $r->date,
+                'category'     => (string) $r->category_name,
+                'location'     => (string) $r->location_name,
+                'executors'    => [],
+                'assignee_ids' => [],
+                'late'         => ($r->time_to_resolve && strtotime($r->time_to_resolve) < time()),
+            ];
+        }
+
+        $exec_name = chief_autoname($r->realname, $r->firstname);
+        if ($exec_name && !in_array($exec_name, $tickets[$id]['executors'], true)) {
+            $tickets[$id]['executors'][] = $exec_name;
+        }
+
+        if ($r->assignee_id !== null && $r->assignee_id !== '') {
+            $aid = (int) $r->assignee_id;
+            if ($aid && !in_array($aid, $tickets[$id]['assignee_ids'], true)) {
+                $tickets[$id]['assignee_ids'][] = $aid;
+            }
+        }
+    }
+
+    $status_counts = [1 => 0, 2 => 0, 3 => 0, 4 => 0];
+    foreach ($tickets as $t) {
+        $s = (int) $t['status'];
+        if (isset($status_counts[$s])) {
+            $status_counts[$s]++;
+        }
+    }
+    $total_count = array_sum($status_counts);
+
+    $category_counts = [];
+    $category_slugs  = [];
+    foreach ($tickets as $t) {
+        $full = (string) $t['category'];
+        $parts = preg_split('/\s*>\s*/u', $full);
+        $leaf = trim((string) end($parts));
+        if ($leaf === '') $leaf = $full ?: '—';
+        if (!isset($category_counts[$leaf])) $category_counts[$leaf] = 0;
+        $category_counts[$leaf]++;
+        if (!isset($category_slugs[$leaf])) {
+            $category_slugs[$leaf] = chief_slugify($leaf);
+        }
+    }
+    if (!empty($category_counts)) {
+        uksort($category_counts, function ($a, $b) {
+            return strnatcasecmp($a, $b);
+        });
+    }
+
+    $tpl = plugin_dir_path(__DIR__ . '/gexe-copy.php') . 'templates/glpi-cards-template.php';
+    if (!file_exists($tpl)) {
+        return '<div style="padding:10px;background:#fee;border:1px solid #f99;">Отсутствует шаблон: templates/glpi-cards-template.php</div>';
+    }
+
+    // Preserve existing globals from the main shortcode to avoid conflicts.
+    $globals = ['gexe_tickets','gexe_status_counts','gexe_total_count','gexe_show_all','gexe_category_counts','gexe_category_slugs','gexe_prefetched_comments'];
+    $backup = [];
+    foreach ($globals as $g) {
+        if (isset($GLOBALS[$g])) {
+            $backup[$g] = $GLOBALS[$g];
+        }
+    }
+
+    $GLOBALS['gexe_tickets']             = $tickets;
+    $GLOBALS['gexe_status_counts']       = $status_counts;
+    $GLOBALS['gexe_total_count']         = $total_count;
+    $GLOBALS['gexe_show_all']            = ($is_manager && $view_as_raw === 'all');
+    $GLOBALS['gexe_category_counts']     = $category_counts;
+    $GLOBALS['gexe_category_slugs']      = $category_slugs;
+    $GLOBALS['gexe_prefetched_comments'] = [];
+
+    ob_start();
+    include $tpl;
+    $html = ob_get_clean();
+
+    foreach ($globals as $g) {
+        if (array_key_exists($g, $backup)) {
+            $GLOBALS[$g] = $backup[$g];
+        } else {
+            unset($GLOBALS[$g]);
+        }
+    }
+
+    return $html;
+}
+
+add_shortcode('glpi_cards_chief', 'chief_glpi_cards_shortcode');
+

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -320,6 +320,6 @@ require_once __DIR__ . '/glpi-solve.php';
 require_once __DIR__ . '/glpi-icon-map.php';
 require_once __DIR__ . '/glpi-new-task.php';
 require_once __DIR__ . '/glpi-settings.php';
-// Loader for the standalone chief interface
-require_once __DIR__ . '/includes/glpi-chief-loader.php';
+// Register the standalone chief shortcode
+require_once __DIR__ . '/chief/glpi-chief.php';
 


### PR DESCRIPTION
## Summary
- add `[glpi_cards_chief]` shortcode with isolated PHP, JS and CSS
- support manager `view_as` filtering and dropdown executor switcher
- hook shortcode loader in main plugin

## Testing
- `php -l chief/glpi-chief.php`
- `php -l gexe-copy.php`
- `npm test` *(fails: Error: no test specified)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68becfb6a41c8328b0df269bd4004680