### PR TITLE
Refactor form data loading with SQL/API fallback

### DIFF
--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -45,6 +45,27 @@ if (!function_exists('wp_glpi_get_connection')) {
     }
 }
 
+/**
+ * Check if a specific column exists in a GLPI table using PDO.
+ */
+function gexe_glpi_table_has_column(PDO $pdo, string $table, string $column): bool {
+    static $cache = [];
+    $table  = preg_replace('/[^a-zA-Z0-9_]/', '', $table);
+    $column = preg_replace('/[^a-zA-Z0-9_]/', '', $column);
+    if ($table === '' || $column === '') {
+        return false;
+    }
+    if (isset($cache[$table][$column])) {
+        return $cache[$table][$column];
+    }
+    $sql  = 'SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :t AND COLUMN_NAME = :c';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':t' => $table, ':c' => $column]);
+    $exists = (bool) $stmt->fetchColumn();
+    $cache[$table][$column] = $exists;
+    return $exists;
+}
+
 define('GEXE_TRIGGERS_VERSION', '2');
 
 define('GEXE_GLPI_API_URL', 'http://192.168.100.12/glpi/apirest.php');

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -10,6 +10,8 @@ if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/glpi-db-setup.php';
 require_once __DIR__ . '/inc/user-map.php';
+require_once __DIR__ . '/includes/glpi-form-data.php';
+require_once __DIR__ . '/includes/executors-cache.php';
 
 add_action('wp_enqueue_scripts', function () {
     wp_register_style('glpi-new-task', plugin_dir_url(__FILE__) . 'glpi-new-task.css', [], '1.0.0');
@@ -43,128 +45,10 @@ function glpi_nt_verify_nonce() {
 }
 
 // -------- Dictionaries --------
-/* legacy loader (rollback)
-add_action('wp_ajax_glpi_get_categories', 'glpi_ajax_get_categories');
-function glpi_ajax_get_categories() { old implementation }
-
-add_action('wp_ajax_glpi_get_locations', 'glpi_ajax_get_locations');
-function glpi_ajax_get_locations() { old implementation }
-
-add_action('wp_ajax_glpi_get_executors', 'glpi_ajax_get_executors');
-function glpi_ajax_get_executors() { old implementation }
-
-function glpi_db_get_executors() { old implementation }
-*/
-
-add_action('wp_ajax_glpi_load_dicts', 'glpi_ajax_load_dicts');
-
-function glpi_get_wp_executors(): array {
-    global $wpdb, $glpi_db;
-    $rows = $wpdb->get_results(
-        "SELECT user_id, meta_value FROM {$wpdb->usermeta} WHERE meta_key='glpi_user_id' AND meta_value <> ''",
-        ARRAY_A
-    );
-    if (!$rows) {
-        return [];
-    }
-    $map = [];
-    $ids = [];
-    foreach ($rows as $r) {
-        $gid = (int) ($r['meta_value'] ?? 0);
-        if ($gid > 0) {
-            $map[$gid] = (int) ($r['user_id'] ?? 0);
-            $ids[] = $gid;
-        }
-    }
-    if (empty($ids)) {
-        return [];
-    }
-    $place = implode(',', array_fill(0, count($ids), '%d'));
-    $sql = $glpi_db->prepare(
-        "SELECT u.id, u.name, u.realname, u.firstname FROM glpi_users u WHERE u.id IN ($place) ORDER BY u.realname COLLATE utf8mb4_unicode_ci ASC, u.firstname COLLATE utf8mb4_unicode_ci ASC",
-        ...$ids
-    );
-    $grows = $glpi_db->get_results($sql, ARRAY_A);
-    $out = [];
-    foreach ($grows as $g) {
-        $gid = (int) ($g['id'] ?? 0);
-        if (!$gid || !isset($map[$gid])) continue;
-        $label = trim(($g['realname'] ?? '') . ' ' . ($g['firstname'] ?? ''));
-        $uname = $g['name'] ?? '';
-        if ($uname === 'vks_m5_local' || $label === '') {
-            $label = 'Куткин Павел';
-        }
-        $out[] = [
-            'user_id'      => $map[$gid],
-            'display_name' => $label,
-            'glpi_user_id' => $gid,
-        ];
-    }
-    usort($out, function ($a, $b) {
-        return strcmp(mb_strtolower($a['display_name'], 'UTF-8'), mb_strtolower($b['display_name'], 'UTF-8'));
-    });
-    return $out;
-}
-
-function glpi_ajax_load_dicts() {
-    glpi_nt_verify_nonce();
-    if (!is_user_logged_in()) {
-        wp_send_json_error([
-            'error' => [
-                'type'    => 'SECURITY',
-                'scope'   => 'all',
-                'code'    => 'NO_AUTH',
-                'message' => 'Пользователь не авторизован',
-            ]
-        ]);
-    }
-    try {
-        $pdo = glpi_get_pdo();
-        $pdo->beginTransaction();
-
-        // Entity-based filtering temporarily disabled. Legacy code preserved below for future restoration.
-        /*
-        $use_filter = defined('WP_GLPI_FILTER_CATALOGS_BY_ENTITY') && WP_GLPI_FILTER_CATALOGS_BY_ENTITY;
-        $allowed = [];
-        if ($use_filter) {
-            // ... previous entity filtering logic ...
-        }
-        */
-
-        $categories = $pdo->query(
-            "SELECT c.id, c.name, c.completename FROM glpi_itilcategories AS c WHERE c.is_helpdeskvisible = 1 ORDER BY c.completename ASC"
-        )->fetchAll(PDO::FETCH_ASSOC);
-
-        $locations = $pdo->query(
-            "SELECT l.id, l.name, l.completename FROM glpi_locations AS l ORDER BY l.completename ASC"
-        )->fetchAll(PDO::FETCH_ASSOC);
-
-        $pdo->commit();
-
-        $executors = glpi_get_wp_executors();
-        $meta = ['empty' => ['categories' => empty($categories), 'locations' => empty($locations)]];
-
-        error_log('[wp-glpi:new-task] catalogs loaded: cats=' . count($categories) . ', locs=' . count($locations));
-
-        wp_send_json_success([
-            'categories' => $categories,
-            'locations'  => $locations,
-            'executors'  => $executors,
-            'meta'       => $meta,
-        ]);
-    } catch (PDOException $e) {
-        if (isset($pdo) && $pdo->inTransaction()) {
-            $pdo->rollBack();
-        }
-        error_log('[wp-glpi:new-task] SQL locations: ' . $e->getMessage());
-        wp_send_json_error([
-            'type'    => 'SQL',
-            'scope'   => 'locations',
-            'message' => 'Ошибка SQL при загрузке локаций',
-            'details' => $e->getMessage(),
-        ]);
-    }
-}
+add_action('wp_ajax_glpi_load_dicts', 'gexe_get_form_data');
+add_action('wp_ajax_glpi_get_categories', 'gexe_get_form_data');
+add_action('wp_ajax_glpi_get_locations', 'gexe_get_form_data');
+add_action('wp_ajax_glpi_get_executors', 'gexe_get_form_data');
 
 // -------- Create ticket --------
 add_action('wp_ajax_glpi_create_ticket', 'glpi_ajax_create_ticket');
@@ -194,10 +78,10 @@ function glpi_ajax_create_ticket() {
     if (mb_strlen($desc, 'UTF-8') === 0 || mb_strlen($desc, 'UTF-8') > 5000) {
         $errors['content'] = 'Описание 1-5000 символов';
     }
-    $executors = glpi_get_wp_executors();
+    [$execs] = gexe_get_wp_executors_cached();
     $allowed = [];
-    foreach ($executors as $e) {
-        $allowed[$e['user_id']] = $e['glpi_user_id'];
+    foreach ($execs as $e) {
+        $allowed[$e['id']] = $e['glpi_user_id'];
     }
     $executor_glpi = 0;
     if ($executor_wp > 0) {

--- a/includes/glpi-form-data.php
+++ b/includes/glpi-form-data.php
@@ -4,6 +4,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/logger.php';
 require_once dirname(__DIR__) . '/glpi-utils.php';
 require_once __DIR__ . '/executors-cache.php';
+require_once dirname(__DIR__) . '/glpi-db-setup.php';
 
 /**
  * AJAX: выдаёт списки категорий и местоположений.
@@ -33,46 +34,29 @@ function gexe_get_form_data() {
     $source      = 'cache';
     $error_msg   = '';
     $debug_tests = [];
+    $cat_sql     = '';
+    $loc_sql     = '';
 
     if (!is_array($data) || empty($data['categories']) || empty($data['locations'])) {
-        global $glpi_db;
         $categories = [];
         $locations  = [];
         $source     = 'db';
+        $cat_sql    = '';
+        $loc_sql    = '';
         try {
-            if (!($glpi_db instanceof wpdb)) {
-                throw new Exception('DB_CONNECT_FAILED');
-            }
-            if (isset($_GET['debug'])) {
-                $tests = [
-                    'SELECT 1',
-                    'SELECT id FROM glpi.glpi_itilcategories LIMIT 1',
-                    'SELECT id FROM glpi.glpi_locations LIMIT 1',
-                ];
-                foreach ($tests as $sql) {
-                    $res = $glpi_db->get_var($sql);
-                    $debug_tests[] = ['sql' => $sql, 'result' => $res, 'error' => $glpi_db->last_error];
-                }
-                $gr = $glpi_db->get_col('SHOW GRANTS FOR CURRENT_USER');
-                gexe_log_action('[form-data] grants ' . implode(' || ', $gr));
-            }
+            $pdo = glpi_get_pdo();
+            $pdo->beginTransaction();
 
             $cat_where = [];
-            if (gexe_glpi_has_column('glpi_itilcategories', 'is_active')) {
-                $cat_where[] = 'is_active = 1';
+            if (gexe_glpi_table_has_column($pdo, 'glpi_itilcategories', 'is_helpdeskvisible')) {
+                $cat_where[] = 'is_helpdeskvisible = 1';
             }
-            if (gexe_glpi_has_column('glpi_itilcategories', 'is_helpdesk_visible')) {
-                $cat_where[] = 'is_helpdesk_visible = 1';
-            }
-            $cat_sql = 'SELECT id, name, completename FROM `glpi`.`glpi_itilcategories`';
-            if (!empty($cat_where)) {
+            $cat_sql = 'SELECT id, name, completename FROM glpi_itilcategories';
+            if ($cat_where) {
                 $cat_sql .= ' WHERE ' . implode(' AND ', $cat_where);
             }
-            $cat_sql .= ' ORDER BY name ASC LIMIT 1000';
-            $cats = $glpi_db->get_results($cat_sql, ARRAY_A);
-            if ($glpi_db->last_error) {
-                throw new Exception($glpi_db->last_error);
-            }
+            $cat_sql .= ' ORDER BY completename ASC LIMIT 1000';
+            $cats = $pdo->query($cat_sql)->fetchAll(PDO::FETCH_ASSOC);
             foreach ($cats as $c) {
                 $name = isset($c['name']) ? trim(preg_replace('/\s+/', ' ', wp_strip_all_tags($c['name']))) : '';
                 $path = isset($c['completename']) ? $c['completename'] : $name;
@@ -85,33 +69,32 @@ function gexe_get_form_data() {
             }
 
             $loc_where = [];
-            if (gexe_glpi_has_column('glpi_locations', 'is_deleted')) {
+            if (gexe_glpi_table_has_column($pdo, 'glpi_locations', 'is_deleted')) {
                 $loc_where[] = 'is_deleted = 0';
             }
-            if (gexe_glpi_has_column('glpi_locations', 'is_active')) {
-                $loc_where[] = 'is_active = 1';
-            }
-            if (gexe_glpi_has_column('glpi_locations', 'is_helpdesk_visible')) {
-                $loc_where[] = 'is_helpdesk_visible = 1';
-            }
-            $loc_sql = 'SELECT id, completename AS name FROM `glpi`.`glpi_locations`';
-            if (!empty($loc_where)) {
+            $loc_sql = 'SELECT id, name, completename FROM glpi_locations';
+            if ($loc_where) {
                 $loc_sql .= ' WHERE ' . implode(' AND ', $loc_where);
             }
             $loc_sql .= ' ORDER BY completename ASC LIMIT 2000';
-            $locs = $glpi_db->get_results($loc_sql, ARRAY_A);
-            if ($glpi_db->last_error) {
-                throw new Exception($glpi_db->last_error);
-            }
+            $locs = $pdo->query($loc_sql)->fetchAll(PDO::FETCH_ASSOC);
             foreach ($locs as $l) {
                 $locations[] = [
                     'id'   => (int) $l['id'],
-                    'name' => $l['name'],
+                    'name' => $l['completename'] ?? ($l['name'] ?? ''),
                 ];
             }
-        } catch (Exception $e) {
-            $error_msg = $glpi_db instanceof wpdb ? $glpi_db->last_error : $e->getMessage();
-            $error_msg = mb_substr(wp_strip_all_tags($error_msg), 0, 200);
+
+            if (empty($categories) || empty($locations)) {
+                throw new Exception('EMPTY_RESULT');
+            }
+
+            $pdo->commit();
+        } catch (Throwable $e) {
+            if (isset($pdo) && $pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            $error_msg = mb_substr(wp_strip_all_tags($e->getMessage()), 0, 200);
             $source    = 'api';
         }
 
@@ -178,18 +161,26 @@ function gexe_get_form_data() {
         set_transient($cache_key, $data, 30 * MINUTE_IN_SECONDS);
     }
 
-    [$executors, $exec_cache, $exec_more] = gexe_get_wp_executors_cached();
+    [$exec_raw, $exec_cache, $exec_more] = gexe_get_wp_executors_cached();
+    $executors = [];
+    foreach ($exec_raw as $e) {
+        $executors[] = [
+            'id'   => (int) ($e['glpi_user_id'] ?? 0),
+            'name' => (string) ($e['label'] ?? ''),
+        ];
+    }
     $data['executors']       = $executors;
     $data['executors_cache'] = $exec_cache;
     $data['executors_more']  = $exec_more;
 
     $elapsed = (int) round((microtime(true) - $t0) * 1000);
     $err_log = isset($error_msg) ? $error_msg : '';
-    gexe_log_action(sprintf('[form-data] source=%s http=200 elapsed=%dms cats=%d locs=%d err="%s"', $source, $elapsed, count($data['categories']), count($data['locations']), $err_log));
+    gexe_log_action(sprintf('[form-data] source=%s tables="itilcategories,locations" sql="%s" sql2="%s" elapsed=%dms cats=%d locs=%d err="%s"', $source, $cat_sql, $loc_sql, $elapsed, count($data['categories']), count($data['locations']), $err_log));
 
     $out = $data;
     $out['source']  = $source;
     $out['took_ms'] = $elapsed;
+    $out['nonce']   = wp_create_nonce('gexe_form_data');
     if (isset($_GET['debug'])) {
         $out['debug'] = [
             'source'  => $source,


### PR DESCRIPTION
## Summary
- add PDO helper for safe GLPI column detection
- normalize form-data SQL with column checks and API fallback
- unify dictionary endpoints and JS loader on `gexe_get_form_data`

## Testing
- `php -l glpi-db-setup.php`
- `php -l includes/glpi-form-data.php`
- `php -l glpi-new-task.php`
- `npx eslint assets/js/gexe-filter.js` *(fails: Parsing error)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bed45d8084832881780262051f57f4