### PR TITLE
feat: add assignee validation for new tickets

### DIFF
--- a/glpi-new-task.css
+++ b/glpi-new-task.css
@@ -23,6 +23,7 @@
 .glpi-create-modal .gnt-submit:disabled { opacity: .7; cursor: default; }
 .glpi-create-modal .gnt-submit.is-loading { position:relative; color:transparent; }
 .glpi-create-modal .gnt-submit.is-loading::after { content:''; position:absolute; top:50%; left:50%; width:16px; height:16px; margin:-8px 0 0 -8px; border:2px solid #fff; border-top-color:transparent; border-radius:50%; animation:gnt-spin .6s linear infinite; }
+.glpi-create-modal .gnt-submit-error { margin-top:8px; color:#f87171; font-size:12px; text-align:center; min-height:1.2em; }
 .glpi-create-modal .gnt-path { margin-top: 4px; font-size: 12px; color: #94a3b8; }
 .glpi-create-modal .gnt-field-error { color:#f87171; font-size:12px; margin-top:4px; }
 .glpi-create-modal .gnt-input.gnt-invalid,
@@ -55,3 +56,5 @@
 @media (min-width:460px){
   .gnt-success-modal .gnt-success-actions{flex-direction:row;justify-content:center;}
 }
+.gnt-toast{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#166534;color:#fff;padding:10px 16px;border-radius:8px;z-index:10000;opacity:0;transition:opacity .3s;}
+.gnt-toast.show{opacity:1;}

--- a/includes/glpi-sql.php
+++ b/includes/glpi-sql.php
@@ -87,15 +87,23 @@ function create_ticket_sql(array $data) {
         'entities_id'      => 0,
         'due_date'         => null,
         'status'           => 1,
+        'type'             => 1,
+        'urgency'          => 3,
+        'impact'           => 3,
+        'priority'         => 3,
     ];
     $p = array_merge($defaults, $data);
 
     $glpi_db->query('START TRANSACTION');
     $sql = $glpi_db->prepare(
-        'INSERT INTO glpi_tickets (name, content, status, date, date_mod, due_date, users_id_recipient, users_id_lastupdater, entities_id, itilcategories_id, locations_id) VALUES (%s,%s,%d,NOW(),NOW(),%s,%d,%d,%d,%d,%d)',
+        'INSERT INTO glpi_tickets (name, content, status, type, urgency, impact, priority, date, date_mod, due_date, users_id_recipient, users_id_lastupdater, entities_id, itilcategories_id, locations_id) VALUES (%s,%s,%d,%d,%d,%d,%d,NOW(),NOW(),%s,%d,%d,%d,%d,%d)',
         $p['name'],
         $p['content'],
         $p['status'],
+        $p['type'],
+        $p['urgency'],
+        $p['impact'],
+        $p['priority'],
         $p['due_date'],
         $p['requester_id'],
         $p['requester_id'],


### PR DESCRIPTION
## Summary
- use preloaded assignee list in new ticket form
- add client validation with inline errors and toast notifications
- create SQL-backed endpoint to persist tickets and prevent duplicates

## Testing
- `php -l glpi-new-task.php`
- `php -l includes/glpi-sql.php`
- `npx eslint assets/js/gexe-new-task.js` *(fails: 294 problems)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bef2ce10fc8328abec22280a763f18