### PR TITLE
Implement GLPI REST API ticket creation

### DIFF
--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -365,3 +365,113 @@ function glpi_ajax_create_ticket_sql() {
     error_log('[new-ticket] user=' . $wp_uid . '/' . $glpi_uid . ' sql=ticket+links ok code=created ticket_id=' . $tid . ' elapsed=' . $elapsed);
     wp_send_json(['ok' => true, 'code' => 'created', 'message' => 'Заявка создана', 'ticket_id' => $tid]);
 }
+add_action('wp_ajax_glpi_create_ticket_api', 'glpi_ajax_create_ticket_api');
+function glpi_ajax_create_ticket_api() {
+    if (!check_ajax_referer('gexe_actions', 'nonce', false)) {
+        wp_send_json(['ok' => false, 'code' => 'SECURITY/NO_CSRF']);
+    }
+    if (!is_user_logged_in() || !current_user_can('read')) {
+        wp_send_json(['ok' => false, 'code' => 'not_logged_in']);
+    }
+    $wp_uid = get_current_user_id();
+    $glpi_uid = gexe_get_glpi_user_id($wp_uid);
+    if ($glpi_uid <= 0) {
+        wp_send_json(['ok' => false, 'code' => 'not_mapped']);
+    }
+
+    $lock_key = 'gexe_nt_submit_' . $wp_uid;
+    if (get_transient($lock_key)) {
+        wp_send_json(['ok' => false, 'code' => 'rate_limit_client']);
+    }
+    set_transient($lock_key, 1, 10);
+
+    $subject = mb_substr(trim((string) ($_POST['subject'] ?? '')), 0, 255);
+    $content = mb_substr(trim((string) ($_POST['content'] ?? '')), 0, 4096);
+    $cat_id = absint($_POST['category_id'] ?? 0);
+    $loc_id = absint($_POST['location_id'] ?? 0);
+    $assignee_glpi_id = absint($_POST['assignee_glpi_id'] ?? 0);
+    $is_self = !empty($_POST['is_self_assignee']);
+
+    $errors = [];
+    if (mb_strlen($subject) < 3) $errors['subject'] = true;
+    if (mb_strlen($content) < 3) $errors['content'] = true;
+    if ($cat_id <= 0) $errors['category_id'] = true;
+    if ($loc_id <= 0) $errors['location_id'] = true;
+
+    $allowed = wp_list_pluck(function_exists('gexe_get_assignee_options') ? gexe_get_assignee_options() : [], 'id');
+    if ($is_self) {
+        $assignee_glpi_id = $glpi_uid;
+    } elseif ($assignee_glpi_id <= 0 || !in_array($assignee_glpi_id, $allowed, true)) {
+        $errors['assignee_glpi_id'] = true;
+    }
+
+    if (!empty($errors)) {
+        wp_send_json(['ok' => false, 'code' => 'validation']);
+    }
+
+    require_once __DIR__ . '/includes/glpi-api.php';
+
+    $search = '/search/Ticket?criteria[0][field]=1&criteria[0][searchtype]=contains&criteria[0][value]=' . rawurlencode($subject) .
+        '&criteria[1][link]=AND&criteria[1][field]=12&criteria[1][searchtype]=equals&criteria[1][value]=' . $cat_id .
+        '&criteria[2][link]=AND&criteria[2][field]=82&criteria[2][searchtype]=equals&criteria[2][value]=' . $loc_id .
+        '&forcedisplay[0]=2&range=0-1';
+    $dup = gexe_glpi_api_request('GET', $search);
+    if (!is_wp_error($dup) && $dup['code'] === 200 && !empty($dup['body']['data'][0])) {
+        $first = $dup['body']['data'][0];
+        $dup_date = isset($first['date']) ? strtotime($first['date']) : 0;
+        if ($dup_date && $dup_date >= time() - 60) {
+            $dup_id = isset($first['2']) ? (int) $first['2'] : 0;
+            if ($dup_id) {
+                wp_send_json(['ok' => true, 'code' => 'already_exists', 'ticket_id' => $dup_id]);
+            }
+        }
+    }
+
+    $start = microtime(true);
+    $r1 = gexe_glpi_api_request('POST', '/Ticket', [
+        'input' => [
+            'name' => $subject,
+            'content' => $content,
+            'itilcategories_id' => $cat_id,
+            'locations_id' => $loc_id,
+            'status' => 1,
+            'type' => 1,
+        ],
+    ]);
+    $elapsed = (int) round((microtime(true) - $start) * 1000);
+    if (is_wp_error($r1)) {
+        error_log('[new-ticket-api] wp_user=' . $wp_uid . ' assignee_glpi=' . $assignee_glpi_id . ' cat=' . $cat_id . ' loc=' . $loc_id . ' result=err code=api_unreachable ticket_id=0 elapsed=' . $elapsed);
+        wp_send_json(['ok' => false, 'code' => 'api_unreachable']);
+    }
+    $code1 = (int) $r1['code'];
+    $body1 = $r1['body'];
+    if ($code1 === 401 || $code1 === 403) {
+        error_log('[new-ticket-api] wp_user=' . $wp_uid . ' assignee_glpi=' . $assignee_glpi_id . ' cat=' . $cat_id . ' loc=' . $loc_id . ' result=err code=api_auth ticket_id=0 elapsed=' . $elapsed);
+        wp_send_json(['ok' => false, 'code' => 'api_auth']);
+    }
+    if ($code1 >= 400) {
+        $ecode = ($code1 === 400) ? 'api_validation' : 'api_unreachable';
+        error_log('[new-ticket-api] wp_user=' . $wp_uid . ' assignee_glpi=' . $assignee_glpi_id . ' cat=' . $cat_id . ' loc=' . $loc_id . ' result=err code=' . $ecode . ' ticket_id=0 elapsed=' . $elapsed);
+        wp_send_json(['ok' => false, 'code' => $ecode]);
+    }
+    $ticket_id = isset($body1['id']) ? (int) $body1['id'] : 0;
+    if ($ticket_id <= 0) {
+        error_log('[new-ticket-api] wp_user=' . $wp_uid . ' assignee_glpi=' . $assignee_glpi_id . ' cat=' . $cat_id . ' loc=' . $loc_id . ' result=err code=api_unreachable ticket_id=0 elapsed=' . $elapsed);
+        wp_send_json(['ok' => false, 'code' => 'api_unreachable']);
+    }
+
+    $r2 = gexe_glpi_api_request('POST', '/Ticket/' . $ticket_id . '/Ticket_User', [
+        'input' => [
+            'tickets_id' => $ticket_id,
+            'users_id'   => $assignee_glpi_id,
+            'type'       => 2,
+        ],
+    ]);
+    if (is_wp_error($r2) || (int) $r2['code'] >= 400) {
+        error_log('[new-ticket-api] wp_user=' . $wp_uid . ' assignee_glpi=' . $assignee_glpi_id . ' cat=' . $cat_id . ' loc=' . $loc_id . ' result=err code=assign_failed ticket_id=' . $ticket_id . ' elapsed=' . $elapsed);
+        wp_send_json(['ok' => false, 'code' => 'assign_failed', 'ticket_id' => $ticket_id]);
+    }
+
+    error_log('[new-ticket-api] wp_user=' . $wp_uid . ' assignee_glpi=' . $assignee_glpi_id . ' cat=' . $cat_id . ' loc=' . $loc_id . ' result=ok code=created ticket_id=' . $ticket_id . ' elapsed=' . $elapsed);
+    wp_send_json(['ok' => true, 'ticket_id' => $ticket_id]);
+}

--- a/includes/glpi-api.php
+++ b/includes/glpi-api.php
@@ -1,0 +1,36 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/rest-client.php';
+require_once __DIR__ . '/../glpi-db-setup.php';
+
+/**
+ * Perform a request to the GLPI REST API.
+ *
+ * @param string     $method  HTTP method.
+ * @param string     $path    API path starting with '/'.
+ * @param array|null $payload Optional JSON payload.
+ * @return array|WP_Error {code:int, body:array, raw:array} or WP_Error on failure.
+ */
+function gexe_glpi_api_request($method, $path, $payload = null) {
+    $url = rtrim(gexe_glpi_api_url(), '/') . '/' . ltrim($path, '/');
+    $headers = gexe_glpi_api_headers();
+    $args = [
+        'headers' => $headers,
+        'timeout' => 15,
+    ];
+    if (null !== $payload) {
+        $args['body'] = wp_json_encode($payload);
+    }
+    $response = gexe_glpi_rest_request($method, $url, $args);
+    if (is_wp_error($response)) {
+        return $response;
+    }
+    $code = (int) wp_remote_retrieve_response_code($response);
+    $body = json_decode(wp_remote_retrieve_body($response), true);
+    return [
+        'code' => $code,
+        'body' => $body,
+        'raw'  => $response,
+    ];
+}


### PR DESCRIPTION
## Summary
- add GLPI REST helper for authorized requests
- create `glpi_create_ticket_api` endpoint to create and assign tickets via GLPI REST
- wire frontend submit to new endpoint with improved error handling and button lock

## Testing
- `npm test` (fails: Error: no test specified)
- `php -l includes/glpi-api.php glpi-new-task.php`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68bef8efe93c8328825ed202ce01170b