### PR TITLE
Include error details in GLPI API responses

### DIFF
--- a/assets/js/gexe-new-task.js
+++ b/assets/js/gexe-new-task.js
@@ -585,7 +585,7 @@
           showToast(msg);
           window.dispatchEvent(new CustomEvent('gexe:tickets:refresh', {detail:{ticketId:data.ticket_id}}));
         } else {
-          setSubmitError(mapError(data.code, data.ticket_id));
+          setSubmitError(mapError(data.code, data.ticket_id) + (data.detail ? (' — ' + String(data.detail)) : ''));
         }
       })
       .catch(()=>{ setSubmitError(mapError('api_unreachable')); })

--- a/glpi-db-setup.php
+++ b/glpi-db-setup.php
@@ -157,9 +157,16 @@ function gexe_glpi_api_url(): string {
 }
 
 function gexe_glpi_api_headers(array $extra = []): array {
+    // Use per-user token if available; fallback to legacy constant.
+    $tok = function_exists('gexe_glpi_get_current_user_token')
+        ? gexe_glpi_get_current_user_token()
+        : null;
+    if (!$tok || $tok === '') {
+        $tok = defined('GEXE_GLPI_USER_TOKEN') ? GEXE_GLPI_USER_TOKEN : '';
+    }
     $base = [
-        'Content-Type' => 'application/json',
-        'Authorization' => 'user_token ' . GEXE_GLPI_USER_TOKEN,
+        'Content-Type'  => 'application/json',
+        'Authorization' => 'user_token ' . $tok,
         'App-Token'     => GEXE_GLPI_APP_TOKEN,
     ];
     return array_merge($base, $extra);

--- a/glpi-new-task.php
+++ b/glpi-new-task.php
@@ -423,7 +423,7 @@ function glpi_ajax_create_ticket_api() {
         $log_init = 'err:' . $err;
         $elapsed = (int) round((microtime(true) - $start) * 1000);
         error_log('[new-ticket-api] initSession=' . $log_init . ' create=' . $log_create . ' assign=' . $log_assign . ' tid=0 elapsed=' . $elapsed);
-        wp_send_json(['ok' => false, 'code' => $err]);
+        wp_send_json(['ok' => false, 'code' => $err, 'detail' => $token->get_error_message()]);
     }
     $log_init = 'ok';
 
@@ -459,7 +459,7 @@ function glpi_ajax_create_ticket_api() {
         $log_create = 'err:api_unreachable';
         $elapsed = (int) round((microtime(true) - $start) * 1000);
         error_log('[new-ticket-api] initSession=' . $log_init . ' create=' . $log_create . ' assign=' . $log_assign . ' tid=0 elapsed=' . $elapsed);
-        wp_send_json(['ok' => false, 'code' => 'api_unreachable']);
+        wp_send_json(['ok' => false, 'code' => 'api_unreachable', 'detail' => $r1->get_error_message()]);
     }
     $code1 = (int) $r1['code'];
     $body1 = $r1['body'];
@@ -473,14 +473,18 @@ function glpi_ajax_create_ticket_api() {
         $log_create = ($code1 === 400) ? 'err:api_validation' : 'err:api_unreachable';
         $elapsed = (int) round((microtime(true) - $start) * 1000);
         error_log('[new-ticket-api] initSession=' . $log_init . ' create=' . $log_create . ' assign=' . $log_assign . ' tid=0 elapsed=' . $elapsed);
-        wp_send_json(['ok' => false, 'code' => ($code1 === 400) ? 'api_validation' : 'api_unreachable']);
+        wp_send_json([
+            'ok'    => false,
+            'code'  => ($code1 === 400) ? 'api_validation' : 'api_unreachable',
+            'detail'=> isset($body1['message']) ? $body1['message'] : ('HTTP ' . $code1),
+        ]);
     }
     $ticket_id = isset($body1['id']) ? (int) $body1['id'] : 0;
     if ($ticket_id <= 0) {
         $log_create = 'err:api_unreachable';
         $elapsed = (int) round((microtime(true) - $start) * 1000);
         error_log('[new-ticket-api] initSession=' . $log_init . ' create=' . $log_create . ' assign=' . $log_assign . ' tid=0 elapsed=' . $elapsed);
-        wp_send_json(['ok' => false, 'code' => 'api_unreachable']);
+        wp_send_json(['ok' => false, 'code' => 'api_unreachable', 'detail' => 'Empty ticket id']);
     }
     $log_create = 'ok';
 
@@ -495,7 +499,12 @@ function glpi_ajax_create_ticket_api() {
         $log_assign = 'err:assign_failed';
         $elapsed = (int) round((microtime(true) - $start) * 1000);
         error_log('[new-ticket-api] initSession=' . $log_init . ' create=' . $log_create . ' assign=' . $log_assign . ' tid=' . $ticket_id . ' elapsed=' . $elapsed);
-        wp_send_json(['ok' => false, 'code' => 'assign_failed', 'ticket_id' => $ticket_id]);
+        wp_send_json([
+            'ok'        => false,
+            'code'      => 'assign_failed',
+            'ticket_id' => $ticket_id,
+            'detail'    => (is_wp_error($r2) ? $r2->get_error_message() : (isset($r2['body']['message']) ? $r2['body']['message'] : ('HTTP ' . ((int)$r2['code'])))),
+        ]);
     }
     $log_assign = 'ok';
 


### PR DESCRIPTION
## Summary
- Use per-user GLPI token when available in request headers
- Return detailed error messages from GLPI ticket creation API
- Surface backend error details in frontend submission errors

## Testing
- `php -l glpi-db-setup.php`
- `php -l glpi-new-task.php`
- `npx eslint assets/js/gexe-new-task.js` *(fails: numerous lint errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf317f4c748328bd8f4441db0338ea