### PR TITLE
fix: correct include paths and asset URLs

### DIFF
--- a/chief/glpi-chief.php
+++ b/chief/glpi-chief.php
@@ -5,6 +5,7 @@ if (!defined('CHIEF_DEBUG')) {
     define('CHIEF_DEBUG', false);
 }
 
+// keep chief self-contained but align with new paths
 require_once dirname(__DIR__) . '/includes/bootstrap/db-setup.php';
 require_once dirname(__DIR__) . '/includes/helpers/icon-map.php';
 require_once dirname(__DIR__) . '/includes/auth/user-map.php';

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -14,6 +14,8 @@ if (!defined('ABSPATH')) exit;
 // Path constants
 if (!defined('GEXE_INC')) define('GEXE_INC', plugin_dir_path(__FILE__) . 'includes/');
 if (!defined('GEXE_TPL')) define('GEXE_TPL', plugin_dir_path(__FILE__) . 'templates/');
+// Ensure constants available early for nested includes
+if (!defined('GEXE_ROOT_FILE')) define('GEXE_ROOT_FILE', __FILE__);
 
 require_once __DIR__ . '/includes/helpers/utils.php';
 require_once __DIR__ . '/includes/glpi-profile-fields.php';

--- a/includes/ajax/modal-actions.php
+++ b/includes/ajax/modal-actions.php
@@ -10,6 +10,7 @@ if (!defined('ABSPATH')) exit;
 require_once dirname(__DIR__) . '/helpers/utils.php';
 require_once dirname(__DIR__) . '/glpi-sql.php';
 require_once dirname(__DIR__) . '/glpi-auth-map.php';
+// paths are from /includes/ajax/ -> /includes/*
 
 function gexe_action_response($ok, $code, $ticket_id, $action, $msg = '', $extra = []) {
     $payload = array_merge([

--- a/includes/ajax/new-task.php
+++ b/includes/ajax/new-task.php
@@ -13,10 +13,12 @@ require_once dirname(__DIR__) . '/helpers/utils.php';
 require_once dirname(__DIR__) . '/glpi-sql.php';
 
 add_action('wp_enqueue_scripts', function () {
-    wp_register_style('glpi-new-task', plugin_dir_url(__FILE__) . 'glpi-new-task.css', [], '1.0.0');
+    // __FILE__ is nested (/includes/ajax/). Use plugins_url() anchored at plugin root file.
+    $root = dirname(__DIR__, 2) . '/gexe-copy.php';
+    wp_register_style('glpi-new-task', plugins_url('glpi-new-task.css', $root), [], '1.0.0');
     wp_enqueue_style('glpi-new-task');
 
-    wp_register_script('gexe-new-task-js', plugin_dir_url(__FILE__) . 'assets/js/gexe-new-task.js', [], '1.0.0', true);
+    wp_register_script('gexe-new-task-js', plugins_url('assets/js/gexe-new-task.js', $root), [], '1.0.0', true);
     wp_enqueue_script('gexe-new-task-js');
 
     $data = [

--- a/includes/ajax/solve.php
+++ b/includes/ajax/solve.php
@@ -1,7 +1,9 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-require_once dirname(__DIR__) . '/helpers/utils.php';
+// Reuse modal-actions helpers (gexe_ajax_error_compat, etc.)
+require_once __DIR__ . '/modal-actions.php';
+// modal-actions.php already includes utils/sql/auth-map
 
 add_action('wp_ajax_glpi_ticket_resolve', 'gexe_glpi_ticket_resolve');
 function gexe_glpi_ticket_resolve() {

--- a/includes/api/glpi-api-legacy.php
+++ b/includes/api/glpi-api-legacy.php
@@ -1,6 +1,8 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+// legacy file moved to includes/api; logic unchanged
+
 class Gexe_GLPI_API {
     private $base;
     private $app_token;

--- a/includes/glpi-api.php
+++ b/includes/glpi-api.php
@@ -2,7 +2,8 @@
 if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/rest-client.php';
-require_once __DIR__ . '/../includes/bootstrap/db-setup.php';
+// glpi-api.php is already in /includes; db-setup lives in /includes/bootstrap
+require_once __DIR__ . '/bootstrap/db-setup.php';
 
 /**
  * Retrieve cached GLPI session token or initialize a new session.

--- a/includes/glpi-auth-map.php
+++ b/includes/glpi-auth-map.php
@@ -1,7 +1,8 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
-require_once __DIR__ . '/../includes/helpers/utils.php';
+// file is in /includes; helpers in /includes/helpers
+require_once __DIR__ . '/helpers/utils.php';
 
 /**
  * Map WordPress users to GLPI user identifiers.

--- a/includes/glpi-form-data.php
+++ b/includes/glpi-form-data.php
@@ -2,7 +2,8 @@
 if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/logger.php';
-require_once dirname(__DIR__) . '/includes/helpers/utils.php';
+// file is in /includes; helpers in /includes/helpers
+require_once __DIR__ . '/helpers/utils.php';
 require_once __DIR__ . '/executors-cache.php';
 
 /**

--- a/includes/glpi-sql.php
+++ b/includes/glpi-sql.php
@@ -7,7 +7,8 @@ if (!defined('ABSPATH')) exit;
  * with prepared statements.
  */
 
-require_once __DIR__ . '/../includes/helpers/utils.php';
+// file is in /includes; helpers in /includes/helpers
+require_once __DIR__ . '/helpers/utils.php';
 
 /**
  * Insert a followup into glpi_itilfollowups.

--- a/includes/helpers/utils.php
+++ b/includes/helpers/utils.php
@@ -2,6 +2,7 @@
 if (!defined('ABSPATH')) exit;
 // (moved to includes/helpers/)
 
+// this file is /includes/helpers; logger at /includes/logger.php, user-map at /includes/auth/user-map.php
 require_once dirname(__DIR__) . '/logger.php';
 require_once dirname(__DIR__) . '/auth/user-map.php';
 


### PR DESCRIPTION
## Summary
- fix incorrect include paths after restructuring
- register new-task assets relative to plugin root
- reuse modal action helpers in solve endpoint
- add root constant for nested includes

## Testing
- `php -l chief/glpi-chief.php gexe-copy.php includes/ajax/modal-actions.php includes/ajax/new-task.php includes/ajax/solve.php includes/api/glpi-api-legacy.php includes/glpi-api.php includes/glpi-auth-map.php includes/glpi-form-data.php includes/glpi-sql.php includes/helpers/utils.php`
- `composer validate --no-check-all --strict`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf38da3bf48328beec0624f86bd333