### PR TITLE
Improve GLPI task creation error handling

### DIFF
--- a/assets/js/gexe-new-task.js
+++ b/assets/js/gexe-new-task.js
@@ -585,7 +585,7 @@
           showToast(msg);
           window.dispatchEvent(new CustomEvent('gexe:tickets:refresh', {detail:{ticketId:data.ticket_id}}));
         } else {
-          setSubmitError(mapError(data.code, data.ticket_id) + (data.detail ? (' — ' + String(data.detail)) : ''));
+          setSubmitError(mapError(data.code, data.ticket_id) + (data.detail ? ('\n' + String(data.detail)) : ''));
         }
       })
       .catch(()=>{ setSubmitError(mapError('api_unreachable')); })


### PR DESCRIPTION
## Summary
- ensure AJAX ticket creation always returns JSON even on PHP errors
- normalize GLPI API session token responses and enrich assignment error details
- show API error details on a new line in the frontend form

## Testing
- `npm test` *(fails: Error: no test specified)*
- `php -l glpi-new-task.php`
- `npx eslint assets/js/gexe-new-task.js` *(fails: 297 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3b4036548328aa03454f09336772