### PR TITLE
Improve GLPI ticket creation error handling

### DIFF
--- a/assets/css/glpi-new-tasks.css
+++ b/assets/css/glpi-new-tasks.css
@@ -1,0 +1,8 @@
+/* Ensure multiline backend errors are visible under the submit button */
+.gnt-submit-error,
+.gnt-error {
+  white-space: pre-line;    /* показываем переносы строк из JS */
+  line-height: 1.2;
+}
+
+/* ... existing styles below ... */


### PR DESCRIPTION
## Summary
- Normalize GLPI ticket creation responses and parse non-JSON replies
- Show backend error codes and details in ticket form
- Preserve line breaks for backend errors in modal styles

## Testing
- ❌ `npx eslint assets/js/gexe-new-task.js` (301 problems)
- ❌ `npm test` (no tests specified)

------
https://chatgpt.com/codex/tasks/task_e_68bf3de1a118832880ed0f545b7cb4a6