### PR TITLE
Add API comment submission

### DIFF
--- a/assets/css/gee.css
+++ b/assets/css/gee.css
@@ -402,8 +402,10 @@ button.disabled{opacity:.5;cursor:not-allowed;}
 .gexe-cmnt__err{ color:#f87171; font-size:13px; margin-top:4px; }
 .gexe-cmnt__counter{ color:#94a3b8; font-size:12px; margin-bottom:8px; text-align:right; }
 .gexe-cmnt__foot{ padding:12px; border-top:1px solid #334155; }
-#gexe-cmnt-send.glpi-act{background:#475569;border:1px solid #334155;color:#fff;border-radius:10px;font-weight:700;width:100%;display:block}
-#gexe-cmnt-send.glpi-act:hover{background:#334155}
+#gexe-cmnt-send.glpi-act,
+#gexe-cmnt-send-api.glpi-act{background:#475569;border:1px solid #334155;color:#fff;border-radius:10px;font-weight:700;width:100%;display:block}
+#gexe-cmnt-send.glpi-act:hover,
+#gexe-cmnt-send-api.glpi-act:hover{background:#334155}
 .glpi-status-btn.glpi-act{background:#475569;border:1px solid #334155;color:#fff;border-radius:10px;font-weight:700;padding:10px 16px;min-width:120px}
 .glpi-status-btn.glpi-act:hover{background:#334155}
 .glpi-status-btn.glpi-act:disabled{background:#1e293b;color:#64748b;border-color:#334155;cursor:not-allowed}

--- a/glpi-modal-actions.php
+++ b/glpi-modal-actions.php
@@ -8,6 +8,7 @@
 require_once __DIR__ . '/glpi-utils.php';
 require_once __DIR__ . '/includes/glpi-sql.php';
 require_once __DIR__ . '/includes/glpi-auth-map.php';
+require_once __DIR__ . '/includes/glpi-comment-api.php';
 
 function gexe_action_response($ok, $code, $ticket_id, $action, $msg = '', $extra = []) {
     $payload = array_merge([

--- a/includes/glpi-comment-api.php
+++ b/includes/glpi-comment-api.php
@@ -1,0 +1,32 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/glpi-api.php';
+
+// AJAX handler for sending comment via GLPI API
+add_action('wp_ajax_glpi_send_comment_api', 'gexe_glpi_send_comment_api');
+function gexe_glpi_send_comment_api() {
+    if (!check_ajax_referer('gexe_form_data', 'nonce', false)) {
+        wp_send_json(['ok' => false, 'code' => 'forbidden', 'detail' => 'Invalid nonce']);
+    }
+    $ticket_id = isset($_POST['ticket_id']) ? intval($_POST['ticket_id']) : 0;
+    $comment   = isset($_POST['comment']) ? sanitize_textarea_field((string) $_POST['comment']) : '';
+    if (!$ticket_id || $comment === '') {
+        wp_send_json(['ok' => false, 'code' => 'invalid_params', 'detail' => 'Missing ticket_id or comment']);
+    }
+    $resp = gexe_glpi_api_request('POST', "/Ticket/$ticket_id/ITILFollowup", [
+        'input' => [
+            'content'    => $comment,
+            'is_private' => 0,
+        ]
+    ]);
+    if (is_wp_error($resp)) {
+        wp_send_json(['ok' => false, 'code' => 'glpi_api', 'detail' => $resp->get_error_message()]);
+    }
+    $code = isset($resp['code']) ? (int) $resp['code'] : 0;
+    $body = $resp['body'] ?? [];
+    if ($code === 201 && isset($body['id'])) {
+        wp_send_json(['ok' => true, 'id' => $body['id']]);
+    }
+    wp_send_json(['ok' => false, 'code' => 'glpi_api', 'detail' => wp_json_encode($body)]);
+}


### PR DESCRIPTION
## Summary
- allow sending comments through GLPI API with new AJAX handler
- add API submission button and logic in comment modal
- style modal buttons consistently

## Testing
- `php -l includes/glpi-comment-api.php`
- `npx eslint assets/js/gexe-filter.js` *(fails: Parsing error)*
- `vendor/bin/phpcs glpi-modal-actions.php includes/glpi-comment-api.php` *(fails: multiple coding standard errors)*
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf519ae0f08328b00a2e94ba053edf