### PR TITLE
Add isolated chief mode with SQL endpoints

### DIFF
--- a/chief/glpi-chief-actions.php
+++ b/chief/glpi-chief-actions.php
@@ -1,0 +1,176 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+/**
+ * Chief-only AJAX endpoints.
+ * Все изменения изолированы в подпапке /chief.
+ * Действия пишутся в GLPI через SQL «от имени» acting_as (GLPI user_id).
+ */
+
+// Регистрация эндпоинтов
+add_action('wp_ajax_gexe_chief_accept_sql', 'gexe_chief_accept_sql');
+add_action('wp_ajax_gexe_chief_update_status_sql', 'gexe_chief_update_status_sql');
+add_action('wp_ajax_gexe_chief_assign_sql', 'gexe_chief_assign_sql');
+add_action('wp_ajax_gexe_chief_comment_sql', 'gexe_chief_comment_sql');
+
+// Вспомогательная авторизация и проверка входных данных
+function gexe_chief_require($keys = []) {
+    if (!function_exists('chief_is_chief_user') || !chief_is_chief_user()) {
+        wp_send_json(['ok' => false, 'code' => 'forbidden', 'detail' => 'Chief only.']);
+    }
+    check_ajax_referer('gexe_chief_nonce');
+    foreach ($keys as $k) {
+        if (!isset($_POST[$k])) {
+            wp_send_json(['ok' => false, 'code' => 'bad_request', 'detail' => "Missing field: {$k}"]);
+        }
+    }
+}
+
+function gexe_chief_accept_sql() {
+    gexe_chief_require(['ticket_id', 'acting_as']);
+    $tid = (int) $_POST['ticket_id'];
+    $acting_as = (int) $_POST['acting_as'];
+    if ($tid <= 0 || $acting_as <= 0) {
+        wp_send_json(['ok' => false, 'code' => 'bad_request', 'detail' => 'Invalid ids']);
+    }
+    global $glpi_db;
+    $glpi_db->query('START TRANSACTION');
+    try {
+        // Ensure assignment (type=2)
+        $exists = (int) $glpi_db->get_var($glpi_db->prepare(
+            "SELECT 1 FROM glpi_tickets_users WHERE tickets_id=%d AND users_id=%d AND type=2 LIMIT 1",
+            $tid, $acting_as
+        ));
+        if (!$exists) {
+            $glpi_db->query($glpi_db->prepare("DELETE FROM glpi_tickets_users WHERE tickets_id=%d AND type=2", $tid));
+            $glpi_db->query($glpi_db->prepare(
+                "INSERT INTO glpi_tickets_users (tickets_id, users_id, type) VALUES (%d, %d, 2)",
+                $tid, $acting_as
+            ));
+        }
+        // Move status to "in progress" (2) if needed
+        $cur = (int) $glpi_db->get_var($glpi_db->prepare("SELECT status FROM glpi_tickets WHERE id=%d FOR UPDATE", $tid));
+        if ($cur !== 2) {
+            $glpi_db->query($glpi_db->prepare("UPDATE glpi_tickets SET status=2 WHERE id=%d", $tid));
+        }
+        // Idempotent accept followup (10 minutes window)
+        $accept_text = 'Принято в работу';
+        $dup = (int) $glpi_db->get_var($glpi_db->prepare(
+            "SELECT id FROM glpi_itilfollowups
+             WHERE items_id=%d AND users_id=%d AND content=%s
+               AND date >= (NOW() - INTERVAL 10 MINUTE)
+             LIMIT 1",
+            $tid, $acting_as, $accept_text
+        ));
+        if (!$dup) {
+            $glpi_db->query($glpi_db->prepare(
+                "INSERT INTO glpi_itilfollowups (items_id, is_private, requesttypes_id, users_id, date, content)
+                 VALUES (%d, 0, 1, %d, NOW(), %s)",
+                $tid, $acting_as, $accept_text
+            ));
+        }
+        $glpi_db->query('COMMIT');
+        wp_send_json(['ok' => true]);
+    } catch (Throwable $e) {
+        $glpi_db->query('ROLLBACK');
+        if (defined('CHIEF_DEBUG') && CHIEF_DEBUG) error_log('chief_accept_sql: '.$e->getMessage());
+        wp_send_json(['ok' => false, 'code' => 'sql_error', 'detail' => 'DB error']);
+    }
+}
+
+function gexe_chief_update_status_sql() {
+    gexe_chief_require(['ticket_id', 'acting_as', 'new_status']);
+    $tid = (int) $_POST['ticket_id'];
+    $acting_as = (int) $_POST['acting_as'];
+    $new_status = (int) $_POST['new_status'];
+    $add_accept = isset($_POST['add_accept_comment']) ? (int) $_POST['add_accept_comment'] : 0;
+    if ($tid <= 0 || $acting_as <= 0 || $new_status <= 0) {
+        wp_send_json(['ok' => false, 'code' => 'bad_request', 'detail' => 'Invalid fields']);
+    }
+    global $glpi_db;
+    $glpi_db->query('START TRANSACTION');
+    try {
+        // Update status if different
+        $cur = (int) $glpi_db->get_var($glpi_db->prepare("SELECT status FROM glpi_tickets WHERE id=%d FOR UPDATE", $tid));
+        if ($cur !== $new_status) {
+            $glpi_db->query($glpi_db->prepare("UPDATE glpi_tickets SET status=%d WHERE id=%d", $new_status, $tid));
+        }
+        // Optional accept comment (idempotent)
+        if ($add_accept) {
+            $accept_text = 'Принято в работу';
+            $dup = (int) $glpi_db->get_var($glpi_db->prepare(
+                "SELECT id FROM glpi_itilfollowups
+                 WHERE items_id=%d AND users_id=%d AND content=%s
+                   AND date >= (NOW() - INTERVAL 10 MINUTE)
+                 LIMIT 1",
+                $tid, $acting_as, $accept_text
+            ));
+            if (!$dup) {
+                $glpi_db->query($glpi_db->prepare(
+                    "INSERT INTO glpi_itilfollowups (items_id, is_private, requesttypes_id, users_id, date, content)
+                     VALUES (%d, 0, 1, %d, NOW(), %s)",
+                     $tid, $acting_as, $accept_text
+                ));
+            }
+        }
+        $glpi_db->query('COMMIT');
+        wp_send_json(['ok' => true]);
+    } catch (Throwable $e) {
+        $glpi_db->query('ROLLBACK');
+        if (defined('CHIEF_DEBUG') && CHIEF_DEBUG) error_log('chief_update_status_sql: '.$e->getMessage());
+        wp_send_json(['ok' => false, 'code' => 'sql_error', 'detail' => 'DB error']);
+    }
+}
+
+function gexe_chief_assign_sql() {
+    gexe_chief_require(['ticket_id', 'acting_as', 'new_assignee']);
+    $tid = (int) $_POST['ticket_id'];
+    $assignee = (int) $_POST['new_assignee'];
+    if ($tid <= 0 || $assignee <= 0) {
+        wp_send_json(['ok' => false, 'code' => 'bad_request', 'detail' => 'Invalid ids']);
+    }
+    global $glpi_db;
+    $glpi_db->query('START TRANSACTION');
+    try {
+        $exists = (int) $glpi_db->get_var($glpi_db->prepare(
+            "SELECT 1 FROM glpi_tickets_users WHERE tickets_id=%d AND users_id=%d AND type=2 LIMIT 1",
+            $tid, $assignee
+        ));
+        if (!$exists) {
+            $glpi_db->query($glpi_db->prepare("DELETE FROM glpi_tickets_users WHERE tickets_id=%d AND type=2", $tid));
+            $glpi_db->query($glpi_db->prepare(
+                "INSERT INTO glpi_tickets_users (tickets_id, users_id, type) VALUES (%d, %d, 2)",
+                $tid, $assignee
+            ));
+        }
+        $glpi_db->query('COMMIT');
+        wp_send_json(['ok' => true]);
+    } catch (Throwable $e) {
+        $glpi_db->query('ROLLBACK');
+        if (defined('CHIEF_DEBUG') && CHIEF_DEBUG) error_log('chief_assign_sql: '.$e->getMessage());
+        wp_send_json(['ok' => false, 'code' => 'sql_error', 'detail' => 'DB error']);
+    }
+}
+
+function gexe_chief_comment_sql() {
+    gexe_chief_require(['ticket_id', 'acting_as', 'comment']);
+    $tid = (int) $_POST['ticket_id'];
+    $comment = wp_kses_post(wp_unslash($_POST['comment']));
+    $acting_as = (int) $_POST['acting_as'];
+    if ($tid <= 0 || $acting_as <= 0 || $comment === '') {
+        wp_send_json(['ok' => false, 'code' => 'bad_request', 'detail' => 'Invalid input']);
+    }
+    global $glpi_db;
+    try {
+        $glpi_db->query($glpi_db->prepare(
+            "INSERT INTO glpi_itilfollowups (items_id, is_private, requesttypes_id, users_id, date, content)
+             VALUES (%d, 0, 1, %d, NOW(), %s)",
+            $tid, $acting_as, $comment
+        ));
+        wp_send_json(['ok' => true]);
+    } catch (Throwable $e) {
+        if (defined('CHIEF_DEBUG') && CHIEF_DEBUG) error_log('chief_comment_sql: '.$e->getMessage());
+        wp_send_json(['ok' => false, 'code' => 'sql_error', 'detail' => 'DB error']);
+    }
+}
+

--- a/chief/glpi-chief.css
+++ b/chief/glpi-chief.css
@@ -1,5 +1,28 @@
+/* Chief styles */
+
 .chief-executors {
   margin-left: 8px;
   padding: 2px 4px;
   font-size: 14px;
+}
+
+.gexe-accept-btn.is-accepted {
+  opacity: .9;
+  cursor: default;
+  background: linear-gradient(180deg, rgba(52,152,219,.22), rgba(52,152,219,.06));
+  border: 1px solid rgba(52,152,219,.45);
+  box-shadow: 0 0 0 1px rgba(52,152,219,.15) inset;
+}
+.gexe-accept-btn.is-accepted:hover {
+  box-shadow: none;
+  transform: none;
+}
+
+/* dark toast */
+.gexe-toast {
+  background: rgba(20,24,30,.96);
+  color: #e6eef8;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 8px;
+  padding: 8px 10px;
 }

--- a/chief/glpi-chief.js
+++ b/chief/glpi-chief.js
@@ -1,38 +1,110 @@
-document.addEventListener('DOMContentLoaded', function () {
-  if (typeof glpiChief === 'undefined') return;
-  if (parseInt(glpiChief.isManager, 10) !== 1) return;
-  var host = document.querySelector('.glpi-top-left');
-  if (!host) return;
-  var select = document.createElement('select');
-  select.className = 'chief-executors';
-  var optAll = document.createElement('option');
-  optAll.value = 'all';
-  optAll.textContent = 'Без фильтров';
-  select.appendChild(optAll);
-  if (Array.isArray(glpiChief.executors)) {
-    glpiChief.executors.forEach(function (ex) {
-      var opt = document.createElement('option');
-      opt.value = ex.id;
-      opt.textContent = ex.name;
-      select.appendChild(opt);
-    });
+// Chief page: default filter to chief, chief-only actions, UI updates
+(function () {
+  const lsKey = 'chief_executor_filter';
+  const cfg = window.GEXE_CHIEF || {};
+  const isChief = !!cfg.isChief;
+  const chiefGlpiId = parseInt(cfg.chiefGlpiId || 1, 10);
+  const nonce = cfg.nonce || '';
+
+  function $sel() {
+    return document.querySelector('.gexe-executor-select');
   }
-  if (glpiChief.viewAs) {
-    var val = String(glpiChief.viewAs);
-    Array.from(select.options).forEach(function (o) {
-      if (o.value === val) select.value = val;
-    });
+  function triggerChange(el) {
+    if (!el) return;
+    const ev = new Event('change', { bubbles: true });
+    el.dispatchEvent(ev);
   }
-  select.addEventListener('change', function () {
-    var val = select.value;
-    select.disabled = true;
-    var url = new URL(window.location.href);
-    url.searchParams.set('view_as', val);
-    window.location.href = url.toString();
+  function currentActingAs() {
+    const el = $sel();
+    const v = el && el.value ? parseInt(el.value, 10) : chiefGlpiId;
+    return Number.isFinite(v) && v > 0 ? v : chiefGlpiId;
+  }
+  function withPayload(extra) {
+    const base = { acting_as: currentActingAs(), _ajax_nonce: nonce };
+    return Object.assign(base, extra || {});
+  }
+
+  // 1) Default to chief filter on first load (no saved choice)
+  document.addEventListener('DOMContentLoaded', function () {
+    try {
+      const select = $sel();
+      if (!select) return;
+      const saved = localStorage.getItem(lsKey);
+      if (!saved && isChief) {
+        const opt = select.querySelector(`option[value="${chiefGlpiId}"]`);
+        if (opt) {
+          select.value = String(chiefGlpiId);
+          localStorage.setItem(lsKey, String(chiefGlpiId));
+          triggerChange(select);
+        }
+      }
+      select.addEventListener('change', () => {
+        localStorage.setItem(lsKey, String(select.value || ''));
+      });
+    } catch (e) {
+      console && console.warn && console.warn('chief init failed', e);
+    }
   });
-  host.appendChild(select);
-  var url2 = new URL(window.location.href);
-  if (url2.searchParams.has('view_as')) {
-    history.replaceState(null, '', location.pathname + location.hash);
-  }
-});
+
+  // 2) Delegate action buttons to chief endpoints
+  document.addEventListener('click', function (e) {
+    const btn = e.target.closest('[data-gexe-action]');
+    if (!btn || !isChief) return;
+    const act = btn.getAttribute('data-gexe-action'); // accept | update_status | assign | comment
+    const tid = parseInt(btn.getAttribute('data-ticket-id') || '0', 10);
+    if (!tid) return;
+
+    const ajaxAction = {
+      accept: 'gexe_chief_accept_sql',
+      update_status: 'gexe_chief_update_status_sql',
+      assign: 'gexe_chief_assign_sql',
+      comment: 'gexe_chief_comment_sql'
+    }[act];
+    if (!ajaxAction) return;
+
+    // Build payload
+    let data = withPayload({ ticket_id: tid });
+    if (act === 'update_status') {
+      data.new_status = parseInt(btn.getAttribute('data-new-status') || '2', 10);
+      data.add_accept_comment = parseInt(btn.getAttribute('data-accept-comment') || '0', 10);
+    }
+    if (act === 'assign') {
+      data.new_assignee = currentActingAs();
+    }
+    if (act === 'comment') {
+      const area = document.querySelector('.gexe-followup-input');
+      data.comment = area ? area.value || '' : '';
+    }
+
+    // Guard against repeat
+    if (btn.dataset.busy === '1') return;
+    btn.dataset.busy = '1';
+    btn.disabled = true;
+
+    (window.jQuery ? window.jQuery.post(ajaxurl, Object.assign({ action: ajaxAction }, data))
+                   : fetch(ajaxurl, { method: 'POST', headers: {'Content-Type':'application/x-www-form-urlencoded; charset=UTF-8'},
+                       body: new URLSearchParams(Object.assign({ action: ajaxAction }, data)) }).then(r=>r.json()))
+      .then(function (resp) {
+        if (!resp || !resp.ok) {
+          const detail = (resp && resp.detail) || 'Unknown error';
+          alert('Ошибка: ' + detail);
+          return;
+        }
+        // Success: reflect UI
+        if (act === 'accept' || data.add_accept_comment) {
+          btn.classList.add('is-accepted','gexe-accept-btn');
+          btn.setAttribute('disabled', 'disabled');
+          btn.innerText = 'Принято в работу';
+        }
+        document.dispatchEvent(new CustomEvent('gexe:chief:updated', { detail: { ticketId: tid, action: act } }));
+      })
+      .catch(function () {
+        alert('Сервер недоступен');
+      })
+      .finally(function () {
+        btn.dataset.busy = '';
+        btn.disabled = false;
+      });
+  });
+})();
+

--- a/chief/glpi-chief.php
+++ b/chief/glpi-chief.php
@@ -8,6 +8,31 @@ if (!defined('CHIEF_DEBUG')) {
 require_once __DIR__ . '/../glpi-db-setup.php';
 require_once __DIR__ . '/../glpi-icon-map.php';
 
+// --- Chief mode constants (do NOT touch core) ---
+if (!defined('CHIEF_WP_USER_ID')) {
+    define('CHIEF_WP_USER_ID', 1); // WP id начальника (vks_m5_local)
+}
+if (!defined('CHIEF_GLPI_USER_ID')) {
+    define('CHIEF_GLPI_USER_ID', 1); // GLPI id начальника (Куткин П.)
+}
+
+function chief_is_chief_user(): bool {
+    return (int) get_current_user_id() === (int) CHIEF_WP_USER_ID;
+}
+
+// Localize data for chief front-end (nonce, defaults)
+add_action('wp_enqueue_scripts', function () {
+    wp_localize_script('glpi-chief', 'GEXE_CHIEF', [
+        'isChief'     => chief_is_chief_user(),
+        'chiefWpId'   => (int) CHIEF_WP_USER_ID,
+        'chiefGlpiId' => (int) CHIEF_GLPI_USER_ID,
+        'nonce'       => wp_create_nonce('gexe_chief_nonce'),
+    ]);
+});
+
+// Подключаем эндпоинты ТОЛЬКО из подпапки chief
+require_once __DIR__ . '/glpi-chief-actions.php';
+
 if (!function_exists('chief_is_manager')) {
     function chief_is_manager(): bool {
         $u = wp_get_current_user();


### PR DESCRIPTION
## Summary
- localize chief defaults and nonce and register chief-only AJAX endpoints
- implement SQL-backed handlers for accept, status, assignment and comments
- update chief JS for default filtering and action payloads; add dark theme acceptance styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc2289aa08328b7024b0d9ef10499