### PR TITLE
fix: delegate new task submission to gexe-filter

### DIFF
--- a/assets/js/gexe-new-task.js
+++ b/assets/js/gexe-new-task.js
@@ -75,8 +75,10 @@
 
     modal.querySelector('.gnt-backdrop').addEventListener('click', close);
     modal.querySelector('.gnt-close').addEventListener('click', close);
-    modal.querySelector('.gnt-submit').addEventListener('click', submit);
+    // SQL canonical: submission is bound in gexe-filter.js (bindNewTaskForm)
+    // modal.querySelector('.gnt-submit').addEventListener('click', submit);
 
+    // Assignment toggle & validation are handled in gexe-filter.js to avoid double-binding
     const assignChk = modal.querySelector('#gnt-assign-me');
     const assigneeSel = modal.querySelector('#gnt-assignee');
     assignChk.addEventListener('change', function(){
@@ -309,8 +311,8 @@
     buildModal();
     modal.classList.add('open');
     document.body.classList.add('glpi-modal-open');
-    startDictLoad(false);
-    updatePaths();
+    // Delegate dictionaries loading to gexe-filter.js (SQL canonical path)
+    window.dispatchEvent(new CustomEvent('gexe:newtask:open'));
   }
 
   function close(){


### PR DESCRIPTION
## Summary
- delegate new task form submission to `gexe-filter.js` rather than direct binding
- notify `gexe-filter.js` to load dictionaries when opening the modal

## Testing
- `npx eslint assets/js/gexe-new-task.js` *(fails: 304 problems)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd265ee408328b5a2cc6d3d852172