### PR TITLE
Rename refreshed nonce field

### DIFF
--- a/assets/js/gexe-new-task.js
+++ b/assets/js/gexe-new-task.js
@@ -203,8 +203,8 @@
       body: params.toString()
     }).then(r=>r.json()).then(function(data){
       if (data && data.success && data.data && data.data.nonce){
-        gexeAjax.formNonce = data.data.nonce;
-        return gexeAjax.formNonce;
+        gexeAjax.nonce = data.data.nonce;
+        return gexeAjax.nonce;
       }
       throw new Error('nonce_refresh_failed');
     });


### PR DESCRIPTION
## Summary
- Assign refreshed nonce to `gexeAjax.nonce` so frontend uses the latest security token

## Testing
- `vendor/bin/phpcs --standard=WordPress --report=summary glpi-new-task.php` (fails: 1371 errors, 80 warnings)
- `vendor/bin/phpstan analyse --level 0 glpi-new-task.php` (fails: Found 93 errors)
- `npx eslint assets/js/gexe-new-task.js` (fails: 304 problems)
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68bfe44324c88328aec52ef4e516ff72