### PR TITLE
Add isolated new ticket module

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -324,4 +324,5 @@ require_once __DIR__ . '/glpi-solve.php';
 require_once __DIR__ . '/glpi-icon-map.php';
 require_once __DIR__ . '/glpi-new-task.php';
 require_once __DIR__ . '/glpi-settings.php';
+require_once __DIR__ . '/new-ticket/new-ticket.php';
 

--- a/new-ticket/assets/new-ticket.css
+++ b/new-ticket/assets/new-ticket.css
@@ -1,0 +1,29 @@
+/* Trigger button */
+.nt-open-modal{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;background:#2d6cdf;color:#fff;border:none;border-radius:10px;cursor:pointer}
+.nt-open-modal:hover{background:#2357b6}
+
+/* Modal shell */
+.nt-wrap{display:none}
+.nt-wrap.nt-wrap--open{display:block;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);z-index:9990}
+.nt-wrap .nt-modal{position:relative;background:#1f1f1f;color:#fff;padding:20px;margin:40px auto;max-width:560px;border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+.nt-wrap .nt-modal h3{margin:0 0 14px;font-size:18px}
+.nt-wrap .nt-close-modal{position:absolute;right:12px;top:12px;background:#333;border:none;color:#fff;border-radius:8px;cursor:pointer;padding:6px 10px}
+.nt-wrap .nt-close-modal:hover{background:#444}
+
+/* Inputs */
+.nt-wrap label{display:block;margin-bottom:10px}
+.nt-wrap input,.nt-wrap select,.nt-wrap textarea{width:100%;margin-top:6px;background:#111;border:1px solid #333;border-radius:8px;color:#fff;padding:8px}
+.nt-wrap textarea{min-height:100px;resize:vertical}
+.nt-inline{display:flex;gap:12px}
+.nt-inline > label{flex:1}
+
+/* States & errors */
+.nt-field--loading{opacity:.7}
+.nt-error{color:#ff6b6b;font-size:12px;margin-top:4px;white-space:pre-line;line-height:1.2}
+.nt-submit-error{color:#ff6b6b;margin-top:8px;white-space:pre-line;line-height:1.2}
+.nt-success{color:#7dd97d;margin-top:8px}
+
+/* Submit */
+.nt-submit{padding:10px 14px;background:#27a376;color:#fff;border:none;border-radius:10px;cursor:pointer}
+.nt-submit[disabled]{opacity:.6;cursor:not-allowed}
+.nt-submit:hover:not([disabled]){background:#1f865f}

--- a/new-ticket/assets/new-ticket.js
+++ b/new-ticket/assets/new-ticket.js
@@ -1,0 +1,191 @@
+(function(){
+  const ajax = window.ntAjax || {};
+  function $(sel, ctx){ return (ctx||document).querySelector(sel); }
+  function $all(sel, ctx){ return Array.from((ctx||document).querySelectorAll(sel)); }
+
+  function setError(el, msg){
+    if(!el) return;
+    el.textContent = msg || '';
+    el.hidden = !msg;
+  }
+
+  function setLoading(container, on){
+    if(!container) return;
+    container.classList.toggle('nt-field--loading', !!on);
+  }
+
+  function renderOptions(select, list, placeholder){
+    if(!select) return;
+    const cur = select.value;
+    select.innerHTML = '';
+    if(placeholder){
+      const opt0 = document.createElement('option');
+      opt0.value = '';
+      opt0.textContent = placeholder;
+      select.appendChild(opt0);
+    }
+    (list||[]).forEach(item=>{
+      const opt = document.createElement('option');
+      opt.value = String(item.id);
+      opt.textContent = item.completename || item.label || item.name || ('#'+item.id);
+      select.appendChild(opt);
+    });
+    // try keep current if exists
+    if(cur && $(`option[value="${CSS.escape(cur)}"]`, select)){
+      select.value = cur;
+    }
+  }
+
+  async function postFormData(data){
+    const fd = new FormData();
+    Object.keys(data).forEach(k=>fd.append(k, data[k]));
+    const r = await fetch(ajax.url, {method:'POST', credentials:'same-origin', body:fd});
+    return r.json();
+  }
+
+  async function fetchList(action){
+    try{
+      const res = await postFormData({action, nonce: ajax.nonce});
+      return res;
+    }catch(e){
+      return {ok:false, code:'network_error', message:'Network error'};
+    }
+  }
+
+  function toggleAssignee(form){
+    const selfCb = $('.nt-self', form);
+    const assSel = $('select[name="assignee_id"]', form);
+    const on = !!(selfCb && selfCb.checked);
+    if(assSel){
+      assSel.disabled = on;
+      if(on){ assSel.value = ''; }
+    }
+  }
+
+  // Open / close modal
+  document.addEventListener('click', function(e){
+    if (e.target.closest('.nt-open-modal')){
+      const wrap = $('.nt-wrap');
+      if(wrap){
+        wrap.classList.add('nt-wrap--open');
+        // kick off dict loads
+        loadDictionaries(wrap);
+      }
+    }
+    if (e.target.closest('.nt-close-modal')){
+      const wrap = $('.nt-wrap');
+      if(wrap){
+        wrap.classList.remove('nt-wrap--open');
+      }
+    }
+  });
+
+  async function loadDictionaries(scope){
+    const form = $('form.nt-form', scope);
+    if(!form) return;
+    const catWrap = $('[data-nt-field="category"]', form);
+    const locWrap = $('[data-nt-field="location"]', form);
+    const assWrap = $('[data-nt-field="assignee"]', form);
+    const catSel = $('select[name="category_id"]', form);
+    const locSel = $('select[name="location_id"]', form);
+    const assSel = $('select[name="assignee_id"]', form);
+    const catErr = $('[data-nt-error="category"]', form);
+    const locErr = $('[data-nt-error="location"]', form);
+    const assErr = $('[data-nt-error="assignee"]', form);
+
+    setLoading(catWrap, true); setError(catErr,'');
+    setLoading(locWrap, true); setError(locErr,'');
+    setLoading(assWrap, true); setError(assErr,'');
+
+    const [cats, locs, ass] = await Promise.all([
+      fetchList('nt_get_categories'),
+      fetchList('nt_get_locations'),
+      fetchList('nt_get_assignees')
+    ]);
+
+    // categories
+    if(cats && cats.ok){
+      renderOptions(catSel, cats.list, 'Select category…');
+    }else{
+      setError(catErr, (cats && cats.message) || 'Failed to load categories');
+    }
+    setLoading(catWrap,false);
+
+    // locations
+    if(locs && locs.ok){
+      renderOptions(locSel, locs.list, 'Select location…');
+    }else{
+      setError(locErr, (locs && locs.message) || 'Failed to load locations');
+    }
+    setLoading(locWrap,false);
+
+    // assignees
+    if(ass && ass.ok){
+      renderOptions(assSel, ass.list, 'Select assignee…');
+    }else{
+      setError(assErr, (ass && ass.message) || 'Failed to load assignees');
+    }
+    setLoading(assWrap,false);
+  }
+
+  // Form handlers
+  document.addEventListener('change', function(e){
+    const form = e.target && e.target.closest('form.nt-form');
+    if(!form) return;
+    if(e.target.matches('.nt-self')){
+      toggleAssignee(form);
+    }
+  });
+
+  const form = document.querySelector('.nt-wrap form.nt-form');
+  if(form){
+    form.addEventListener('submit', async function(ev){
+      ev.preventDefault();
+      const btn = $('.nt-submit', form);
+      const submitErr = $('.nt-submit-error', form);
+      const okMsg = $('.nt-submit-success', form);
+      setError(submitErr,''); if(okMsg) okMsg.textContent='';
+
+      // basic client validation
+      const title = $('input[name="title"]', form).value.trim();
+      const content = $('textarea[name="content"]', form).value.trim();
+      const category_id = $('select[name="category_id"]', form).value;
+      const location_id = $('select[name="location_id"]', form).value;
+      const self_assign = $('.nt-self', form).checked ? '1' : '';
+      const assignee_id = $('select[name="assignee_id"]', form).value;
+
+      if(title.length<3){ return setError(submitErr,'Введите тему (мин. 3 символа)'); }
+      if(content.length<3){ return setError(submitErr,'Введите описание (мин. 3 символа)'); }
+      if(!category_id){ return setError(submitErr,'Выберите категорию'); }
+      if(!location_id){ return setError(submitErr,'Выберите местоположение'); }
+      if(!self_assign && !assignee_id){ return setError(submitErr,'Выберите исполнителя или отметьте «Назначить меня»'); }
+
+      // send
+      btn && (btn.disabled = true);
+      try{
+        const res = await postFormData({
+          action:'nt_create_ticket',
+          nonce: ajax.nonce,
+          title, content, category_id, location_id, assignee_id, self_assign
+        });
+        if(res && res.ok){
+          const tid = res.ticket_id || res.data && res.data.ticket_id;
+          if(okMsg){ okMsg.textContent = tid ? ('Заявка #'+tid+' создана') : 'Заявка создана'; }
+          // reset and close
+          form.reset();
+          toggleAssignee(form);
+          setTimeout(()=>{ $('.nt-wrap')?.classList.remove('nt-wrap--open'); }, 800);
+        }else if(res && res.code === 'already_exists'){
+          if(okMsg){ okMsg.textContent = 'Такая заявка уже была создана недавно'+(res.ticket_id?(' (#'+res.ticket_id+')'):''); }
+          setTimeout(()=>{ $('.nt-wrap')?.classList.remove('nt-wrap--open'); }, 800);
+        }else{
+          setError(submitErr, (res && res.message) || 'Ошибка отправки заявки');
+        }
+      }catch(e){
+        setError(submitErr, 'Сетевая ошибка при отправке');
+      }finally{
+        btn && (btn.disabled = false);
+      }
+    });
+  }
+})();

--- a/new-ticket/inc/nt-auth.php
+++ b/new-ticket/inc/nt-auth.php
@@ -1,0 +1,21 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nt_get_current_glpi_uid() {
+    $u = wp_get_current_user();
+    if (!$u || !isset($u->ID) || !$u->ID) {
+        return 0;
+    }
+    return (int) get_user_meta($u->ID, 'glpi_user_id', true);
+}
+
+function nt_require_glpi_user() {
+    if (!is_user_logged_in()) {
+        nt_response_error('auth', 'Auth required');
+    }
+    $id = nt_get_current_glpi_uid();
+    if ($id <= 0) {
+        nt_response_error('no_glpi_id', 'У пользователя не задан GLPI ID');
+    }
+    return $id;
+}

--- a/new-ticket/inc/nt-db.php
+++ b/new-ticket/inc/nt-db.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nt_db() {
+    static $db = null;
+    if ($db === null) {
+        // Connect directly to GLPI database (isolated from WP DB)
+        // Adjust if your GLPI DB settings differ.
+        $glpi_user = 'wp_glpi';
+        $glpi_pass = 'xapetVD4OWZqw8f';
+        $glpi_name = 'glpi';
+        $glpi_host = '192.168.100.12';
+
+        require_once ABSPATH . 'wp-includes/wp-db.php';
+        $db = new wpdb($glpi_user, $glpi_pass, $glpi_name, $glpi_host);
+        $charset = defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4';
+        $db->set_charset($db->dbh, $charset);
+    }
+    return $db;
+}
+
+function nt_db_begin() {
+    nt_db()->query('START TRANSACTION');
+}
+
+function nt_db_commit() {
+    nt_db()->query('COMMIT');
+}
+
+function nt_db_rollback() {
+    nt_db()->query('ROLLBACK');
+}
+
+// Simple helper for escaping error messages into responses if needed
+function nt_db_last_error(){
+    $e = nt_db()->last_error;
+    return is_string($e) ? $e : '';
+}

--- a/new-ticket/inc/nt-response.php
+++ b/new-ticket/inc/nt-response.php
@@ -1,0 +1,10 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nt_response($data) {
+    wp_send_json($data);
+}
+
+function nt_response_error($code, $message = '', $extra = []) {
+    nt_response(array_merge(['ok' => false, 'code' => $code, 'message' => $message], $extra));
+}

--- a/new-ticket/inc/nt-sql.php
+++ b/new-ticket/inc/nt-sql.php
@@ -1,0 +1,85 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nt_sql_get_categories() {
+    $db = nt_db();
+    $sql = "SELECT id, name, completename FROM glpi_itilcategories WHERE is_helpdeskvisible=1 ORDER BY completename ASC LIMIT 2000";
+    $rows = $db->get_results($sql, ARRAY_A) ?: [];
+    return array_map(function ($r) {
+        return [
+            'id' => (int) $r['id'],
+            'name' => (string) $r['name'],
+            'completename' => (string) $r['completename'],
+        ];
+    }, $rows);
+}
+
+function nt_sql_get_locations() {
+    $db = nt_db();
+    $sql = "SELECT id, name, completename FROM glpi_locations ORDER BY completename ASC LIMIT 3000";
+    $rows = $db->get_results($sql, ARRAY_A) ?: [];
+    return array_map(function ($r) {
+        return [
+            'id' => (int) $r['id'],
+            'name' => (string) $r['name'],
+            'completename' => (string) $r['completename'],
+        ];
+    }, $rows);
+}
+
+function nt_sql_get_assignees() {
+    $db = nt_db();
+    $sql = "SELECT id, name, realname, firstname FROM glpi_users WHERE is_active=1 ORDER BY realname, firstname LIMIT 2000";
+    $rows = $db->get_results($sql, ARRAY_A) ?: [];
+    return array_map(function ($r) {
+        $label = trim(($r['realname'] ?? '') . ' ' . ($r['firstname'] ?? ''));
+        if ($label === '') {
+            $label = $r['name'] ?? '';
+        }
+        return [
+            'id' => (int) $r['id'],
+            'label' => $label,
+        ];
+    }, $rows);
+}
+
+function nt_sql_find_duplicate($uid, $title, $content) {
+    $db = nt_db();
+    $sql = "SELECT id FROM glpi_tickets WHERE users_id_recipient = %d AND name = %s AND content = %s AND TIMESTAMPDIFF(SECOND, date, NOW()) <= 3 LIMIT 1";
+    $id = $db->get_var($db->prepare($sql, $uid, $title, $content));
+    return $id ? (int) $id : 0;
+}
+
+function nt_sql_create_ticket($title, $content, $cat_id, $loc_id, $uid, $assignee_id) {
+    $db = nt_db();
+    nt_db_begin();
+    $dup = nt_sql_find_duplicate($uid, $title, $content);
+    if ($dup) {
+        nt_db_rollback();
+        return ['ok' => true, 'code' => 'already_exists', 'ticket_id' => $dup];
+    }
+    $now = current_time('mysql');
+    $sql = "INSERT INTO glpi_tickets (name, content, status, itilcategories_id, locations_id, users_id_recipient, date, date_mod) VALUES (%s,%s,1,%d,%d,%d,%s,%s)";
+    $r = $db->query($db->prepare($sql, $title, $content, $cat_id, $loc_id, $uid, $now, $now));
+    if ($r === false) {
+        $err = $db->last_error;
+        nt_db_rollback();
+        return ['ok' => false, 'code' => 'sql_error', 'message' => $err];
+    }
+    $tid = (int) $db->insert_id;
+    $q1 = "INSERT INTO glpi_tickets_users (tickets_id, users_id, type) VALUES (%d,%d,1)";
+    if ($db->query($db->prepare($q1, $tid, $uid)) === false) {
+        $err = $db->last_error;
+        nt_db_rollback();
+        return ['ok' => false, 'code' => 'sql_error', 'message' => $err];
+    }
+    $assign = $assignee_id > 0 ? $assignee_id : $uid;
+    $q2 = "INSERT INTO glpi_tickets_users (tickets_id, users_id, type) VALUES (%d,%d,2)";
+    if ($db->query($db->prepare($q2, $tid, $assign)) === false) {
+        $err = $db->last_error;
+        nt_db_rollback();
+        return ['ok' => false, 'code' => 'sql_error', 'message' => $err];
+    }
+    nt_db_commit();
+    return ['ok' => true, 'ticket_id' => $tid];
+}

--- a/new-ticket/inc/nt-validate.php
+++ b/new-ticket/inc/nt-validate.php
@@ -1,0 +1,36 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nt_validate_ticket_input($src) {
+    $title   = isset($src['title']) ? trim((string)$src['title']) : '';
+    $content = isset($src['content']) ? trim((string)$src['content']) : '';
+    $cat_id  = isset($src['category_id']) ? (int)$src['category_id'] : 0;
+    $loc_id  = isset($src['location_id']) ? (int)$src['location_id'] : 0;
+    $ass_id  = isset($src['assignee_id']) ? (int)$src['assignee_id'] : 0;
+    $self    = !empty($src['self_assign']);
+
+    if (mb_strlen($title) < 3 || mb_strlen($title) > 255) {
+        return new WP_Error('validation', 'Invalid title');
+    }
+    if (mb_strlen($content) < 3 || mb_strlen($content) > 65535) {
+        return new WP_Error('validation', 'Invalid content');
+    }
+    if ($cat_id <= 0) {
+        return new WP_Error('validation', 'Invalid category');
+    }
+    if ($loc_id <= 0) {
+        return new WP_Error('validation', 'Invalid location');
+    }
+    if (!$self && $ass_id <= 0) {
+        return new WP_Error('validation', 'Invalid assignee');
+    }
+
+    return [
+        'title'       => $title,
+        'content'     => $content,
+        'category_id' => $cat_id,
+        'location_id' => $loc_id,
+        'assignee_id' => $ass_id,
+        'self_assign' => $self,
+    ];
+}

--- a/new-ticket/new-ticket.php
+++ b/new-ticket/new-ticket.php
@@ -1,0 +1,80 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/inc/nt-db.php';
+require_once __DIR__ . '/inc/nt-auth.php';
+require_once __DIR__ . '/inc/nt-sql.php';
+require_once __DIR__ . '/inc/nt-validate.php';
+require_once __DIR__ . '/inc/nt-response.php';
+
+function nt_bootstrap() {
+    add_shortcode('glpi_new_ticket2', 'nt_render_shortcode');
+}
+add_action('init', 'nt_bootstrap');
+
+function nt_register_assets() {
+    wp_register_script('nt-new-ticket', plugin_dir_url(__FILE__) . 'assets/new-ticket.js', [], '1.0.0', true);
+    wp_localize_script('nt-new-ticket', 'ntAjax', [
+        'url'   => admin_url('admin-ajax.php'),
+        'nonce' => wp_create_nonce('new_ticket_actions'),
+    ]);
+    wp_register_style('nt-new-ticket', plugin_dir_url(__FILE__) . 'assets/new-ticket.css', [], '1.0.0');
+}
+add_action('wp_enqueue_scripts', 'nt_register_assets');
+
+function nt_render_shortcode() {
+    wp_enqueue_style('nt-new-ticket');
+    wp_enqueue_script('nt-new-ticket');
+    ob_start();
+    include __DIR__ . '/partials/form.php';
+    return ob_get_clean();
+}
+
+function nt_ajax_nopriv() {
+    nt_response_error('auth', 'Auth required');
+}
+add_action('wp_ajax_nopriv_nt_get_categories', 'nt_ajax_nopriv');
+add_action('wp_ajax_nopriv_nt_get_locations', 'nt_ajax_nopriv');
+add_action('wp_ajax_nopriv_nt_get_assignees', 'nt_ajax_nopriv');
+add_action('wp_ajax_nopriv_nt_create_ticket', 'nt_ajax_nopriv');
+
+function nt_verify_ajax() {
+    if (!check_ajax_referer('new_ticket_actions', 'nonce', false)) {
+        nt_response_error('csrf', 'Invalid nonce');
+    }
+    nt_require_glpi_user();
+}
+
+add_action('wp_ajax_nt_get_categories', 'nt_ajax_get_categories');
+function nt_ajax_get_categories() {
+    nt_verify_ajax();
+    $list = nt_sql_get_categories();
+    nt_response(['ok' => true, 'list' => $list]);
+}
+
+add_action('wp_ajax_nt_get_locations', 'nt_ajax_get_locations');
+function nt_ajax_get_locations() {
+    nt_verify_ajax();
+    $list = nt_sql_get_locations();
+    nt_response(['ok' => true, 'list' => $list]);
+}
+
+add_action('wp_ajax_nt_get_assignees', 'nt_ajax_get_assignees');
+function nt_ajax_get_assignees() {
+    nt_verify_ajax();
+    $list = nt_sql_get_assignees();
+    nt_response(['ok' => true, 'list' => $list]);
+}
+
+add_action('wp_ajax_nt_create_ticket', 'nt_ajax_create_ticket');
+function nt_ajax_create_ticket() {
+    nt_verify_ajax();
+    $input = nt_validate_ticket_input($_POST);
+    if (is_wp_error($input)) {
+        nt_response_error('validation', $input->get_error_message());
+    }
+    $uid = nt_get_current_glpi_uid();
+    $assignee = $input['self_assign'] ? $uid : (int) $input['assignee_id'];
+    $res = nt_sql_create_ticket($input['title'], $input['content'], $input['category_id'], $input['location_id'], $uid, $assignee);
+    nt_response($res);
+}

--- a/new-ticket/partials/form.php
+++ b/new-ticket/partials/form.php
@@ -1,0 +1,33 @@
+<button type="button" class="nt-open-modal">Новая заявка</button>
+<div class="nt-wrap" aria-hidden="true" role="dialog" aria-modal="true">
+  <div class="nt-modal">
+    <button type="button" class="nt-close-modal" aria-label="Закрыть">×</button>
+    <h3>Новая заявка</h3>
+    <form class="nt-form" novalidate>
+      <label>Тема
+        <input type="text" name="title" required minlength="3" maxlength="255" />
+      </label>
+      <label>Описание
+        <textarea name="content" required minlength="3" maxlength="65535"></textarea>
+      </label>
+      <div class="nt-inline">
+        <label data-nt-field="category">Категория
+          <select name="category_id"></select>
+          <div class="nt-error" data-nt-error="category" hidden></div>
+        </label>
+        <label data-nt-field="location">Местоположение
+          <select name="location_id"></select>
+          <div class="nt-error" data-nt-error="location" hidden></div>
+        </label>
+      </div>
+      <label><input type="checkbox" name="self_assign" class="nt-self" /> Назначить меня</label>
+      <label data-nt-field="assignee">Исполнитель
+        <select name="assignee_id"></select>
+        <div class="nt-error" data-nt-error="assignee" hidden></div>
+      </label>
+      <button type="submit" class="nt-submit">Создать</button>
+      <div class="nt-submit-error"></div>
+      <div class="nt-success nt-submit-success"></div>
+    </form>
+  </div>
+</div>

--- a/new-ticket/readme.md
+++ b/new-ticket/readme.md
@@ -1,0 +1,15 @@
+# New ticket module
+
+This module is isolated under `/new-ticket`.
+
+## Usage
+
+1. In the main plugin file add:
+
+```php
+require_once __DIR__ . '/new-ticket/new-ticket.php';
+```
+
+2. Use shortcode `[glpi_new_ticket2]` to render the modal form.
+
+The module handles its own assets and AJAX requests.


### PR DESCRIPTION
## Summary
- include modular new-ticket system in main plugin
- add shortcode-based modal form with assets and AJAX handlers for ticket creation
- provide database helpers for categories, locations, assignees and safe ticket insertion

## Testing
- `php -l gexe-copy.php`
- `find new-ticket -name '*.php' -exec php -l {} \;`
- `npm test` *(fails: Error: no test specified)*
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68c01cae190c8328ac409e93c058153b