### PR TITLE
Add GLPI API ticket creation module

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -324,4 +324,6 @@ require_once __DIR__ . '/glpi-solve.php';
 require_once __DIR__ . '/glpi-icon-map.php';
 require_once __DIR__ . '/glpi-new-task.php';
 require_once __DIR__ . '/glpi-settings.php';
+require_once __DIR__ . '/new-ticket/new-ticket.php';
+require_once __DIR__ . '/new-ticket-api/new-ticket-api.php';
 

--- a/new-ticket-api/assets/new-ticket-api.css
+++ b/new-ticket-api/assets/new-ticket-api.css
@@ -1,0 +1,29 @@
+/* Trigger button */
+.nta-open-modal{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;background:#2d6cdf;color:#fff;border:none;border-radius:10px;cursor:pointer}
+.nta-open-modal:hover{background:#2357b6}
+
+/* Modal shell */
+.nta-wrap{display:none}
+.nta-wrap.nta-wrap--open{display:block;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);z-index:9990}
+.nta-wrap .nta-modal{position:relative;background:#1f1f1f;color:#fff;padding:20px;margin:40px auto;max-width:560px;border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+.nta-wrap .nta-modal h3{margin:0 0 14px;font-size:18px}
+.nta-wrap .nta-close-modal{position:absolute;right:12px;top:12px;background:#333;border:none;color:#fff;border-radius:8px;cursor:pointer;padding:6px 10px}
+.nta-wrap .nta-close-modal:hover{background:#444}
+
+/* Inputs */
+.nta-wrap label{display:block;margin-bottom:10px}
+.nta-wrap input,.nta-wrap select,.nta-wrap textarea{width:100%;margin-top:6px;background:#111;border:1px solid #333;border-radius:8px;color:#fff;padding:8px}
+.nta-wrap textarea{min-height:100px;resize:vertical}
+.nta-inline{display:flex;gap:12px}
+.nta-inline > label{flex:1}
+
+/* States & errors */
+.nta-field--loading{opacity:.7}
+.nta-error{color:#ff6b6b;font-size:12px;margin-top:4px;white-space:pre-line;line-height:1.2}
+.nta-submit-error{color:#ff6b6b;margin-top:8px;white-space:pre-line;line-height:1.2}
+.nta-success{color:#7dd97d;margin-top:8px}
+
+/* Submit */
+.nta-submit{padding:10px 14px;background:#27a376;color:#fff;border:none;border-radius:10px;cursor:pointer}
+.nta-submit[disabled]{opacity:.6;cursor:not-allowed}
+.nta-submit:hover:not([disabled]){background:#1f865f}

--- a/new-ticket-api/assets/new-ticket-api.js
+++ b/new-ticket-api/assets/new-ticket-api.js
@@ -1,0 +1,140 @@
+(function(){
+  const ajax = window.ntaAjax || {};
+  function $(sel, ctx){ return (ctx||document).querySelector(sel); }
+
+  function setError(el, msg){ if(!el) return; el.textContent = msg||''; el.hidden = !msg; }
+  function setLoading(el, on){ if(!el) return; el.classList.toggle('nta-field--loading', !!on); }
+
+  function renderOptions(select, list, placeholder){
+    if(!select) return;
+    const cur = select.value;
+    select.innerHTML = '';
+    if(placeholder){
+      const o = document.createElement('option'); o.value=''; o.textContent=placeholder; select.appendChild(o);
+    }
+    (list||[]).forEach(item=>{
+      const opt = document.createElement('option');
+      opt.value = String(item.id);
+      opt.textContent = item.completename || item.label || item.name || ('#'+item.id);
+      select.appendChild(opt);
+    });
+    if(cur && select.querySelector(`option[value="${CSS.escape(cur)}"]`)){ select.value = cur; }
+  }
+
+  async function postForm(data){
+    const fd = new FormData();
+    Object.keys(data).forEach(k=>fd.append(k, data[k]));
+    const r = await fetch(ajax.url, {method:'POST', credentials:'same-origin', body:fd});
+    return r.json();
+  }
+
+  async function fetchList(action){
+    try{ return await postForm({action, nonce: ajax.nonce}); }
+    catch(e){ return {ok:false, code:'network_error', message:'Network error'}; }
+  }
+
+  function toggleAssignee(form){
+    const selfCb = form.querySelector('.nta-self');
+    const assSel = form.querySelector('select[name="assignee_id"]');
+    const on = !!(selfCb && selfCb.checked);
+    if(assSel){ assSel.disabled = on; if(on){ assSel.value=''; } }
+  }
+
+  document.addEventListener('click', function(e){
+    if(e.target.closest('.nta-open-modal')){
+      const wrap = $('.nta-wrap'); if(!wrap) return;
+      wrap.classList.add('nta-wrap--open');
+      loadDicts(wrap);
+    }
+    if(e.target.closest('.nta-close-modal')){
+      $('.nta-wrap')?.classList.remove('nta-wrap--open');
+    }
+  });
+
+  async function loadDicts(scope){
+    const form = scope.querySelector('form.nta-form'); if(!form) return;
+    const catWrap = form.querySelector('[data-nta-field="category"]');
+    const locWrap = form.querySelector('[data-nta-field="location"]');
+    const assWrap = form.querySelector('[data-nta-field="assignee"]');
+    const catSel = form.querySelector('select[name="category_id"]');
+    const locSel = form.querySelector('select[name="location_id"]');
+    const assSel = form.querySelector('select[name="assignee_id"]');
+    const catErr = form.querySelector('[data-nta-error="category"]');
+    const locErr = form.querySelector('[data-nta-error="location"]');
+    const assErr = form.querySelector('[data-nta-error="assignee"]');
+
+    setLoading(catWrap,true); setLoading(locWrap,true); setLoading(assWrap,true);
+    setError(catErr,''); setError(locErr,''); setError(assErr,'');
+
+    const [cats, locs, ass] = await Promise.all([
+      fetchList('nta_get_categories'),
+      fetchList('nta_get_locations'),
+      fetchList('nta_get_assignees')
+    ]);
+
+    if(cats && cats.ok){ renderOptions(catSel, cats.list, 'Select category…'); }
+    else { setError(catErr, (cats && cats.message) || 'Failed to load categories'); }
+    setLoading(catWrap,false);
+
+    if(locs && locs.ok){ renderOptions(locSel, locs.list, 'Select location…'); }
+    else { setError(locErr, (locs && locs.message) || 'Failed to load locations'); }
+    setLoading(locWrap,false);
+
+    if(ass && ass.ok){ renderOptions(assSel, ass.list, 'Select assignee…'); }
+    else { setError(assErr, (ass && ass.message) || 'Failed to load assignees'); }
+    setLoading(assWrap,false);
+  }
+
+  document.addEventListener('change', function(e){
+    const form = e.target && e.target.closest('form.nta-form'); if(!form) return;
+    if(e.target.matches('.nta-self')) toggleAssignee(form);
+  });
+
+  const form = document.querySelector('.nta-wrap form.nta-form');
+  if(form){
+    form.addEventListener('submit', async function(ev){
+      ev.preventDefault();
+      const btn = form.querySelector('.nta-submit');
+      const err = form.querySelector('.nta-submit-error');
+      const ok = form.querySelector('.nta-submit-success');
+      setError(err,''); if(ok) ok.textContent='';
+
+      const title = form.querySelector('input[name="title"]').value.trim();
+      const content = form.querySelector('textarea[name="content"]').value.trim();
+      const category_id = form.querySelector('select[name="category_id"]').value;
+      const location_id = form.querySelector('select[name="location_id"]').value;
+      const self_assign = form.querySelector('.nta-self').checked ? '1' : '';
+      const assignee_id = form.querySelector('select[name="assignee_id"]').value;
+
+      if(title.length<3) return setError(err,'Введите тему (мин. 3 символа)');
+      if(content.length<3) return setError(err,'Введите описание (мин. 3 символа)');
+      if(!category_id) return setError(err,'Выберите категорию');
+      if(!location_id) return setError(err,'Выберите местоположение');
+      if(!self_assign && !assignee_id) return setError(err,'Выберите исполнителя или отметьте «Назначить меня»');
+
+      btn && (btn.disabled = true);
+      try{
+        const res = await postForm({
+          action: 'nta_create_ticket_api',
+          nonce: ajax.nonce,
+          title, content, category_id, location_id, assignee_id, self_assign
+        });
+        if(res && res.ok){
+          const tid = res.ticket_id || (res.data && res.data.ticket_id);
+          if(ok){ ok.textContent = tid ? ('Заявка #'+tid+' создана по API') : 'Заявка создана по API'; }
+          form.reset(); toggleAssignee(form);
+          setTimeout(()=>{ document.querySelector('.nta-wrap')?.classList.remove('nta-wrap--open'); }, 800);
+        }else if(res && res.code === 'already_exists'){
+          if(ok){ ok.textContent = 'Такая заявка уже создана недавно'+(res.ticket_id?(' (#'+res.ticket_id+')'):''); }
+          setTimeout(()=>{ document.querySelector('.nta-wrap')?.classList.remove('nta-wrap--open'); }, 800);
+        }else{
+          setError(err, (res && res.message) || 'Ошибка отправки по API');
+        }
+      }catch(e){
+        setError(err, 'Сетевая ошибка при отправке');
+      }finally{
+        btn && (btn.disabled = false);
+      }
+    });
+  }
+})();

--- a/new-ticket-api/inc/nta-api.php
+++ b/new-ticket-api/inc/nta-api.php
@@ -1,0 +1,103 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+// Adjust to your GLPI REST API endpoint and App-Token
+define('NTA_GLPI_API_URL', 'http://192.168.100.12/glpi/apirest.php');
+define('NTA_GLPI_APP_TOKEN', 'nqubXrD6j55bgLRuD1mrrtz5D69cXz94HHPvgmac');
+
+function nta_api_headers($user_token, $session_token = '') {
+    $h = [
+        'App-Token'    => NTA_GLPI_APP_TOKEN,
+        'Content-Type' => 'application/json',
+        'Accept'       => 'application/json',
+        'Authorization'=> 'user_token ' . $user_token,
+    ];
+    if ($session_token) $h['Session-Token'] = $session_token;
+    return $h;
+}
+
+function nta_api_request($method, $path, $headers, $body = null) {
+    $url = rtrim(NTA_GLPI_API_URL,'/') . '/' . ltrim($path,'/');
+    $args = [
+        'method'  => $method,
+        'headers' => $headers,
+        'timeout' => 15,
+    ];
+    if ($body !== null) $args['body'] = is_string($body) ? $body : wp_json_encode($body);
+    $res = wp_remote_request($url, $args);
+    if (is_wp_error($res)) {
+        return ['ok'=>false, 'code'=>'network_error', 'message'=>$res->get_error_message()];
+    }
+    $code = (int) wp_remote_retrieve_response_code($res);
+    $raw  = wp_remote_retrieve_body($res);
+    $json = json_decode($raw, true);
+    if ($code >= 200 && $code < 300) {
+        return ['ok'=>true, 'data'=>$json];
+    }
+    $msg = $json['message'] ?? ('HTTP '.$code);
+    return ['ok'=>false, 'code'=>'api_error', 'message'=>$msg, 'http'=>$code, 'raw'=>$raw];
+}
+
+function nta_api_open_session($user_token) {
+    $headers = nta_api_headers($user_token);
+    $r = nta_api_request('POST', 'initSession', $headers);
+    if (!$r['ok']) return $r;
+    $sess = $r['data']['session_token'] ?? '';
+    if (!$sess) return ['ok'=>false,'code'=>'api_error','message'=>'No session token'];
+    return ['ok'=>true,'session'=>$sess];
+}
+
+function nta_api_kill_session($user_token, $session_token) {
+    $headers = nta_api_headers($user_token, $session_token);
+    return nta_api_request('DELETE', 'killSession', $headers);
+}
+
+function nta_api_create_ticket($user_token, $input, $requester_glpi_id, $assignee_glpi_id) {
+    // 1) open session
+    $s = nta_api_open_session($user_token);
+    if (!$s['ok']) return $s;
+    $sess = $s['session'];
+    $headers = nta_api_headers($user_token, $sess);
+
+    try {
+        // 2) create ticket
+        $payload = [
+            'input' => [
+                'name'              => $input['title'],
+                'content'           => $input['content'],
+                'status'            => 1,
+                'itilcategories_id' => (int)$input['category_id'],
+                'locations_id'      => (int)$input['location_id'],
+            ]
+        ];
+        $r1 = nta_api_request('POST', 'Ticket', $headers, $payload);
+        if (!$r1['ok']) return $r1;
+        $tid = (int)($r1['data']['id'] ?? 0);
+        if ($tid <= 0) return ['ok'=>false,'code'=>'api_error','message'=>'Ticket ID not returned'];
+
+        // 3) add requester (type=1)
+        $r2 = nta_api_request('POST', 'Ticket_User', $headers, [
+            'input' => [
+                'tickets_id' => $tid,
+                'users_id'   => (int)$requester_glpi_id,
+                'type'       => 1
+            ]
+        ]);
+        if (!$r2['ok']) return $r2;
+
+        // 4) add assignee (type=2)
+        $r3 = nta_api_request('POST', 'Ticket_User', $headers, [
+            'input' => [
+                'tickets_id' => $tid,
+                'users_id'   => (int)$assignee_glpi_id,
+                'type'       => 2
+            ]
+        ]);
+        if (!$r3['ok']) return $r3;
+
+        return ['ok'=>true, 'ticket_id'=>$tid];
+    } finally {
+        // 5) close session (best-effort)
+        nta_api_kill_session($user_token, $sess);
+    }
+}

--- a/new-ticket-api/inc/nta-auth.php
+++ b/new-ticket-api/inc/nta-auth.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nta_get_current_glpi_uid() {
+    $u = wp_get_current_user();
+    if (!$u || empty($u->ID)) return 0;
+    return (int) get_user_meta($u->ID, 'glpi_user_id', true);
+}
+
+function nta_get_current_glpi_token() {
+    $u = wp_get_current_user();
+    if (!$u || empty($u->ID)) return '';
+    $tok = (string) get_user_meta($u->ID, 'glpi_user_token', true);
+    return trim($tok);
+}
+
+function nta_require_glpi_user_and_token() {
+    if (!is_user_logged_in()) {
+        nta_response_error('auth', 'Auth required');
+    }
+    $uid = nta_get_current_glpi_uid();
+    if ($uid <= 0) {
+        nta_response_error('no_glpi_id', 'У пользователя не задан GLPI ID');
+    }
+    $tok = nta_get_current_glpi_token();
+    if ($tok === '') {
+        nta_response_error('no_glpi_token', 'У пользователя не задан GLPI user token');
+    }
+    return [$uid, $tok];
+}

--- a/new-ticket-api/inc/nta-db.php
+++ b/new-ticket-api/inc/nta-db.php
@@ -1,0 +1,23 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nta_db() {
+    static $db = null;
+    if ($db === null) {
+        // GLPI DB connection for fast dictionaries and anti-duplicate
+        $glpi_user = 'wp_glpi';
+        $glpi_pass = 'xapetVD4OWZqw8f';
+        $glpi_name = 'glpi';
+        $glpi_host = '192.168.100.12';
+        require_once ABSPATH . 'wp-includes/wp-db.php';
+        $db = new wpdb($glpi_user, $glpi_pass, $glpi_name, $glpi_host);
+        $charset = defined('DB_CHARSET') ? DB_CHARSET : 'utf8mb4';
+        $db->set_charset($db->dbh, $charset);
+    }
+    return $db;
+}
+
+function nta_db_last_error(){
+    $e = nta_db()->last_error;
+    return is_string($e) ? $e : '';
+}

--- a/new-ticket-api/inc/nta-response.php
+++ b/new-ticket-api/inc/nta-response.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nta_response($data){ wp_send_json($data); }
+
+function nta_response_error($code, $message = '', $extra = []) {
+    nta_response(array_merge(['ok'=>false,'code'=>$code,'message'=>$message], $extra));
+}
+
+function nta_check_nonce_and_auth() {
+    if (!check_ajax_referer('new_ticket_api_actions', 'nonce', false)) { nta_response_error('csrf','Invalid nonce'); }
+}

--- a/new-ticket-api/inc/nta-sql.php
+++ b/new-ticket-api/inc/nta-sql.php
@@ -1,0 +1,38 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nta_sql_get_categories(){
+    $db = nta_db();
+    $sql = "SELECT id, name, completename FROM glpi_itilcategories WHERE is_helpdeskvisible=1 ORDER BY completename ASC LIMIT 2000";
+    $rows = $db->get_results($sql, ARRAY_A) ?: [];
+    return array_map(function($r){
+        return ['id'=>(int)$r['id'],'name'=>(string)$r['name'],'completename'=>(string)$r['completename']];
+    }, $rows);
+}
+
+function nta_sql_get_locations(){
+    $db = nta_db();
+    $sql = "SELECT id, name, completename FROM glpi_locations ORDER BY completename ASC LIMIT 3000";
+    $rows = $db->get_results($sql, ARRAY_A) ?: [];
+    return array_map(function($r){
+        return ['id'=>(int)$r['id'],'name'=>(string)$r['name'],'completename'=>(string)$r['completename']];
+    }, $rows);
+}
+
+function nta_sql_get_assignees(){
+    $db = nta_db();
+    $sql = "SELECT id, name, realname, firstname FROM glpi_users WHERE is_active=1 ORDER BY realname, firstname LIMIT 2000";
+    $rows = $db->get_results($sql, ARRAY_A) ?: [];
+    return array_map(function($r){
+        $label = trim(($r['realname'] ?? '').' '.($r['firstname'] ?? ''));
+        if($label===''){ $label = $r['name'] ?? ''; }
+        return ['id'=>(int)$r['id'],'label'=>$label];
+    }, $rows);
+}
+
+function nta_sql_find_duplicate($uid, $title, $content){
+    $db = nta_db();
+    $sql = "SELECT id FROM glpi_tickets WHERE users_id_recipient=%d AND name=%s AND content=%s AND TIMESTAMPDIFF(SECOND,date,NOW())<=3 LIMIT 1";
+    $id = $db->get_var($db->prepare($sql, $uid, $title, $content));
+    return $id ? (int)$id : 0;
+}

--- a/new-ticket-api/inc/nta-validate.php
+++ b/new-ticket-api/inc/nta-validate.php
@@ -1,0 +1,26 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+function nta_validate_ticket_input($src) {
+    $title   = isset($src['title']) ? trim((string)$src['title']) : '';
+    $content = isset($src['content']) ? trim((string)$src['content']) : '';
+    $cat_id  = isset($src['category_id']) ? (int)$src['category_id'] : 0;
+    $loc_id  = isset($src['location_id']) ? (int)$src['location_id'] : 0;
+    $ass_id  = isset($src['assignee_id']) ? (int)$src['assignee_id'] : 0;
+    $self    = !empty($src['self_assign']);
+
+    if (mb_strlen($title) < 3 || mb_strlen($title) > 255) return new WP_Error('validation','Invalid title');
+    if (mb_strlen($content) < 3 || mb_strlen($content) > 65535) return new WP_Error('validation','Invalid content');
+    if ($cat_id <= 0) return new WP_Error('validation','Invalid category');
+    if ($loc_id <= 0) return new WP_Error('validation','Invalid location');
+    if (!$self && $ass_id <= 0) return new WP_Error('validation','Invalid assignee');
+
+    return [
+        'title'       => $title,
+        'content'     => $content,
+        'category_id' => $cat_id,
+        'location_id' => $loc_id,
+        'assignee_id' => $ass_id,
+        'self_assign' => $self,
+    ];
+}

--- a/new-ticket-api/new-ticket-api.php
+++ b/new-ticket-api/new-ticket-api.php
@@ -1,0 +1,80 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/inc/nta-response.php';
+require_once __DIR__ . '/inc/nta-auth.php';
+require_once __DIR__ . '/inc/nta-db.php';
+require_once __DIR__ . '/inc/nta-sql.php';
+require_once __DIR__ . '/inc/nta-validate.php';
+require_once __DIR__ . '/inc/nta-api.php';
+
+function nta_bootstrap_api(){
+    add_shortcode('glpi_new_ticket_api', 'nta_render_shortcode_api');
+}
+add_action('init', 'nta_bootstrap_api');
+
+function nta_register_assets_api(){
+    wp_register_script('nta-new-ticket', plugin_dir_url(__FILE__) . 'assets/new-ticket-api.js', [], '1.0.0', true);
+    wp_localize_script('nta-new-ticket', 'ntaAjax', [
+        'url'   => admin_url('admin-ajax.php'),
+        'nonce' => wp_create_nonce('new_ticket_api_actions'),
+    ]);
+    wp_register_style('nta-new-ticket', plugin_dir_url(__FILE__) . 'assets/new-ticket-api.css', [], '1.0.0');
+}
+add_action('wp_enqueue_scripts', 'nta_register_assets_api');
+
+function nta_render_shortcode_api(){
+    wp_enqueue_style('nta-new-ticket');
+    wp_enqueue_script('nta-new-ticket');
+    ob_start();
+    include __DIR__ . '/partials/form.php';
+    return ob_get_clean();
+}
+
+// nopriv -> auth required
+function nta_ajax_nopriv_api(){ nta_response_error('auth','Auth required'); }
+add_action('wp_ajax_nopriv_nta_get_categories', 'nta_ajax_nopriv_api');
+add_action('wp_ajax_nopriv_nta_get_locations',  'nta_ajax_nopriv_api');
+add_action('wp_ajax_nopriv_nta_get_assignees',  'nta_ajax_nopriv_api');
+add_action('wp_ajax_nopriv_nta_create_ticket_api', 'nta_ajax_nopriv_api');
+
+// dictionaries
+add_action('wp_ajax_nta_get_categories', function(){
+    nta_check_nonce_and_auth();
+    $list = nta_sql_get_categories();
+    nta_response(['ok'=>true,'list'=>$list]);
+});
+add_action('wp_ajax_nta_get_locations', function(){
+    nta_check_nonce_and_auth();
+    $list = nta_sql_get_locations();
+    nta_response(['ok'=>true,'list'=>$list]);
+});
+add_action('wp_ajax_nta_get_assignees', function(){
+    nta_check_nonce_and_auth();
+    $list = nta_sql_get_assignees();
+    nta_response(['ok'=>true,'list'=>$list]);
+});
+
+// create ticket via API
+add_action('wp_ajax_nta_create_ticket_api', function(){
+    nta_check_nonce_and_auth();
+    $validated = nta_validate_ticket_input($_POST);
+    if (is_wp_error($validated)) {
+        nta_response_error('validation', $validated->get_error_message());
+    }
+    list($uid, $token) = nta_require_glpi_user_and_token();
+
+    // anti-duplicate (SQL)
+    $dup = nta_sql_find_duplicate($uid, $validated['title'], $validated['content']);
+    if ($dup) {
+        nta_response(['ok'=>true, 'code'=>'already_exists', 'ticket_id'=>$dup]);
+    }
+
+    $assignee = $validated['self_assign'] ? $uid : (int)$validated['assignee_id'];
+    $res = nta_api_create_ticket($token, $validated, $uid, $assignee);
+    if(!$res['ok']){
+        $msg = $res['message'] ?? 'API error';
+        nta_response_error($res['code'] ?? 'api_error', $msg);
+    }
+    nta_response(['ok'=>true, 'ticket_id'=>$res['ticket_id']]);
+});

--- a/new-ticket-api/partials/form.php
+++ b/new-ticket-api/partials/form.php
@@ -1,0 +1,33 @@
+<button type="button" class="nta-open-modal">Новая заявка (API)</button>
+<div class="nta-wrap" aria-hidden="true" role="dialog" aria-modal="true">
+  <div class="nta-modal">
+    <button type="button" class="nta-close-modal" aria-label="Закрыть">×</button>
+    <h3>Новая заявка (через API)</h3>
+    <form class="nta-form" novalidate>
+      <label>Тема
+        <input type="text" name="title" required minlength="3" maxlength="255" />
+      </label>
+      <label>Описание
+        <textarea name="content" required minlength="3" maxlength="65535"></textarea>
+      </label>
+      <div class="nta-inline">
+        <label data-nta-field="category">Категория
+          <select name="category_id"></select>
+          <div class="nta-error" data-nta-error="category" hidden></div>
+        </label>
+        <label data-nta-field="location">Местоположение
+          <select name="location_id"></select>
+          <div class="nta-error" data-nta-error="location" hidden></div>
+        </label>
+      </div>
+      <label><input type="checkbox" name="self_assign" class="nta-self" /> Назначить меня</label>
+      <label data-nta-field="assignee">Исполнитель
+        <select name="assignee_id"></select>
+        <div class="nta-error" data-nta-error="assignee" hidden></div>
+      </label>
+      <button type="submit" class="nta-submit">Создать (API)</button>
+      <div class="nta-submit-error"></div>
+      <div class="nta-success nta-submit-success"></div>
+    </form>
+  </div>
+</div>

--- a/new-ticket-api/readme.md
+++ b/new-ticket-api/readme.md
@@ -1,0 +1,18 @@
+# New ticket (API) module
+
+Isolated module under `/new-ticket-api`. UI mirrors the SQL module but creates tickets via GLPI REST API.
+
+## Usage
+
+1. Ensure the main plugin includes:
+```php
+require_once __DIR__ . '/new-ticket-api/new-ticket-api.php';
+```
+2. Place shortcode `[glpi_new_ticket_api]` on a page.
+3. Each WP user must have `glpi_user_id` and `glpi_user_token` in their usermeta.
+
+## Notes
+- Dictionaries (categories, locations, assignees) are loaded from GLPI DB for performance.
+- Ticket creation uses API: initSession → POST /Ticket → POST /Ticket_User (requester, assignee) → killSession.
+- Duplicate protection uses a short SQL check (≤3 seconds window).
+- Errors are returned to the frontend with clear messages; no file/DB logging is performed.


### PR DESCRIPTION
## Summary
- add `new-ticket-api` module providing modal form and API-based ticket creation
- register shortcode and AJAX handlers for categories, locations, assignees, and ticket creation
- load new module from main plugin

## Testing
- `php -l gexe-copy.php`
- `find new-ticket-api -name "*.php" -exec php -l {} \;`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c02128d4908328bc70988b10516602