### PR TITLE
Add due date computation for GLPI tickets

### DIFF
--- a/new-ticket-api/readme.md
+++ b/new-ticket-api/readme.md
@@ -16,3 +16,4 @@ require_once __DIR__ . '/new-ticket-api/new-ticket-api.php';
 - Ticket creation uses API: initSession → POST /Ticket → POST /Ticket_User (requester, assignee) → killSession.
 - Duplicate protection uses a short SQL check (≤3 seconds window).
 - Errors are returned to the frontend with clear messages; no file/DB logging is performed.
+- Tickets are planned for 17:30 local time; after 17:30 or on weekends, the due date moves to the next business day at 17:30.


### PR DESCRIPTION
## Summary
- add helper to compute next business-day 17:30 due date
- set `due_date` when creating tickets
- document automated due date planning in module README

## Testing
- `php -l new-ticket-api/inc/nta-api.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0224bebb48328b18f62762a6f5cd3