### PR TITLE
Improve GLPI token resolution and docs

### DIFF
--- a/new-ticket-api/inc/nta-auth.php
+++ b/new-ticket-api/inc/nta-auth.php
@@ -1,6 +1,56 @@
 <?php
 if (!defined('ABSPATH')) exit;
 
+/**
+ * Try to resolve GLPI User Token using several sources:
+ *  1) usermeta 'glpi_user_token'
+ *  2) external integration via filter 'nt_glpi_user_token' (return non-empty string to use it)
+ *  3) existing project glue (optional, non-fatal):
+ *     - function glpi_get_user_token( $wp_user_id, $glpi_user_id ) or gexe_get_glpi_user_token(...)
+ *     - constant/array GEXE_GLPI_USER_TOKENS keyed by login/email/user_id/glpi_id
+ */
+function nta_resolve_glpi_token($wp_user, $glpi_uid) {
+    // 1) usermeta
+    $tok = (string) get_user_meta($wp_user->ID, 'glpi_user_token', true);
+    $tok = trim($tok);
+    if ($tok !== '') {
+        return $tok;
+    }
+
+    // 2) allow integrators to provide token
+    $filtered = apply_filters('nt_glpi_user_token', '', $wp_user, (int)$glpi_uid);
+    if (is_string($filtered) && $filtered !== '') {
+        return trim($filtered);
+    }
+
+    // 3) optional: use existing project helpers if present (keeps isolation; no hard require)
+    // 3.1 functions
+    if (function_exists('glpi_get_user_token')) {
+        $t = (string) glpi_get_user_token($wp_user->ID, (int)$glpi_uid);
+        if ($t !== '') return trim($t);
+    }
+    if (function_exists('gexe_get_glpi_user_token')) {
+        $t = (string) gexe_get_glpi_user_token($wp_user->ID, (int)$glpi_uid);
+        if ($t !== '') return trim($t);
+    }
+    // 3.2 array constant map
+    if (defined('GEXE_GLPI_USER_TOKENS') && is_array(GEXE_GLPI_USER_TOKENS)) {
+        $map = GEXE_GLPI_USER_TOKENS;
+        $candidates = [];
+        // common keys that might be used in the project
+        $candidates[] = (string)$wp_user->user_login;
+        $candidates[] = (string)$wp_user->user_email;
+        $candidates[] = 'wp:' . (int)$wp_user->ID;
+        $candidates[] = 'glpi:' . (int)$glpi_uid;
+        foreach ($candidates as $k) {
+            if (isset($map[$k]) && is_string($map[$k]) && trim($map[$k]) !== '') {
+                return trim($map[$k]);
+            }
+        }
+    }
+    return '';
+}
+
 function nta_get_current_glpi_uid() {
     $u = wp_get_current_user();
     if (!$u || empty($u->ID)) return 0;
@@ -10,8 +60,8 @@ function nta_get_current_glpi_uid() {
 function nta_get_current_glpi_token() {
     $u = wp_get_current_user();
     if (!$u || empty($u->ID)) return '';
-    $tok = (string) get_user_meta($u->ID, 'glpi_user_token', true);
-    return trim($tok);
+    $glpi_uid = nta_get_current_glpi_uid();
+    return nta_resolve_glpi_token($u, $glpi_uid);
 }
 
 function nta_require_glpi_user_and_token() {
@@ -24,7 +74,12 @@ function nta_require_glpi_user_and_token() {
     }
     $tok = nta_get_current_glpi_token();
     if ($tok === '') {
-        nta_response_error('no_glpi_token', 'У пользователя не задан GLPI user token');
+        // Give integrators a hint how to wire the token
+        nta_response_error(
+            'no_glpi_token',
+            'У пользователя не задан GLPI user token. Задайте usermeta glpi_user_token, ' .
+            'или верните токен фильтром nt_glpi_user_token, или добавьте в GEXE_GLPI_USER_TOKENS (login/email/wp:id/glpi:id).'
+        );
     }
     return [$uid, $tok];
 }

--- a/new-ticket-api/readme.md
+++ b/new-ticket-api/readme.md
@@ -9,7 +9,13 @@ Isolated module under `/new-ticket-api`. UI mirrors the SQL module but creates t
 require_once __DIR__ . '/new-ticket-api/new-ticket-api.php';
 ```
 2. Place shortcode `[glpi_new_ticket_api]` on a page.
-3. Each WP user must have `glpi_user_id` and `glpi_user_token` in their usermeta.
+3. User credentials:
+   - Each WP user must have `glpi_user_id` in usermeta.
+   - GLPI user token is resolved automatically from (first match wins):
+     - usermeta `glpi_user_token`
+     - `nt_glpi_user_token` filter
+     - helper functions `glpi_get_user_token()` or `gexe_get_glpi_user_token()` if available
+     - `GEXE_GLPI_USER_TOKENS` constant/array keyed by login, email, `wp:id` or `glpi:id`
 
 ## Notes
 - Dictionaries (categories, locations, assignees) are loaded from GLPI DB for performance.


### PR DESCRIPTION
## Summary
- add helper to resolve GLPI token from usermeta, filters, helper functions or map
- use resolver in auth utility and improve error message
- document token resolution options

## Testing
- `npm test` (fails: no test specified)
- `composer validate`
- `php -l new-ticket-api/inc/nta-auth.php`


------
https://chatgpt.com/codex/tasks/task_e_68c024a2304c8328bfa4f3c4d682ec1d