### PR TITLE
Use project helpers for GLPI token and assignee resolution

### DIFF
--- a/new-ticket-api/inc/nta-sql.php
+++ b/new-ticket-api/inc/nta-sql.php
@@ -24,6 +24,18 @@ function nta_resolve_assignees_from_project(){
         }
         if ($out) return $out;
     }
+    // project helper: gexe_get_executors_list() → [{display_name,glpi_user_id}]
+    if (function_exists('gexe_get_executors_list')) {
+        $res = gexe_get_executors_list();
+        if (is_array($res) && !empty($res['ok']) && !empty($res['list']) && is_array($res['list'])) {
+            return array_map(function($r){
+                return [
+                    'id'    => (int) ($r['glpi_user_id'] ?? 0),
+                    'label' => (string) ($r['display_name'] ?? ''),
+                ];
+            }, $res['list']);
+        }
+    }
     return null;
 }
 
@@ -46,7 +58,7 @@ function nta_sql_get_locations(){
 }
 
 function nta_sql_get_assignees(){
-    // try project-provided list first
+    // try project-provided list first (фильтр/константа/функция)
     $provided = nta_resolve_assignees_from_project();
     if (is_array($provided) && !empty($provided)) {
         return $provided;


### PR DESCRIPTION
## Summary
- Prefer project helper functions for resolving GLPI user tokens and IDs
- Allow assignee list to come from project helper `gexe_get_executors_list`

## Testing
- `php -l new-ticket-api/inc/nta-auth.php`
- `php -l new-ticket-api/inc/nta-sql.php`
- `npm test` *(fails: Error: no test specified)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c028d45f208328943547c29268bd76