### PR TITLE
Fix assignee selection override in API

### DIFF
--- a/new-ticket-api/assets/new-ticket-api.js
+++ b/new-ticket-api/assets/new-ticket-api.js
@@ -98,7 +98,17 @@
   document.addEventListener('change', function(e){
     const form = e.target && e.target.closest('form.nta-form'); if(!form) return;
     if(e.target.matches('.nta-self')) toggleAssignee(form);
-    if(e.target.matches('select[name="assignee_id"]')) validateForm(form);
+    if(e.target.matches('select[name="assignee_id"]')){
+      // Если пользователь вручную выбрал исполнителя — снимаем "Я исполнитель"
+      const val = e.target.value;
+      const selfCb = form.querySelector('.nta-self');
+      if(val && selfCb && selfCb.checked){
+        selfCb.checked = false;
+        toggleAssignee(form); // обновит disabled и валидацию
+      } else {
+        validateForm(form);
+      }
+    }
   });
 
   const form = document.querySelector('.nta-wrap form.nta-form');

--- a/new-ticket-api/new-ticket-api.php
+++ b/new-ticket-api/new-ticket-api.php
@@ -70,7 +70,12 @@ add_action('wp_ajax_nta_create_ticket_api', function(){
         nta_response(['ok'=>true, 'code'=>'already_exists', 'ticket_id'=>$dup]);
     }
 
-    $assignee = $validated['self_assign'] ? $uid : (int)$validated['assignee_id'];
+    // Если выбран конкретный исполнитель — используем его всегда.
+    // Иначе, если отмечено "Я исполнитель" — назначаем текущего пользователя.
+    // Фолбэк на текущего пользователя для надёжности.
+    $assignee = !empty($validated['assignee_id'])
+        ? (int)$validated['assignee_id']
+        : ($validated['self_assign'] ? (int)$uid : (int)$uid);
     $res = nta_api_create_ticket($token, $validated, $uid, $assignee);
     if(!$res['ok']){
         $msg = $res['message'] ?? 'API error';


### PR DESCRIPTION
## Summary
- Clear "self" checkbox when a different assignee is selected in the new ticket form
- Ensure API always respects chosen assignee with fallback to current user

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint new-ticket-api/assets/new-ticket-api.js` *(fails: Parsing error: Unexpected token .)*
- `php -l new-ticket-api/new-ticket-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68c02cc59d408328a62df8f74028c821