### PR TITLE
Improve new-ticket modal usability

### DIFF
--- a/new-ticket-api/assets/new-ticket-api.css
+++ b/new-ticket-api/assets/new-ticket-api.css
@@ -6,14 +6,15 @@
 .nta-wrap{display:none}
 .nta-wrap.nta-wrap--open{display:block;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);z-index:9990}
 .nta-wrap .nta-modal{position:relative;background:#0f172a;color:#fff;padding:24px;margin:40px auto;max-width:760px;border-radius:16px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
-.nta-wrap .nta-modal h3{margin:0 0 14px;font-size:18px}
+/* заголовок убран в разметке */
 .nta-wrap .nta-close-modal{position:absolute;right:12px;top:12px;background:#333;border:none;color:#fff;border-radius:8px;cursor:pointer;padding:6px 10px}
 .nta-wrap .nta-close-modal:hover{background:#444}
 
 /* Inputs */
 .nta-wrap label{display:block;margin-bottom:12px}
 .nta-wrap input,.nta-wrap select,.nta-wrap textarea{width:100%;margin-top:6px;background:#0b1220;border:1px solid #2b3550;border-radius:10px;color:#fff;padding:10px 12px}
-.nta-wrap textarea{min-height:100px;resize:vertical}
+/* уменьшили поле описания на ~1 строку */
+.nta-wrap textarea{min-height:84px;resize:vertical}
 .nta-inline{display:flex;gap:16px}
 .nta-inline > label{flex:1}
 

--- a/new-ticket-api/assets/new-ticket-api.js
+++ b/new-ticket-api/assets/new-ticket-api.js
@@ -53,6 +53,23 @@
     }
   });
 
+  // Закрытие по клику на подложку
+  document.addEventListener('click', function(e){
+    const wrap = document.querySelector('.nta-wrap.nta-wrap--open');
+    if(!wrap) return;
+    // если кликнули прямо по подложке (а не внутри модалки) — закрываем
+    if(e.target === wrap){
+      wrap.classList.remove('nta-wrap--open');
+    }
+  });
+
+  // Закрытие по Esc
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape'){
+      document.querySelector('.nta-wrap')?.classList.remove('nta-wrap--open');
+    }
+  });
+
   async function loadDicts(scope){
     const form = scope.querySelector('form.nta-form'); if(!form) return;
     const catWrap = form.querySelector('[data-nta-field="category"]');

--- a/new-ticket-api/new-ticket-api.php
+++ b/new-ticket-api/new-ticket-api.php
@@ -32,7 +32,7 @@ function nta_render_shortcode_api(){
 }
 
 // nopriv -> auth required
-function nta_ajax_nopriv_api(){ nta_response_error('auth','Auth required'); }
+function nta_ajax_nopriv_api(){ nta_response_error('auth','Нужна авторизация'); }
 add_action('wp_ajax_nopriv_nta_get_categories', 'nta_ajax_nopriv_api');
 add_action('wp_ajax_nopriv_nta_get_locations',  'nta_ajax_nopriv_api');
 add_action('wp_ajax_nopriv_nta_get_assignees',  'nta_ajax_nopriv_api');

--- a/new-ticket-api/partials/form.php
+++ b/new-ticket-api/partials/form.php
@@ -2,7 +2,6 @@
 <div class="nta-wrap" aria-hidden="true" role="dialog" aria-modal="true">
   <div class="nta-modal">
     <button type="button" class="nta-close-modal" aria-label="Закрыть">×</button>
-    <h3>Новая заявка (через API)</h3>
     <form class="nta-form" novalidate>
       <label>Тема
         <input type="text" name="title" required minlength="3" maxlength="255" />


### PR DESCRIPTION
## Summary
- Allow closing the new-ticket modal by clicking the backdrop or pressing Esc
- Remove modal heading and reduce description field height for a cleaner layout
- Localize authorization error message for unauthenticated requests

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint new-ticket-api/assets/new-ticket-api.js` *(fails: Parsing error: Unexpected token .)*
- `php -l new-ticket-api/new-ticket-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68c02e31c80c832898a3769f350c1f69