### PR TITLE
Add lookup toggles and custom assignee name

### DIFF
--- a/new-ticket-api/assets/new-ticket-api.css
+++ b/new-ticket-api/assets/new-ticket-api.css
@@ -32,13 +32,18 @@
 
 /* Typeahead */
 .nta-lookup-wrap{position:relative}
-.nta-lookup-input{width:100%;background:#0b1220;border:1px solid #2b3550;border-radius:10px;color:#fff;padding:10px 12px}
+.nta-lookup-input{width:100%;background:#0b1220;border:1px solid #2b3550;border-radius:10px;color:#fff;padding:10px 40px 10px 12px}
 .nta-lookup-list{position:absolute;left:0;right:0;top:100%;margin-top:6px;background:#111827;border:1px solid #2b3550;border-radius:10px;max-height:260px;overflow:auto;display:none;z-index:9991}
 .nta-lookup-list.nta-open{display:block}
 .nta-lookup-item{padding:10px 12px;cursor:pointer}
 .nta-lookup-item:hover{background:#1f2937}
 .nta-lookup-title{display:block;font-size:14px;color:#e5e7eb}
 .nta-lookup-sub{display:block;font-size:12px;color:#9aa7c7;margin-top:2px}
+
+/* Toggle (triangle) */
+.nta-lookup-toggle{position:absolute;right:8px;top:50%;transform:translateY(-50%);width:28px;height:28px;border:1px solid #2b3550;border-radius:8px;background:transparent;cursor:pointer;display:flex;align-items:center;justify-content:center}
+.nta-lookup-toggle:after{content:"";width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:7px solid #94a3b8}
+.nta-lookup-toggle.nta-open:after{border-top:none;border-bottom:7px solid #94a3b8}
 
 /* Field highlight like main plugin */
 .nta-highlight{box-shadow:0 0 0 2px #e11d48 inset;border-color:#e11d48}

--- a/new-ticket-api/assets/new-ticket-api.js
+++ b/new-ticket-api/assets/new-ticket-api.js
@@ -49,7 +49,8 @@
       loadDicts(wrap);
     }
     if(e.target.closest('.nta-close-modal')){
-      $('.nta-wrap')?.classList.remove('nta-wrap--open');
+      const wrapEl = $('.nta-wrap');
+      if(wrapEl){ wrapEl.classList.remove('nta-wrap--open'); }
     }
   });
 
@@ -66,7 +67,8 @@
   // Закрытие по Esc
   document.addEventListener('keydown', function(e){
     if(e.key === 'Escape'){
-      document.querySelector('.nta-wrap')?.classList.remove('nta-wrap--open');
+      const wrap = document.querySelector('.nta-wrap');
+      if(wrap){ wrap.classList.remove('nta-wrap--open'); }
     }
   });
 
@@ -105,6 +107,7 @@
     if(ass && ass.ok){ renderOptions(assSel, ass.list, 'Select assignee…'); }
     else { setError(assErr, (ass && ass.message) || 'Failed to load assignees'); }
     setLoading(assWrap,false);
+    if(ass && ass.ok){ renderOptions(assSel, ass.list, 'Назначить исполнителя'); }
 
     // build typeahead lists
     setupLookup(form, 'category', form._ntaCats, catId, catNote);
@@ -161,10 +164,10 @@
           const tid = res.ticket_id || (res.data && res.data.ticket_id);
           if(ok){ ok.textContent = tid ? ('Заявка #'+tid+' создана по API') : 'Заявка создана по API'; }
           form.reset(); toggleAssignee(form);
-          setTimeout(()=>{ document.querySelector('.nta-wrap')?.classList.remove('nta-wrap--open'); }, 800);
+          setTimeout(()=>{ const wrap=document.querySelector('.nta-wrap'); if(wrap){ wrap.classList.remove('nta-wrap--open'); } }, 800);
         }else if(res && res.code === 'already_exists'){
           if(ok){ ok.textContent = 'Такая заявка уже создана недавно'+(res.ticket_id?(' (#'+res.ticket_id+')'):''); }
-          setTimeout(()=>{ document.querySelector('.nta-wrap')?.classList.remove('nta-wrap--open'); }, 800);
+          setTimeout(()=>{ const wrap=document.querySelector('.nta-wrap'); if(wrap){ wrap.classList.remove('nta-wrap--open'); } }, 800);
         }else{
           setError(err, (res && res.message) || 'Ошибка отправки по API');
         }
@@ -213,6 +216,7 @@
     if(!wrap) return;
     const input = wrap.querySelector('.nta-lookup-input');
     const dropdown = wrap.querySelector('.nta-lookup-list');
+    const toggle = wrap.querySelector('.nta-lookup-toggle');
     const {counts} = dedupeLeafs(list);
 
     function render(items){
@@ -239,6 +243,7 @@
         dropdown.appendChild(div);
       });
       dropdown.classList.toggle('nta-open', items.length>0);
+      if(toggle){ toggle.classList.toggle('nta-open', items.length>0); }
     }
 
     function doFilter(){
@@ -257,8 +262,16 @@
       validateForm(form);
     });
     input.addEventListener('focus', ()=>{ if(input.value){ doFilter(); } });
+    if(toggle){
+      toggle.addEventListener('click', (e)=>{
+        e.preventDefault();
+        if(dropdown.classList.contains('nta-open')){
+          dropdown.classList.remove('nta-open'); toggle.classList.remove('nta-open');
+        } else { render(list); }
+      });
+    }
     document.addEventListener('click', (e)=>{
-      if(!wrap.contains(e.target)) dropdown.classList.remove('nta-open');
+      if(!wrap.contains(e.target)) { dropdown.classList.remove('nta-open'); if(toggle){toggle.classList.remove('nta-open');} }
     });
   }
 })();

--- a/new-ticket-api/inc/nta-sql.php
+++ b/new-ticket-api/inc/nta-sql.php
@@ -69,6 +69,7 @@ function nta_sql_get_assignees(){
     return array_map(function($r){
         $label = trim(($r['realname'] ?? '').' '.($r['firstname'] ?? ''));
         if($label===''){ $label = $r['name'] ?? ''; }
+        if (($r['name'] ?? '') === 'vks_m5_local') { $label = 'Павел Куткин'; }
         return ['id'=>(int)$r['id'],'label'=>$label];
     }, $rows);
 }

--- a/new-ticket-api/partials/form.php
+++ b/new-ticket-api/partials/form.php
@@ -13,6 +13,7 @@
         <label data-nta-field="category">Категория
           <div class="nta-lookup-wrap" data-nta-lookup="category">
             <input type="text" class="nta-lookup-input" placeholder="Начните вводить..." />
+            <button type="button" class="nta-lookup-toggle" aria-label="Показать список"></button>
             <div class="nta-lookup-list"></div>
           </div>
           <input type="hidden" name="category_id" />
@@ -22,6 +23,7 @@
         <label data-nta-field="location">Местоположение
           <div class="nta-lookup-wrap" data-nta-lookup="location">
             <input type="text" class="nta-lookup-input" placeholder="Начните вводить..." />
+            <button type="button" class="nta-lookup-toggle" aria-label="Показать список"></button>
             <div class="nta-lookup-list"></div>
           </div>
           <input type="hidden" name="location_id" />


### PR DESCRIPTION
## Summary
- add toggle buttons for category/location lookup dropdowns
- support custom label mapping for specific assignee
- translate assignee placeholder text

## Testing
- `php -l new-ticket-api/inc/nta-sql.php`
- `php -l new-ticket-api/partials/form.php`
- `npx eslint new-ticket-api/assets/new-ticket-api.js` *(fails: many style errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0329baba483289a34a93a45cde490