### PR TITLE
Enable API modal and intercept ticket links globally

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,8 @@
     "browser": true,
     "es2021": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2022
+  },
   "rules": {}
 }

--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -14,6 +14,15 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/glpi-utils.php';
 require_once __DIR__ . '/includes/glpi-profile-fields.php';
 require_once __DIR__ . '/chief/glpi-chief.php';
+// Включение нового модального окна (API-only)
+define('GEXE_USE_NEWMODAL', true);
+
+/**
+ * Лоадер нового модального окна.
+ * Он инертен, если GEXE_USE_NEWMODAL=false, но при true подключает стили/скрипты
+ * и перехватывает клики на карточках/кнопках открытия.
+ */
+require_once __DIR__ . '/newmodal/newmodal-loader.php';
 
 // [manager-switcher] local helper to detect manager account
 function gexe_is_manager_local() {
@@ -86,20 +95,6 @@ add_action('wp_enqueue_scripts', function () {
 
 // ====== ПОДКЛЮЧЕНИЕ К БД GLPI ======
 require_once __DIR__ . '/glpi-db-setup.php';
-
-/**
- * Feature flag for NEW modal (API-only, no SQL)
- * Can be overridden via query param ?use_newmodal=1
- */
-if (!defined('GEXE_USE_NEWMODAL')) {
-    define('GEXE_USE_NEWMODAL', false);
-}
-if (!defined('GEXE_NEWMODAL_QS')) {
-    define('GEXE_NEWMODAL_QS', 'use_newmodal');
-}
-
-// New modal isolated module (safe to require; it is inert unless enabled)
-require_once __DIR__ . '/newmodal/newmodal-loader.php';
 
 function gexe_glpi_uninstall() {
     gexe_glpi_remove_triggers();

--- a/newmodal/newmodal.css
+++ b/newmodal/newmodal.css
@@ -1,3 +1,12 @@
+/* При активном newmodal жёстко скрываем старые контейнеры модалок */
+body[data-newmodal-active="1"] .gexe-modal,
+body[data-newmodal-active="1"] .gexe-modal_backdrop,
+body[data-newmodal-active="1"] .gexe-cmnt,
+body[data-newmodal-active="1"] .gexe-cmnt_backdrop {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
 /* Dark-friendly modal UI matching existing style (no layout breakage) */
 .gexe-nm-backdrop{
   position: fixed; inset: 0; background: rgba(0,0,0,.55); z-index: 9998;
@@ -51,3 +60,14 @@
 }
 .gexe-nm__actions{ display:flex; gap:8px; justify-content:flex-end; }
 .gexe-nm__error{ color:#ff8a8a; font-size:12px; white-space: pre-line; line-height:1.2; }
+
+/* Маленький маркер для отладки */
+.gexe-nm__badge{
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
+  font-size: 10px;
+  padding: 2px 6px;
+  opacity: .45;
+  user-select: none;
+}


### PR DESCRIPTION
## Summary
- Enable new API-based ticket modal and load its assets
- Intercept ticket link clicks with broader selector and badge new modal
- Hide legacy modal containers when API modal is active
- Update ESLint config for modern syntax parsing

## Testing
- `php -l gexe-copy.php`
- `npx eslint newmodal/newmodal.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c042e66208832898dc21afd8949a43