### PR TITLE
Add debug badge to API modal

### DIFF
--- a/newmodal/newmodal.js
+++ b/newmodal/newmodal.js
@@ -218,4 +218,11 @@
         .finally(() => { busy = false; });
     });
   }
+  // Неброский маркер для отладки — виден только в API-модале
+  if (dom.modal) {
+    const badge = document.createElement('div');
+    badge.className = 'gexe-nm__badge';
+    badge.textContent = 'API modal';
+    dom.modal.querySelector('.gexe-nm__card').appendChild(badge);
+  }
 }());


### PR DESCRIPTION
## Summary
- add an unobtrusive badge to API modal for debugging

## Testing
- `npx eslint --parser-options=ecmaVersion:2021 newmodal/newmodal.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c04bfc49c08328ac6cec835a84da7d