### PR TITLE
Improve new modal activation and event handling

### DIFF
--- a/newmodal/newmodal.css
+++ b/newmodal/newmodal.css
@@ -1,3 +1,16 @@
+/* При активном newmodal жёстко скрываем старые контейнеры модалок */
+body[data-newmodal-active="1"] .gexe-modal,
+body[data-newmodal-active="1"] .gexe-modal_backdrop,
+body[data-newmodal-active="1"] .gexe-cmnt,
+body[data-newmodal-active="1"] .gexe-cmnt_backdrop,
+body.gexe-newmodal-active .gexe-modal,
+body.gexe-newmodal-active .gexe-modal_backdrop,
+body.gexe-newmodal-active .gexe-cmnt,
+body.gexe-newmodal-active .gexe-cmnt_backdrop {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
 /* Dark-friendly modal UI matching existing style (no layout breakage) */
 .gexe-nm-backdrop{
   position: fixed; inset: 0; background: rgba(0,0,0,.55); z-index: 9998;


### PR DESCRIPTION
## Summary
- Load new modal assets early without dependencies and expose CSS body flag to hide old modals
- Add body class filter and JS body flag for reliable styling
- Broaden delegated click opener to cover more selectors and suppress legacy handlers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `composer validate`
- `vendor/bin/phpcs` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c04ccf4c488328977b50e57a387b95