### PR TITLE
Show old modal only when new one opens

### DIFF
--- a/newmodal/newmodal-loader.php
+++ b/newmodal/newmodal-loader.php
@@ -54,22 +54,14 @@ add_action('wp_enqueue_scripts', function () {
         'enabled' => true,
         'qs'      => defined('GEXE_NEWMODAL_QS') ? GEXE_NEWMODAL_QS : 'use_newmodal',
     ]);
-}, 1); // priority=1 — грузим раньше прочих скриптов
+}, 1); // грузим раньше прочих скриптов
 
 add_action('wp_footer', function () {
     if (!gexe_newmodal_is_enabled()) return;
     // Inject hidden modal container (HTML markup kept minimal; visual parity in CSS)
     echo gexe_newmodal_render_container();
 }, 100);
-
-/**
- * Добавляем класс в body для надёжного скрытия старых модалок CSS-ом,
- * даже если JS ещё не успел инициализироваться.
- */
-add_filter('body_class', function(array $classes){
-    if (gexe_newmodal_is_enabled()) $classes[] = 'gexe-newmodal-active';
-    return $classes;
-});
+// Никаких классов в body на сервере — блокировку старых модалок включает JS только при открытии нового.
 
 /**
  * AJAX: Fetch ticket with followups (comments) via API

--- a/newmodal/newmodal.css
+++ b/newmodal/newmodal.css
@@ -1,12 +1,8 @@
-/* При активном newmodal жёстко скрываем старые контейнеры модалок */
-body[data-newmodal-active="1"] .gexe-modal,
-body[data-newmodal-active="1"] .gexe-modal_backdrop,
-body[data-newmodal-active="1"] .gexe-cmnt,
-body[data-newmodal-active="1"] .gexe-cmnt_backdrop,
-body.gexe-newmodal-active .gexe-modal,
-body.gexe-newmodal-active .gexe-modal_backdrop,
-body.gexe-newmodal-active .gexe-cmnt,
-body.gexe-newmodal-active .gexe-cmnt_backdrop {
+/* Скрываем СТАРЫЙ модал только когда новый действительно открыт */
+body[data-newmodal-open="1"] .gexe-modal,
+body[data-newmodal-open="1"] .gexe-modal_backdrop,
+body[data-newmodal-open="1"] .gexe-cmnt,
+body[data-newmodal-open="1"] .gexe-cmnt_backdrop {
   display: none !important;
   visibility: hidden !important;
   pointer-events: none !important;

--- a/newmodal/newmodal.js
+++ b/newmodal/newmodal.js
@@ -5,11 +5,6 @@
     return;
   }
 
-  // Ставим флаг на body сразу (для CSS-блокировки старых модалок)
-  if (document.body) {
-    document.body.classList.add('gexe-newmodal-active');
-    document.body.setAttribute('data-newmodal-active', '1');
-  }
 
   const qsKey = gexeNewModal.qs || 'use_newmodal';
   const ajax = gexeNewModal.ajaxUrl;
@@ -39,6 +34,10 @@
   }
 
   function openModal() {
+    // Включаем блокировку старых модалок только на время, когда открыт новый
+    if (document.body) {
+      document.body.setAttribute('data-newmodal-open', '1');
+    }
     dom.backdrop.hidden = false;
     dom.modal.hidden = false;
   }
@@ -50,6 +49,9 @@
     dom.meta.innerHTML = '';
     dom.textarea.value = '';
     showError('');
+    if (document.body) {
+      document.body.removeAttribute('data-newmodal-open');
+    }
   }
 
   if (dom.backdrop) {
@@ -142,11 +144,16 @@
     document.addEventListener('click', (ev) => {
       const a = ev.target.closest(OPEN_SELECTORS);
       if (!a) return;
-      const idAttr = a.getAttribute('data-ticket-id') || (a.dataset && a.dataset.ticketId);
+      const idAttr = a.getAttribute('data-ticket-id') || (a.dataset ? a.dataset.ticketId : null);
       const titleAttr = a.getAttribute('data-ticket-title') || a.getAttribute('data-title') || '';
       const id = parseInt(idAttr, 10);
       if (!id || Number.isNaN(id)) return;
-      // Гасим старые обработчики жёстко (capture + стоп)
+      // Открываем новый модал только если его контейнер реально есть на странице.
+      if (!dom.modal || !dom.backdrop) {
+        // Нет контейнера — даём старой логике отработать.
+        return;
+      }
+      // Контейнер есть — перехватываем полностью.
       ev.preventDefault();
       ev.stopImmediatePropagation();
       openModal();


### PR DESCRIPTION
## Summary
- Activate hiding of legacy modal only while API modal is open
- Remove server-side body class flag and let JS manage modal state
- Guard delegated opener to fall back when API modal container missing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint newmodal/newmodal.js` *(fails: Parsing error: Unexpected token .)*

------
https://chatgpt.com/codex/tasks/task_e_68c11f1fd7e88328853ed618df6daf18