### PR TITLE
feat: add isolated cards page for new modal

### DIFF
--- a/gexe-copy.php
+++ b/gexe-copy.php
@@ -100,6 +100,9 @@ require_once __DIR__ . '/glpi-db-setup.php';
  
 // New modal isolated module (safe to require; it is inert unless enabled)
 require_once __DIR__ . '/newmodal/newmodal-loader.php';
+// Изолированная страница карточек (badge) — очищенная от конфликтов со старой модалкой
+// Переопределяет шорткод карточек и гарантирует работу новой модалки.
+require_once __DIR__ . '/newmodal/bage/bage-loader.php';
 
 function gexe_glpi_uninstall() {
     gexe_glpi_remove_triggers();

--- a/newmodal/bage/bage-loader.php
+++ b/newmodal/bage/bage-loader.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * BAGE (cards page) – isolated loader for cards grid, conflict-free with new modal.
+ * - Reuses existing template via output buffering, then strips old modal triggers.
+ * - Preserves look & features; only removes classes/attributes that launch old modals.
+ * - Registers/overrides shortcode so only the cleaned version is used.
+ *
+ * No SQL/API logic is changed here; listing stays as is. Only HTML is sanitized.
+ */
+if (!defined('ABSPATH')) exit;
+
+// Handle to original template (expected location)
+if (!defined('GEXE_CARDS_TEMPLATE')) {
+    define('GEXE_CARDS_TEMPLATE', __DIR__ . '/../../templates/glpi-cards-template.php');
+}
+
+/**
+ * Render cleaned cards page.
+ * This function includes the original template into a buffer,
+ * then removes old-modal trigger classes and conflicting attributes.
+ */
+function gexe_bage_render_cards($atts = []) {
+    // Fallback if template not found — clear error to UI per project policy (no logging)
+    if (!file_exists(GEXE_CARDS_TEMPLATE)) {
+        return '<div class="gexe-error">Шаблон карточек не найден: ' . esc_html(GEXE_CARDS_TEMPLATE) . '</div>';
+    }
+    // Collect output from original template
+    ob_start();
+    // Make sure helper functions/vars used by the original template are available in scope.
+    // We deliberately do not modify their logic.
+    include GEXE_CARDS_TEMPLATE;
+    $html = (string) ob_get_clean();
+
+    if ($html === '') {
+        return '<div class="gexe-error">Пустой вывод шаблона карточек.</div>';
+    }
+
+    // Strip old modal triggers: classes and data-attrs which bind legacy JS
+    //  - .gexe-modal_open, .gexe-cmnt_open, .glpi-card-in-modal
+    //  - data-open="comment|ticket" (legacy)
+    $replacements = [
+        '/\bgexe-modal_open\b/'        => '',
+        '/\bgexe-cmnt_open\b/'         => '',
+        '/\bglpi-card-in-modal\b/'     => '',
+        '/\sdata-open="(?:comment|ticket)"/' => '',
+    ];
+    $clean = $html;
+    foreach ($replacements as $rx => $to) {
+        $clean = preg_replace($rx, $to, $clean);
+    }
+
+    // Ensure cards have a selector that new modal listens to:
+    // if there's a root card element missing data-ticket-id but having data-id, duplicate it.
+    // This is conservative: we don't change existing attributes, only add when helpful.
+    $clean = preg_replace_callback(
+        '/(<[^>]+class="[^"]*(?:\bgexe-card\b|\bticket-card\b)[^"]*"[^>]*)(>)/i',
+        function ($m) {
+            $tag = $m[1];
+            // do not touch if data-ticket-id already present
+            if (strpos($tag, 'data-ticket-id=') !== false) return $m[0];
+            // try to reuse existing data-id or data-ticket
+            if (preg_match('/\sdata-id="(\d+)"/i', $tag, $mm)) {
+                return str_replace($m[1], $m[1] . ' data-ticket-id="' . esc_attr($mm[1]) . '"', $m[0]);
+            }
+            if (preg_match('/\sdata-ticket="(\d+)"/i', $tag, $mm)) {
+                return str_replace($m[1], $m[1] . ' data-ticket-id="' . esc_attr($mm[1]) . '"', $m[0]);
+            }
+            return $m[0];
+        },
+        $clean
+    );
+
+    // Namespacing hook: mark container so our tiny CSS can scope fixes without touching global CSS.
+    // Wrap the whole block into a scoped div if not already wrapped.
+    if (strpos($clean, 'gexe-bage-scope') === false) {
+        $clean = '<div class="gexe-bage-scope">' . $clean . '</div>';
+    }
+    return $clean;
+}
+
+/**
+ * Register/override cards shortcode with conflict-free renderer.
+ * We try to replace the same shortcode id the project uses for cards.
+ * If the shortcode name differs in your build, update $shortcode_names accordingly.
+ */
+add_action('init', function () {
+    if (!defined('GEXE_USE_NEWMODAL') || !GEXE_USE_NEWMODAL) {
+        return; // keep legacy behavior when new modal is disabled
+    }
+    $shortcode_names = [
+        'glpi_cards',       // common
+        'gexe_glpi_cards',  // alt
+    ];
+    foreach ($shortcode_names as $tag) {
+        if (shortcode_exists($tag)) {
+            remove_shortcode($tag);
+        }
+        add_shortcode($tag, 'gexe_bage_render_cards');
+    }
+});
+
+/**
+ * Enqueue tiny CSS/JS shim for cards page (namespaced; no conflicts).
+ * We keep it minimal: only helpers that cannot be expressed via sanitizing HTML.
+ */
+add_action('wp_enqueue_scripts', function () {
+    if (!defined('GEXE_USE_NEWMODAL') || !GEXE_USE_NEWMODAL) return;
+    $ver = defined('GEXE_TRIGGERS_VERSION') ? GEXE_TRIGGERS_VERSION : '1.0.0';
+    $base = plugin_dir_url(__FILE__);
+    wp_enqueue_style('gexe-bage', $base . 'bage.css', [], $ver);
+    wp_enqueue_script('gexe-bage', $base . 'bage.js', [], $ver, true);
+}, 11);

--- a/newmodal/bage/bage.css
+++ b/newmodal/bage/bage.css
@@ -1,0 +1,12 @@
+/* BAGE scope – minimal safety styles to avoid any visual drift while removing legacy modal triggers */
+.gexe-bage-scope .gexe-card,
+.gexe-bage-scope .ticket-card{
+  /* no-op: keep original styles; this file is intentionally minimal */
+}
+
+/* Ensure clickable cursor even if legacy classes removed */
+.gexe-bage-scope [data-ticket-id]{
+  cursor: pointer;
+}
+
+/* Do NOT style modal here; modal styles live in newmodal/newmodal.css */

--- a/newmodal/bage/bage.js
+++ b/newmodal/bage/bage.js
@@ -1,0 +1,20 @@
+/* Minimal shim: ensure clicks on cards have data-ticket-id attribute for the new modal to pick up.
+   We do not open modal here (handled in newmodal/newmodal.js); we only normalize attributes. */
+(function bageShim() {
+  // Find anchors that still hold ticket id in href and mirror to data-ticket-id
+  const root = document.querySelector('.gexe-bage-scope');
+  if (!root) return;
+  const links = root.querySelectorAll('a[href*="#ticket-"], a[href*="ticket_id="]');
+  links.forEach((a) => {
+    if (a.hasAttribute('data-ticket-id')) return;
+    const href = a.getAttribute('href') || '';
+    let id = null;
+    const m1 = href.match(/#ticket-(\d+)/i);
+    if (m1) [, id] = m1;
+    const m2 = href.match(/[?&]ticket_id=(\d+)/i);
+    if (!id && m2) [, id] = m2;
+    if (id) {
+      a.setAttribute('data-ticket-id', id);
+    }
+  });
+}());


### PR DESCRIPTION
## Summary
- load new badge module to sanitize GLPI cards and avoid legacy modal triggers
- register shortcode and add minimal CSS/JS for new modal cards

## Testing
- `php -l gexe-copy.php`
- `php -l newmodal/bage/bage-loader.php`
- `npx eslint newmodal/bage/bage.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c12219ffcc8328a1347996e0095527