### PR TITLE
Add sanitized cards shortcode and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This plugin integrates WordPress with a GLPI helpdesk.
 
+## Shortcodes
+
+- `[glpi_cards_new]` – renders ticket cards with sanitized HTML.
+
 ## Database triggers
 
 The plugin maintains `glpi.glpi_tickets.last_followup_at` using two triggers on `glpi.glpi_itilfollowups`.

--- a/newmodal/bage/bage-loader.php
+++ b/newmodal/bage/bage-loader.php
@@ -97,6 +97,14 @@ add_action('init', function () {
         }
         add_shortcode($tag, 'gexe_bage_render_cards');
     }
+
+    // Дополнительно регистрируем новый явный шорткод для тестов
+    // Он не конфликтует со старым и всегда выводит очищенную версию
+    if (!shortcode_exists('glpi_cards_new')) {
+        add_shortcode('glpi_cards_new', function($atts = []) {
+            return gexe_bage_render_cards($atts);
+        });
+    }
 });
 
 /**

--- a/tests/glpi_cards_new_shortcode_test.php
+++ b/tests/glpi_cards_new_shortcode_test.php
@@ -1,0 +1,59 @@
+<?php
+// Minimal stubs for WordPress environment
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+if (!defined('GEXE_USE_NEWMODAL')) {
+    define('GEXE_USE_NEWMODAL', true);
+}
+if (!defined('GEXE_CARDS_TEMPLATE')) {
+    define('GEXE_CARDS_TEMPLATE', __DIR__ . '/glpi_cards_test_template.php');
+}
+
+// Basic shortcode API implementation
+$GLOBALS['shortcodes'] = [];
+function add_shortcode($tag, $func) {
+    $GLOBALS['shortcodes'][$tag] = $func;
+}
+function remove_shortcode($tag) {
+    unset($GLOBALS['shortcodes'][$tag]);
+}
+function shortcode_exists($tag) {
+    return isset($GLOBALS['shortcodes'][$tag]);
+}
+function do_shortcode($content) {
+    return preg_replace_callback('/\[(\w+)]/', function ($m) {
+        $tag = $m[1];
+        return isset($GLOBALS['shortcodes'][$tag])
+            ? call_user_func($GLOBALS['shortcodes'][$tag])
+            : $m[0];
+    }, $content);
+}
+function add_action($hook, $func, $prio = null) {
+    if ($hook === 'init') {
+        $func();
+    }
+}
+
+// Escaping helpers
+function esc_attr($s) { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+function esc_html($s) { return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
+
+require __DIR__ . '/../newmodal/bage/bage-loader.php';
+
+$output = do_shortcode('[glpi_cards_new]');
+
+if (strpos($output, 'gexe-modal_open') !== false) {
+    fwrite(STDERR, "unsanitized class still present\n");
+    exit(1);
+}
+if (strpos($output, 'data-open="comment"') !== false) {
+    fwrite(STDERR, "unsanitized attribute still present\n");
+    exit(1);
+}
+if (strpos($output, 'gexe-bage-scope') === false) {
+    fwrite(STDERR, "scope wrapper missing\n");
+    exit(1);
+}
+
+echo "OK\n";

--- a/tests/glpi_cards_test_template.php
+++ b/tests/glpi_cards_test_template.php
@@ -1,0 +1,6 @@
+<?php
+if (!defined('ABSPATH')) exit;
+?>
+<div class="glpi-card gexe-modal_open" data-open="comment" data-id="42">
+  Content
+</div>


### PR DESCRIPTION
## Summary
- add `glpi_cards_new` shortcode to render sanitized GLPI cards
- document the new shortcode
- add regression test confirming sanitizer removes legacy markup

## Testing
- `php -l newmodal/bage/bage-loader.php`
- `php -l tests/glpi_cards_new_shortcode_test.php`
- `php tests/glpi_cards_new_shortcode_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68c12437d3208328a949125d5afb3a8a