### PR TITLE
Improve BAGE module with session recovery and layout tweaks

### DIFF
--- a/newmodal/bage/bage-template.php
+++ b/newmodal/bage/bage-template.php
@@ -1,25 +1,27 @@
 <?php if (!defined('ABSPATH')) exit; ?>
 <div class="gexe-bage">
-  <div class="gexe-bage__toolbar">
+  <div class="gexe-bage__container">
+    <div class="gexe-bage__toolbar">
     <button class="gexe-bage__btn" id="gexe-bage-cat">Категории</button>
     <a class="gexe-bage__btn gexe-bage__btn--primary" href="#" id="gexe-bage-new">Новая заявка</a>
     <input type="search" class="gexe-bage__search" id="gexe-bage-search" placeholder="Поиск..." />
   </div>
-  <div class="gexe-bage__filters" id="gexe-bage-status">
+    <div class="gexe-bage__filters" id="gexe-bage-status">
     <button class="gexe-bage__pill is-active" data-status="0"><span class="gexe-bage__num" id="c0">0</span><span>Все задачи</span></button>
     <button class="gexe-bage__pill" data-status="2"><span class="gexe-bage__num" id="c2">0</span><span>В работе</span></button>
     <button class="gexe-bage__pill" data-status="3"><span class="gexe-bage__num" id="c3">0</span><span>В плане</span></button>
     <button class="gexe-bage__pill" data-status="4"><span class="gexe-bage__num" id="c4">0</span><span>В стопе</span></button>
     <button class="gexe-bage__pill" data-status="1"><span class="gexe-bage__num" id="c1">0</span><span>Новые</span></button>
   </div>
-  <div class="gexe-bage__grid" id="gexe-bage-grid">
+    <div class="gexe-bage__grid" id="gexe-bage-grid">
     <!-- карты подгружаются AJAX-ом -->
   </div>
-  <div class="gexe-bage__pager" id="gexe-bage-pager">
-    <button class="gexe-bage__btn" id="gexe-bage-prev" disabled>Назад</button>
-    <span id="gexe-bage-page">1</span>
-    <button class="gexe-bage__btn" id="gexe-bage-next" disabled>Далее</button>
+    <div class="gexe-bage__pager" id="gexe-bage-pager">
+      <button class="gexe-bage__btn" id="gexe-bage-prev" disabled>Назад</button>
+      <span id="gexe-bage-page">1</span>
+      <button class="gexe-bage__btn" id="gexe-bage-next" disabled>Далее</button>
+    </div>
+    <div class="gexe-bage__error" id="gexe-bage-err" hidden></div>
   </div>
-  <div class="gexe-bage__error" id="gexe-bage-err" hidden></div>
 </div>
 

--- a/newmodal/bage/bage.css
+++ b/newmodal/bage/bage.css
@@ -1,5 +1,6 @@
 /* Изолированная тёмная тема карточек (минимум — не конфликтует со старым CSS) */
-.gexe-bage{ padding:24px; color:#e8eef7; background:transparent; }
+.gexe-bage{ padding:16px 0 24px; color:#e8eef7; background:transparent; }
+.gexe-bage__container{ margin:0 auto; width:min(1180px, 96vw); }
 .gexe-bage__toolbar{ display:flex; gap:10px; align-items:center; margin-bottom:16px; }
 .gexe-bage__btn{ background:#1d2230; color:#fff; border:1px solid rgba(255,255,255,.1); border-radius:10px; padding:8px 12px; cursor:pointer; }
 .gexe-bage__btn:hover{ background:#26304a; }
@@ -10,7 +11,12 @@
 .gexe-bage__pill{ display:flex; align-items:center; gap:8px; background:#141925; color:#cdd7ee; border:1px solid rgba(255,255,255,.08); border-radius:14px; padding:10px 14px; cursor:pointer; }
 .gexe-bage__pill.is-active{ background:#1e2b4e; color:#fff; border-color:#3a56a1; }
 .gexe-bage__num{ display:inline-block; min-width:18px; text-align:center; font-weight:700; }
-.gexe-bage__grid{ display:grid; grid-template-columns: repeat(auto-fill,minmax(320px,1fr)); gap:12px; }
+.gexe-bage__grid{
+  display:grid;
+  grid-template-columns: repeat(auto-fill,minmax(350px,1fr));
+  gap:12px;
+  align-items:stretch;
+}
 .gexe-bage__card{ background:#0e111a; border:1px solid rgba(255,255,255,.08); border-radius:14px; padding:12px; display:flex; flex-direction:column; gap:8px; cursor:pointer; }
 .gexe-bage__card:hover{ background:#121726; }
 .gexe-bage__title{ font-weight:700; font-size:16px; line-height:1.25; }

--- a/newmodal/bage/bage.js
+++ b/newmodal/bage/bage.js
@@ -3,6 +3,7 @@
   const ajax = gexeBage.ajaxUrl;
   const nonce = gexeBage.nonce;
   const perPage = gexeBage.perPage || 20;
+  let loading = false;
 
   const els = {
     grid: document.getElementById('gexe-bage-grid'),
@@ -39,6 +40,11 @@
     f.append('nonce', nonce);
     Object.keys(data||{}).forEach(k => f.append(k, data[k]));
     return fetch(ajax, { method:'POST', body:f, credentials:'same-origin' }).then(r=>r.json());
+  }
+
+  function setLoading(on){
+    loading = !!on;
+    els.grid.classList.toggle('is-loading', loading);
   }
 
   function formatDate(s){
@@ -96,6 +102,8 @@
 
   function loadList(){
     showError('');
+    if (loading) return Promise.resolve();
+    setLoading(true);
     return post('gexe_bage_list_tickets', {
       page: state.page,
       per_page: perPage,
@@ -109,7 +117,8 @@
       els.page.textContent = state.page;
       els.prev.disabled = state.page <= 1;
       els.next.disabled = (state.page * perPage) >= total;
-    }).catch(e=>showError(e.message || 'Ошибка загрузки списка'));
+    }).catch(e=>showError(e.message || 'Ошибка загрузки списка'))
+      .finally(()=>setLoading(false));
   }
 
   // events


### PR DESCRIPTION
## Summary
- Add `gexe_bage_api_safe` wrapper to auto-recover GLPI session and retry failed API calls
- Expose `useNewModal` flag and use the safe API wrapper for ticket searches and counters
- Adjust BAGE layout with container/grid changes and loading indicator in JS

## Testing
- `php -l newmodal/bage/bage-loader.php`
- `php -l newmodal/bage/bage-template.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1326960bc8328a3c24b583ce37e66