### PR TITLE
Add safety rewrite for glpi_itilstatuses queries

### DIFF
--- a/glpi-newmodal.php
+++ b/glpi-newmodal.php
@@ -16,6 +16,14 @@ define('NM_BASE_URL', plugin_dir_url(__FILE__) . 'newmodal/');
 // === Load common layer ===
 require_once NM_BASE_DIR . 'config.php';
 require_once NM_BASE_DIR . 'helpers.php';
+// Подключаем SQL-хелперы раньше всего, чтобы сработал перехват "голого" SQL.
+// Это защитит от падения из-за "SELECT ... FROM glpi_itilstatuses" без имени БД.
+if (file_exists(NM_BASE_DIR . 'common/sql.php')) {
+    require_once NM_BASE_DIR . 'common/sql.php';
+    if (function_exists('nm_sql_enable_rewrite')) {
+        nm_sql_enable_rewrite();
+    }
+}
 require_once NM_BASE_DIR . 'common/api.php';
 require_once NM_BASE_DIR . 'common/ping.php';
 


### PR DESCRIPTION
## Summary
- load SQL helpers before other modules in the Newmodal plugin
- rewrite raw `glpi_itilstatuses` queries to include the GLPI database name

## Testing
- `php -l glpi-newmodal.php`
- `php -l newmodal/common/sql.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e3ce67dc832895b4743944705cdc