### PR TITLE
feat(newmodal): isolate GLPI DB connection

### DIFF
--- a/newmodal/common/sql.php
+++ b/newmodal/common/sql.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Newmodal SQL helpers (safe)
- *
- * Всегда используем отдельное соединение к БД GLPI и НИКОГДА не падаем на WP-подключение.
- * Хост по умолчанию: 192.168.100.12 (можно переопределить константами/опциями).
+ * Newmodal SQL helpers (STRICT, no $wpdb)
+ * Всегда работаем ТОЛЬКО с отдельным подключением к БД GLPI.
+ * Никаких запросов к базе WordPress. Возвращаем WP_Error вместо фатала.
  */
 if (!defined('ABSPATH')) { exit; }
 
@@ -11,46 +10,8 @@ if (!defined('ABSPATH')) { exit; }
 global $nm_glpi_wpdb; // wpdb|WP_Error
 
 /**
- * Получить wpdb-подключение к GLPI.
- * @return wpdb|WP_Error
- */
-function nm_glpi_db() {
-    global $wpdb, $nm_glpi_wpdb;
-
-    // Повторно используем успешное соединение
-    if ($nm_glpi_wpdb instanceof wpdb && $nm_glpi_wpdb->dbh) {
-        return $nm_glpi_wpdb;
-    }
-    // Проверяем креды (константы определяются в config.php из констант/опций)
-    $host = defined('NM_GLPI_DB_HOST') ? NM_GLPI_DB_HOST : null;
-    $name = defined('NM_GLPI_DB_NAME') ? NM_GLPI_DB_NAME : null;
-    $user = defined('NM_GLPI_DB_USER') ? NM_GLPI_DB_USER : null;
-    $pass = defined('NM_GLPI_DB_PASS') ? NM_GLPI_DB_PASS : null;
-
-    if (!$host || !$name || !$user || $pass === null) {
-        return new WP_Error('glpi_db_creds_missing', 'GLPI DB credentials not configured (NM_GLPI_DB_*).');
-    }
-
-    // Открываем отдельное соединение к GLPI, независимо от WP
-    $glpi = new wpdb($user, $pass, $name, $host);
-    if (!empty($glpi->error)) {
-        return new WP_Error('glpi_db_connect_failed', $glpi->error);
-    }
-    // Устанавливаем кодировку, аналогичную WP
-    if (method_exists($glpi, 'set_charset') && isset($wpdb->charset, $wpdb->collate)) {
-        $glpi->set_charset($glpi->dbh, $wpdb->charset, $wpdb->collate);
-    }
-    $nm_glpi_wpdb = $glpi;
-    return $nm_glpi_wpdb;
-}
-
-/**
  * Имя БД GLPI.
- *
- * Приоритет:
- * 1) константа NM_GLPI_DB или NM_GLPI_DB_NAME
- * 2) опция WordPress 'nm_glpi_dbname'
- * 3) значение по умолчанию 'glpi'
+ * Приоритет: NM_GLPI_DB / NM_GLPI_DB_NAME -> опция 'nm_glpi_dbname' -> 'glpi'
  */
 function nm_glpi_dbname() {
     if (defined('NM_GLPI_DB') && NM_GLPI_DB !== '') {
@@ -60,63 +21,80 @@ function nm_glpi_dbname() {
         return NM_GLPI_DB_NAME;
     }
     $opt = get_option('nm_glpi_dbname');
-    if (is_string($opt) && $opt !== '') {
-        return $opt;
-    }
-    return 'glpi';
+    return (is_string($opt) && $opt !== '') ? $opt : 'glpi';
 }
 
-/** Экранировать идентификатор (БД/таблица/колонка) */
+/**
+ * Экранирование идентификатора (БД/таблица/колонка).
+ */
 function nm_sql_ident($ident) {
     $ident = (string)$ident;
     $ident = str_replace('`', '``', $ident);
     return '`' . $ident . '`';
 }
 
-/** Полное имя таблицы GLPI: `dbname`.`table` */
+/**
+ * Полное имя таблицы GLPI: `dbname`.`table`
+ */
 function nm_glpi_table($table) {
     return nm_sql_ident(nm_glpi_dbname()) . '.' . nm_sql_ident($table);
 }
 
-// Любые попытки «подстраховаться» WP-подключением запрещены:
-if (!defined('NM_SQL_STRICT_GLPI') || NM_SQL_STRICT_GLPI !== true) {
-    define('NM_SQL_STRICT_GLPI', true);
+/**
+ * Получить отдельное wpdb-подключение к GLPI.
+ * Ожидаются константы: NM_GLPI_DB_HOST, NM_GLPI_DB_USER, NM_GLPI_DB_PASS, NM_GLPI_DB_NAME.
+ * Если не заданы — вернём WP_Error.
+ */
+function nm_glpi_db() {
+    global $wpdb, $nm_glpi_wpdb;
+    if ($nm_glpi_wpdb instanceof wpdb && $nm_glpi_wpdb->dbh) {
+        return $nm_glpi_wpdb;
+    }
+    $host = defined('NM_GLPI_DB_HOST') ? NM_GLPI_DB_HOST : null;
+    $name = defined('NM_GLPI_DB_NAME') ? NM_GLPI_DB_NAME : nm_glpi_dbname();
+    $user = defined('NM_GLPI_DB_USER') ? NM_GLPI_DB_USER : null;
+    $pass = defined('NM_GLPI_DB_PASS') ? NM_GLPI_DB_PASS : null;
+    if (!$host || !$name || !$user || $pass === null) {
+        return new WP_Error('glpi_db_creds_missing', 'GLPI DB credentials not configured (NM_GLPI_DB_*).');
+    }
+    $glpi = new wpdb($user, $pass, $name, $host);
+    if (!empty($glpi->error)) {
+        return new WP_Error('glpi_db_connect_failed', $glpi->error);
+    }
+    if (method_exists($glpi, 'set_charset') && isset($wpdb->charset, $wpdb->collate)) {
+        $glpi->set_charset($glpi->dbh, $wpdb->charset, $wpdb->collate);
+    }
+    $nm_glpi_wpdb = $glpi;
+    return $nm_glpi_wpdb;
 }
 
 /**
- * Проверка существования таблицы.
+ * Проверка существования таблицы в БД GLPI.
  */
 function nm_glpi_table_exists($tableRaw) {
     $dbi = nm_glpi_db();
-    if (is_wp_error($dbi)) {
-        return false;
-    }
+    if (is_wp_error($dbi)) return false;
     $db  = nm_glpi_dbname();
-    $sql = $dbi->prepare(
-        'SHOW TABLES FROM ' . nm_sql_ident($db) . ' LIKE %s',
-        $tableRaw
-    );
+    $sql = $dbi->prepare('SHOW TABLES FROM ' . nm_sql_ident($db) . ' LIKE %s', $tableRaw);
     $found = $dbi->get_var($sql);
     return (bool)$found;
 }
 
 /**
- * Универсальный SELECT по GLPI с проверкой существования таблицы.
- * Возвращает массив строк или WP_Error — но не приводит к фаталу.
+ * Универсальный SELECT по GLPI (без падений на WP-БД).
+ * Возвращает массив строк или WP_Error.
  */
 function nm_glpi_select($tableRaw, $columns = '*', $where = '', array $params = [], $output = ARRAY_A) {
     $dbi = nm_glpi_db();
     if (is_wp_error($dbi)) {
         return $dbi;
     }
-
     if (!nm_glpi_table_exists($tableRaw)) {
         return new WP_Error(
             'glpi_table_missing',
             sprintf('GLPI table "%s" not found in database "%s".', $tableRaw, nm_glpi_dbname())
         );
     }
-
     $table = nm_glpi_table($tableRaw);
     $sql   = "SELECT {$columns} FROM {$table}";
     if ($where) {
@@ -133,25 +111,24 @@ function nm_glpi_select($tableRaw, $columns = '*', $where = '', array $params = 
 }
 
 /**
- * Получить список статусов (id, name) из GLPI.
- *
- * @return array|WP_Error
+ * Список статусов (id, name) из GLPI. Без фатала.
  */
 function nm_sql_get_statuses() {
-    return nm_glpi_select('glpi_itilstatuses', 'id,name');
+    $res = nm_glpi_select('glpi_itilstatuses', 'id,name');
+    if (is_wp_error($res) || !is_array($res)) {
+        return [];
+    }
+    return $res;
 }
 
-/**
- * Яркое админ-уведомление, если нет соединения к GLPI — чтобы не было
- * тихих падений на попытках сходить в WP-БД.
- */
+// Админ-подсказка, если соединение к GLPI не настроено
 add_action('admin_notices', function () {
     if (!current_user_can('manage_options')) return;
     $dbi = nm_glpi_db();
     if (is_wp_error($dbi)) {
         echo '<div class="notice notice-error"><p><strong>GLPI DB connection error:</strong> '
             . esc_html($dbi->get_error_message())
-            . ' (host=' . esc_html(defined('NM_GLPI_DB_HOST')?NM_GLPI_DB_HOST:'?')
+            . ' (host=' . esc_html(defined('NM_GLPI_DB_HOST') ? NM_GLPI_DB_HOST : '?')
             . ', name=' . esc_html(nm_glpi_dbname())
             . ').</p></div>';
     }

--- a/newmodal/config.php
+++ b/newmodal/config.php
@@ -5,20 +5,20 @@ if (!defined('ABSPATH')) { exit; }
 if (!defined('NM_VER'))          define('NM_VER', '1.0.0');
 if (!defined('NM_BASE_URL'))     define('NM_BASE_URL', plugins_url('newmodal/', __FILE__));
 if (!defined('NM_BASE_DIR'))     define('NM_BASE_DIR', plugin_dir_path(__FILE__) . 'newmodal/');
-if (!defined('NM_DB_PREFIX'))    define('NM_DB_PREFIX', 'glpi_');
 
 // API (могут переопределяться через wp-config.php)
-if (!defined('NM_OPT_BASE_URL'))  define('NM_OPT_BASE_URL',  'glpi_api_base_url');   // http://<glpi>/apirest.php
-if (!defined('NM_OPT_APP_TOKEN')) define('NM_OPT_APP_TOKEN', 'glpi_app_token');
+if (!defined('NM_OPT_BASE_URL'))  define('NM_OPT_BASE_URL',  'nm_base_url');   // http://<glpi>/apirest.php
+if (!defined('NM_OPT_APP_TOKEN')) define('NM_OPT_APP_TOKEN', 'nm_app_token');
 
 /**
- * SQL-подключение к GLPI.
+ * SQL-подключение к GLPI (строго отдельно от БД WordPress).
+ *
  * Источники значений (по приоритету):
  *   1) Константы в wp-config.php:
  *      NM_GLPI_DB_HOST, NM_GLPI_DB_USER, NM_GLPI_DB_PASS, NM_GLPI_DB_NAME
  *   2) Опции WP:
  *      nm_glpi_db_host, nm_glpi_db_user, nm_glpi_db_pass, nm_glpi_dbname
- *   3) Безопасные дефолты: только HOST/NAME, чтобы явно требовать user/pass.
+ *   3) Дефолты для host/name (user/pass не задаём по умолчанию).
  */
 if (!defined('NM_GLPI_DB_HOST')) {
     $h = get_option('nm_glpi_db_host');
@@ -28,7 +28,6 @@ if (!defined('NM_GLPI_DB_NAME')) {
     $n = get_option('nm_glpi_dbname');
     define('NM_GLPI_DB_NAME', $n ? $n : 'glpi');
 }
-// user/pass без дефолтов: должны быть заданы (константами или опциями)
 if (!defined('NM_GLPI_DB_USER')) {
     $u = get_option('nm_glpi_db_user');
     if ($u) define('NM_GLPI_DB_USER', $u);
@@ -37,11 +36,6 @@ if (!defined('NM_GLPI_DB_PASS')) {
     $p = get_option('nm_glpi_db_pass');
     if ($p) define('NM_GLPI_DB_PASS', $p);
 }
-
-// Жёстко запрещаем использование WP-подключения как «запасного».
-if (!defined('NM_SQL_STRICT_GLPI')) {
-    define('NM_SQL_STRICT_GLPI', true);
-}
-
-
-
+// Подключаем базовые части
+require_once __DIR__ . '/common/api.php';
+require_once __DIR__ . '/common/sql.php';


### PR DESCRIPTION
## Summary
- decouple newmodal from WordPress DB by pulling GLPI credentials from constants/options
- replace `$wpdb` usage with dedicated GLPI connection helpers returning `WP_Error` on failure

## Testing
- `php -l newmodal/config.php`
- `php -l newmodal/common/sql.php`
- `composer validate --no-check-all --strict`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e98244748328aa11747be5503918