### PR TITLE
Add strict GLPI configuration and DB helpers

### DIFF
--- a/newmodal/config.php
+++ b/newmodal/config.php
@@ -10,31 +10,24 @@ if (!defined('NM_BASE_DIR'))     define('NM_BASE_DIR', plugin_dir_path(__FILE__)
 if (!defined('NM_OPT_BASE_URL'))  define('NM_OPT_BASE_URL',  'nm_base_url');   // http://<glpi>/apirest.php
 if (!defined('NM_OPT_APP_TOKEN')) define('NM_OPT_APP_TOKEN', 'nm_app_token');
 
-/**
- * SQL-подключение к GLPI (строго отдельно от БД WordPress).
- *
- * Источники значений (по приоритету):
- *   1) Константы в wp-config.php:
- *      NM_GLPI_DB_HOST, NM_GLPI_DB_USER, NM_GLPI_DB_PASS, NM_GLPI_DB_NAME
- *   2) Опции WP:
- *      nm_glpi_db_host, nm_glpi_db_user, nm_glpi_db_pass, nm_glpi_dbname
- *   3) Дефолты для host/name (user/pass не задаём по умолчанию).
- */
-if (!defined('NM_GLPI_DB_HOST')) {
-    $h = get_option('nm_glpi_db_host');
-    define('NM_GLPI_DB_HOST', $h ? $h : '192.168.100.12');
+// === GLPI API: жёстко зафиксированные значения из рабочей инсталляции ===
+if (!defined('GEXE_GLPI_API_URL')) {
+    define('GEXE_GLPI_API_URL', 'http://192.168.100.12/glpi/apirest.php');
 }
-if (!defined('NM_GLPI_DB_NAME')) {
-    $n = get_option('nm_glpi_dbname');
-    define('NM_GLPI_DB_NAME', $n ? $n : 'glpi');
+if (!defined('GEXE_GLPI_APP_TOKEN')) {
+    define('GEXE_GLPI_APP_TOKEN', 'nqubXrD6j55bgLRuD1mrrtz5D69cXz94HHPvgmac');
 }
-if (!defined('NM_GLPI_DB_USER')) {
-    $u = get_option('nm_glpi_db_user');
-    if ($u) define('NM_GLPI_DB_USER', $u);
-}
-if (!defined('NM_GLPI_DB_PASS')) {
-    $p = get_option('nm_glpi_db_pass');
-    if ($p) define('NM_GLPI_DB_PASS', $p);
+
+// === SQL-подключение к GLPI (строго отдельно от БД WordPress) ===
+// Данные взяты из твоего примера и заданы константами, чтобы исключить fallback.
+if (!defined('NM_GLPI_DB_HOST')) define('NM_GLPI_DB_HOST', '192.168.100.12');
+if (!defined('NM_GLPI_DB_NAME')) define('NM_GLPI_DB_NAME', 'glpi');
+if (!defined('NM_GLPI_DB_USER')) define('NM_GLPI_DB_USER', 'wp_glpi');
+if (!defined('NM_GLPI_DB_PASS')) define('NM_GLPI_DB_PASS', 'xapetVD4OWZqw8f');
+
+// Включаем строгий режим: никакого использования $wpdb для GLPI.
+if (!defined('NM_SQL_STRICT_GLPI')) {
+    define('NM_SQL_STRICT_GLPI', true);
 }
 // Подключаем базовые части
 require_once __DIR__ . '/common/api.php';


### PR DESCRIPTION
## Summary
- hard-code GLPI API endpoint and credentials for newmodal integration
- enforce dedicated GLPI database connection with strict mode
- provide SQL helpers that avoid WordPress DB and surface connection errors

## Testing
- `php -l newmodal/config.php`
- `php -l newmodal/common/sql.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eb7745c08328817b24847e0a6a1e