### PR TITLE
Use GLPI DB for counts and catalogs

### DIFF
--- a/newmodal/assets/js/newticket.js
+++ b/newmodal/assets/js/newticket.js
@@ -35,9 +35,9 @@
              .on('input', '#nm-nt-location-input', function(){ dropdown($(this), 'nm_catalog_locations'); });
   $(document).on('focus', '#nm-nt-assignee-input', function(){
                 if ($(this).prop('disabled')) return;
-                dropdown($(this), 'nm_catalog_assignees');
+                dropdown($(this), 'nm_catalog_users');
               })
-             .on('input', '#nm-nt-assignee-input', function(){ if (!$(this).prop('disabled')) dropdown($(this), 'nm_catalog_assignees'); });
+             .on('input', '#nm-nt-assignee-input', function(){ if (!$(this).prop('disabled')) dropdown($(this), 'nm_catalog_users'); });
 
   $(document).on('click', '.nm-dd-item', function(){
     var id = $(this).data('id');

--- a/newmodal/common/sql.php
+++ b/newmodal/common/sql.php
@@ -99,9 +99,16 @@ function nm_glpi_select($tableRaw, $columns = '*', $where = '', array $params = 
  * Список статусов (id, name) из GLPI. Без фатала.
  */
 function nm_sql_get_statuses() {
-    $res = nm_glpi_select('glpi_itilstatuses', 'id,name');
-    if (is_wp_error($res) || !is_array($res)) return [];
-    return $res;
+    // В GLPI 9.5.x статусы — константы ядра, таблицы glpi_itilstatuses нет.
+    // Возвращаем статический набор, используемый интерфейсом.
+    return [
+        ['id' => 1, 'name' => 'New'],
+        ['id' => 2, 'name' => 'In progress'],
+        ['id' => 4, 'name' => 'Pending'],
+        ['id' => 5, 'name' => 'Solved (to validate)'],
+        ['id' => 6, 'name' => 'Solved'],
+        ['id' => 7, 'name' => 'Closed'],
+    ];
 }
 
 // Админ-подсказка, если соединение к GLPI не настроено/падает


### PR DESCRIPTION
## Summary
- Replace dynamic status lookup with static list for GLPI 9.5
- Query GLPI DB directly for ticket counts and user suggestions
- Use GLPI connection for category/location/user catalogs and update JS endpoint

## Testing
- `php -l newmodal/common/sql.php`
- `php -l newmodal/bage/ajax-extra.php`
- `php -l newmodal/new-ticket/catalogs.php`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f2335bf08328a91b18db9d0dbfb3